### PR TITLE
feat: set up SNS channels with KMS encryption and no subscriptions

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "aws/**"
+      - "env/staging/**"
       - ".github/workflows/*"
 
 defaults:
@@ -50,15 +51,20 @@ jobs:
           MODULES=`echo '${{ steps.changed-files.outputs.added_modified }}' | jq -c '[.[] | match("(.*aws?)\/(.*)\/").captures[1].string] | unique | select(length > 0)'` 
           echo "MODULES=$MODULES" >> $GITHUB_ENV
 
+      - name: Get touched Terragrunt configurations
+        run: |
+          CONFIGS=`echo '${{ steps.changed-files.outputs.added_modified }}' | jq -c '[.[] | match("(.*env?)\/(.*staging?)\/(.*)\/").captures[2].string] | unique | select(length > 0)'` 
+          echo "CONFIGS=$CONFIGS" >> $GITHUB_ENV
+
       - name: Plan aws/common
-        if: contains(env.MODULES, 'common')
+        if: contains(env.MODULES, 'common') || contains(env.CONFIGS, 'common') 
         run: |
           echo $MODULES
           cd env/staging/common
           ../../../bin/terragrunt plan --terragrunt-non-interactive
 
       - name: Plan aws/eks
-        if: contains(env.MODULES, 'eks')
+        if: contains(env.MODULES, 'eks') || contains(env.CONFIGS, 'eks') 
         run: |
           echo $MODULES
           cd env/staging/eks

--- a/.github/workflows/terraform_static_analysis.yml
+++ b/.github/workflows/terraform_static_analysis.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "aws/**"
+      - "env/staging/**"
 
 defaults:
   run:

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -27,9 +27,9 @@ include {
 }
 
 inputs = {
-  primary_worker_desired_size   = 1
-  primary_worker_instance_types = ["t3.medium"]
-  primary_worker_max_size       = 1
+  primary_worker_desired_size   = 3
+  primary_worker_instance_types = ["t3.medium"] 
+  primary_worker_max_size       = 5
   primary_worker_min_size       = 1
   vpc_id                        = dependency.common.outputs.vpc_id
   vpc_private_subnets           = dependency.common.outputs.vpc_private_subnets


### PR DESCRIPTION
Closes #9. Adds SNS channels for the following topics:

- SES callbacks
- SMS callbacks
- Warning alerts
- Critical alerts

It also includes code to encrypt communication with a KMS key. This PR does not set up any subscriber endpoints.