### PR TITLE
feat: redirect web alt domains

### DIFF
--- a/aws/eks/alb.tf
+++ b/aws/eks/alb.tf
@@ -219,7 +219,7 @@ resource "aws_lb_listener_rule" "alt-domain-host-route" {
 
   condition {
     host_header {
-      values = [${var.alt_domain}]
+      values = [var.alt_domain]
     }
   }
 }


### PR DESCRIPTION
Redirect:
- api.document.notification.alpha.canada.ca to api.document.notification.canada.ca
- document.notification.alpha.canada.ca to document.notification.canada.ca
- notification.alpha.canada.ca to notification.canada.ca

No redirections for the API, this should be handled transparently by the API target group