### PR TITLE
Add Cloudwatch alarms

### DIFF
--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -19,7 +19,10 @@ env:
   TERRAFORM_VERSION: 0.13.5
   TERRAGRUNT_VERSION: v0.26.0
   TF_VAR_rds_cluster_password: ${{ secrets.STAGING_RDS_CLUSTER_PASSWORD }}
-  TF_VAR_cloudwatch_slack_webhook: ${{ secrets.STAGING_CLOUDWATCH_SLACK_WEBHOOK }}
+  TF_VAR_cloudwatch_slack_webhook_warning_topic: ${{ secrets.STAGING_CLOUDWATCH_SLACK_WEBHOOK }}
+  TF_VAR_cloudwatch_slack_webhook_critical_topic: ${{ secrets.STAGING_CLOUDWATCH_SLACK_WEBHOOK }}
+  TF_VAR_slack_channel_warning_topic: "notification-staging-ops"
+  TF_VAR_slack_channel_critical_topic: "notification-staging-ops"
 
 jobs:
   terraform-apply:
@@ -69,7 +72,7 @@ jobs:
           ../../../bin/terragrunt apply --terragrunt-non-interactive -auto-approve
 
       - name: Apply aws/dns
-        if: contains(env.MODULES, 'dns') || contains(env.CONFIGS, 'dns') 
+        if: contains(env.MODULES, 'dns') || contains(env.CONFIGS, 'dns')
         run: |
           echo $MODULES
           cd env/staging/dns

--- a/.github/workflows/terraform_static_analysis.yml
+++ b/.github/workflows/terraform_static_analysis.yml
@@ -1,10 +1,6 @@
 name: "Terraform security scan"
 
-on:
-  pull_request:
-    paths:
-      - "aws/**"
-      - "env/staging/**"
+on: [pull_request]
 
 defaults:
   run:

--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -88,6 +88,27 @@ resource "aws_s3_bucket" "asset_bucket" {
   #tfsec:ignore:AWS017 - Defines an unencrypted S3 bucket
 }
 
