### PR TITLE
Replace get-changed-files action

### DIFF
--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -1,7 +1,3 @@
-output "availability_zones" {
-  value = data.aws_availability_zones.available.names
-}
-
 output "vpc_id" {
   value = aws_vpc.notification-canada-ca.id
 }


### PR DESCRIPTION
Update on #11. The previous action used to detect changed files relied on the `pull_request` context which did not work for changes that were `push`ed to the `main` branch. The new action uses a different mechanism and makes the `jq` aggregation easier to read because it exposes a `added_modified` output.