### PR TITLE
feat: Add managed KMS key to allow for encryption in SNS and Cloudwatch

### DIFF
--- a/aws/common/kms.tf
+++ b/aws/common/kms.tf
@@ -20,7 +20,7 @@ resource "aws_kms_key" "notification-canada-ca" {
     },
     {
       "Effect": "Allow",
-      "Principal": { "Service": "logs.ca-central-1.amazonaws.com" },
+      "Principal": { "Service": "logs.${var.region}.amazonaws.com" },
       "Action": [ 
         "kms:Encrypt*",
         "kms:Decrypt*",


### PR DESCRIPTION
Closes #7 by adding a managed KMS key. This will allow us to encrypt messages in SNS and in Cloudwatch as well as if we want to continue encrypting our environment variables. 