+resource "aws_s3_bucket_policy" "asset_bucket_public_read" {
+  bucket = aws_s3_bucket.asset_bucket.id
+
+  policy = <<POLICY
+{
+   "Version":"2008-10-17",
+   "Statement":[
+      {
+         "Sid":"AllowPublicRead",
+         "Effect":"Allow",
+         "Principal":{
+            "AWS":"*"
+         },
+         "Action":"s3:GetObject",
+         "Resource":"${aws_s3_bucket.asset_bucket.arn}/*"
+      }
+   ]
+}
+POLICY
+}
+
 resource "aws_s3_bucket" "document_bucket" {
   bucket = "notification-canada-ca-${var.env}-document-download"
   acl    = "private"

--- a/aws/common/slack.tf
+++ b/aws/common/slack.tf
@@ -1,12 +1,32 @@
 # Doc: https://registry.terraform.io/modules/terraform-aws-modules/notify-slack/aws/
-module "notify_slack" {
+module "notify_slack_warning" {
   source  = "terraform-aws-modules/notify-slack/aws"
   version = "~> 4.0"
 
-  sns_topic_name = "cloudwatch-slack-topic"
+  create_sns_topic = false
+  sns_topic_name   = aws_sns_topic.notification-canada-ca-alert-warning.name
 
-  slack_webhook_url = var.cloudwatch_slack_webhook
-  slack_channel     = "notification-ops"
-  slack_username    = "AWS Cloudwatch"
-  slack_emoji       = ":lightning:"
+  slack_webhook_url = var.cloudwatch_slack_webhook_warning_topic
+  slack_channel     = var.slack_channel_warning_topic
+  slack_username    = "[WARNING] AWS Cloudwatch"
+  slack_emoji       = ":aws:"
+
+  lambda_function_name                   = "notify-slack-warning"
+  cloudwatch_log_group_retention_in_days = 90
+}
+
+module "notify_slack_critical" {
+  source  = "terraform-aws-modules/notify-slack/aws"
+  version = "~> 4.0"
+
+  create_sns_topic = false
+  sns_topic_name   = aws_sns_topic.notification-canada-ca-alert-critical.name
+
+  slack_webhook_url = var.cloudwatch_slack_webhook_critical_topic
+  slack_channel     = var.slack_channel_critical_topic
+  slack_username    = "[CRITICAL] AWS Cloudwatch"
+  slack_emoji       = ":aws:"
+
+  lambda_function_name                   = "notify-slack-critical"
+  cloudwatch_log_group_retention_in_days = 90
 }

--- a/aws/common/variables.tf
+++ b/aws/common/variables.tf
@@ -2,6 +2,18 @@ variable sns_monthly_spend_limit {
   type = number
 }
 
-variable cloudwatch_slack_webhook {
+variable cloudwatch_slack_webhook_warning_topic {
+  type = string
+}
+
+variable cloudwatch_slack_webhook_critical_topic {
+  type = string
+}
+
+variable slack_channel_warning_topic {
+  type = string
+}
+
+variable slack_channel_critical_topic {
   type = string
 }

--- a/aws/eks/iam.tf
+++ b/aws/eks/iam.tf
@@ -180,7 +180,7 @@ data "aws_iam_policy_document" "eks-assume-role-policy" {
     condition {
       test     = "StringEquals"
       variable = "${replace(aws_iam_openid_connect_provider.notification-canada-ca.url, "https://", "")}:sub"
-      values   = ["system:serviceaccount:kube-system:aws-node"]
+      values   = ["system:serviceaccount:notification-canada-ca:notification-service-account"]
     }
 
     principals {

--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -22,6 +22,7 @@ resource "aws_rds_cluster_instance" "notification-canada-ca-instances" {
   engine                       = aws_rds_cluster.notification-canada-ca.engine
   engine_version               = aws_rds_cluster.notification-canada-ca.engine_version
   performance_insights_enabled = true
+  preferred_maintenance_window = "wed:04:00-wed:04:30"
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
@@ -59,4 +60,20 @@ resource "aws_rds_cluster" "notification-canada-ca" {
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
   }
+}
+
+resource "aws_db_event_subscription" "notification-canada-ca" {
+  name      = "notification-canada-ca-events-subscription"
+  sns_topic = var.sns_alert_warning_arn
+
+  source_type = "db-instance"
+
+  # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html
+  event_categories = [
+    "availability",
+    "failover",
+    "failure",
+    "low storage",
+    "maintenance",
+  ]
 }

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -18,3 +18,7 @@ variable rds_instance_type {
 variable vpc_private_subnets {
   type = list
 }
+
+variable sns_alert_warning_arn {
+  type = string
+}

--- a/env/staging/rds/terragrunt.hcl
+++ b/env/staging/rds/terragrunt.hcl
@@ -14,6 +14,7 @@ dependency "common" {
       "subnet-08de34a9e1a7458dc",
       "subnet-0af8b8402f1d605ff",
     ]
+    sns_alert_warning_arn = ""
   }
 }
 
@@ -37,6 +38,7 @@ inputs = {
   rds_instance_count        = 1
   rds_instance_type         = "db.t3.medium"
   vpc_private_subnets       = dependency.common.outputs.vpc_private_subnets
+  sns_alert_warning_arn     = dependency.common.outputs.sns_alert_warning_arn
 }
 
 terraform {


### PR DESCRIPTION
Fixes https://github.com/cds-snc/notification-terraform/issues/31

A good first take at adding alarms in Cloudwatch, almost all our existing ones. Some with different thresholds between `warning` and `critical` topics to make sure that we don't get paged on non-critical alerts

@brdunfield, assigning you as a reviewer, not for the Terraform code but to make sure that I don't miss important alarms and that you're okay with warning/critical and thresholds.

@maxneuvians said it was expected for the CI to not pass as we have a dependency on the `common` module