### PR TITLE
Initial test for PR CI

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -14,7 +14,7 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: ca-central-1
-  TERRAFORM_VERSION: 0.13.4
+  TERRAFORM_VERSION: 0.13.5
   TERRAGRUNT_VERSION: v0.26.0
 
 jobs:
@@ -27,17 +27,41 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v1.2.1
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_wrapper: false
 
       - name: Setup Terragrunt
         run: |
           mkdir bin
-          wget -O bin/terragrunt_linux_amd64 https://github.com/gruntwork-io/terragrunt/releases/download/$TERRAGRUNT_VERSION/terragrunt_linux_amd64
-          echo "/bin" >> $GITHUB_PATH
+          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/$TERRAGRUNT_VERSION/terragrunt_linux_amd64
+          chmod +x bin/terragrunt
+          echo "bin" >> $GITHUB_PATH
 
-      - name: Test Terragrunt
+      - name: Get changed files
+        id: changed-files
+        uses: futuratrepadeira/changed-files@v3.3.0
+        with:
+          repo-token: ${{ github.token }}
+          pattern: '^.*\.(tf)$'
+          result-encoding: 'json'
+
+      - name: Get touched Terragrunt modules
         run: |
-          terragrunt -version
+          MODULES=`jq --argjson created '${{ steps.changed-files.outputs.files_created }}' --argjson updated '${{ steps.changed-files.outputs.files_updated }}' -n '$updated + $created' | jq -c '[.[] | match("(.*aws?)\/(.*)\/").captures[1].string] | unique | select(length > 0)'` 
+          echo "MODULES=$MODULES" >> $GITHUB_ENV
 
+      - name: Plan aws/common
+        if: contains(env.MODULES, 'common')
+        run: |
+          echo $MODULES
+          cd env/staging/common
+          ../../../bin/terragrunt plan --terragrunt-non-interactive
+
+      - name: Plan aws/eks
+        if: contains(env.MODULES, 'eks')
+        run: |
+          echo $MODULES
+          cd env/staging/eks
+          ../../../bin/terragrunt plan --terragrunt-non-interactive


### PR DESCRIPTION
This pull request adds a GitHub action that runs `terraform plan` on each of the modules contained inside this repository when a pull request has been opened. The purpose of this is to determine if any of the terraform code breaks existing changes.

The GitHub action intelligently only runs `terraform plan` on any modules that have been touched as to avoid long run times by running `terraform plan` on unchanged infrastructure. It does this by using the ~~`futuratrepadeira/changed-files@v3.3.0`~~, (updated in #13)  action to get a list of what files have been changed. It then uses `jq` to parse the list for module names such as `eks` or `common`. Next it uses an `if` statement to see if it should run `terraform plan` on those modules.

A previous implementation used the GitHub Actions `matrix` feature to dynamically run all the `terraform plans` concurrently. The problem with that approach is that some modules have dependencies on each other, ex. `common -> eks` which would lead to potential race conditions. While the `matrix` solution is far more elegant, using `if` switches simplifies the logic. 

Defining the modules explicitly in the action also allows a certain order of operations which in the end might be easier to work with.