### PR TITLE
feat: CPU and memory warning alarms

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -128,3 +128,148 @@ resource "aws_cloudwatch_metric_alarm" "logs-10-500-error-5-minutes-critical" {
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_critical_arn]
 }
+
+resource "aws_cloudwatch_metric_alarm" "admin-pods-high-cpu-warning" {
+  alarm_name          = "admin-pods-high-cpu-warning"
+  alarm_description   = "Average CPU of admin pods >=50% during 10 minutes"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "pod_cpu_utilization"
+  namespace           = "ContainerInsights"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = 50
+  alarm_actions       = [var.sns_alert_warning_arn]
+  dimensions = {
+    Namespace   = "notification-canada-ca"
+    Service     = "admin"
+    ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "api-pods-high-cpu-warning" {
+  alarm_name          = "api-pods-high-cpu-warning"
+  alarm_description   = "Average CPU of API pods >=50% during 10 minutes"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "pod_cpu_utilization"
+  namespace           = "ContainerInsights"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = 50
+  alarm_actions       = [var.sns_alert_warning_arn]
+  dimensions = {
+    Namespace   = "notification-canada-ca"
+    Service     = "api"
+    ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "celery-pods-high-cpu-warning" {
+  alarm_name          = "celery-pods-high-cpu-warning"
+  alarm_description   = "Average CPU of Celery pods >=50% during 10 minutes"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "pod_cpu_utilization"
+  namespace           = "ContainerInsights"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = 50
+  alarm_actions       = [var.sns_alert_warning_arn]
+  dimensions = {
+    Namespace   = "notification-canada-ca"
+    Service     = "celery"
+    ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "celery-sms-pods-high-cpu-warning" {
+  alarm_name          = "celery-sms-pods-high-cpu-warning"
+  alarm_description   = "Average CPU of celery-sms pods >=50% during 10 minutes"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "pod_cpu_utilization"
+  namespace           = "ContainerInsights"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = 50
+  alarm_actions       = [var.sns_alert_warning_arn]
+  dimensions = {
+    Namespace   = "notification-canada-ca"
+    Service     = "celery-sms"
+    ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
+  }
+}
+
+
+resource "aws_cloudwatch_metric_alarm" "admin-pods-high-memory-warning" {
+  alarm_name          = "admin-pods-high-memory-warning"
+  alarm_description   = "Average memory of admin pods >=50% during 10 minutes"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "pod_memory_utilization"
+  namespace           = "ContainerInsights"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = 50
+  alarm_actions       = [var.sns_alert_warning_arn]
+  dimensions = {
+    Namespace   = "notification-canada-ca"
+    Service     = "admin"
+    ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "api-pods-high-memory-warning" {
+  alarm_name          = "api-pods-high-memory-warning"
+  alarm_description   = "Average memory of API pods >=50% during 10 minutes"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "pod_memory_utilization"
+  namespace           = "ContainerInsights"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = 50
+  alarm_actions       = [var.sns_alert_warning_arn]
+  dimensions = {
+    Namespace   = "notification-canada-ca"
+    Service     = "api"
+    ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "celery-pods-high-memory-warning" {
+  alarm_name          = "celery-pods-high-memory-warning"
+  alarm_description   = "Average memory of Celery pods >=50% during 10 minutes"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "pod_memory_utilization"
+  namespace           = "ContainerInsights"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = 50
+  alarm_actions       = [var.sns_alert_warning_arn]
+  dimensions = {
+    Namespace   = "notification-canada-ca"
+    Service     = "celery"
+    ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "celery-sms-pods-high-memory-warning" {
+  alarm_name          = "celery-sms-pods-high-memory-warning"
+  alarm_description   = "Average memory of celery-sms >=50% during 10 minutes"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "pod_memory_utilization"
+  namespace           = "ContainerInsights"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = 50
+  alarm_actions       = [var.sns_alert_warning_arn]
+  dimensions = {
+    Namespace   = "notification-canada-ca"
+    Service     = "celery-sms"
+    ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
+  }
+}


### PR DESCRIPTION
Adds warning alarms for admin, API, Celery and Celery SMS pods:
- Average CPU >= 50% during 10 minutes
- Average memory >= 50% during 10 minutes

This is evaluated at the service level, meaning this will be the average of all pods within each service.

I did not add a critical alarm yet as we didn't have warning alarms on CPU/memory before. We could do that after we've confirmed these alarms don't go off when they're not supposed to + we've got usage data

I'll update the spreadsheet if you approve this PR.