### PR TITLE
feat: enable multiple AWS rules on WAF

### DIFF
--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -6,8 +6,10 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     allow {}
   }
 
+  # Use a bunch of AWS managed rules
+  # See https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html
   rule {
-    name     = "aws-managed-rules-common"
+    name     = "AWSManagedRulesAmazonIpReputationList"
     priority = 1
 
     override_action {
@@ -15,25 +17,104 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     }
 
     statement {
-      # See https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html
       managed_rule_group_statement {
-        name        = "AWSManagedRulesCommonRuleSet"
+        name        = "AWSManagedRulesAmazonIpReputationList"
         vendor_name = "AWS"
-
-        excluded_rule {
-          name = "SizeRestrictions_QUERYSTRING"
-        }
-
-        excluded_rule {
-          name = "NoUserAgent_HEADER"
-        }
       }
     }
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "wafv2-aws-managed-rules-common"
-      sampled_requests_enabled   = false
+      metric_name                = "AWSManagedRulesAmazonIpReputationList"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 2
+
+    override_action {
+      count {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 3
+
+    override_action {
+      count {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesKnownBadInputsRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesLinuxRuleSet"
+    priority = 4
+
+    override_action {
+      count {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesLinuxRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesLinuxRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesAnonymousIpList"
+    priority = 5
+
+    override_action {
+      count {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAnonymousIpList"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesAnonymousIpList"
+      sampled_requests_enabled   = true
     }
   }
 


### PR DESCRIPTION
Use a common set of rules from AWS on the WAF 

These rules are also used by [the COVID Alert server](https://github.com/cds-snc/covid-alert-server-staging-terraform/blob/master/server/aws/waf.tf)