### PR TITLE
feat: update StatsD prefix for API

### DIFF
--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -159,7 +159,7 @@ resource "aws_cloudwatch_metric_alarm" "healtheck-page-slow-response-critical" {
   statistic           = "Average"
   threshold           = 2
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
-  treat_missing_data  = "missing"
+  treat_missing_data  = "breaching"
   dimensions = {
     metric_type = "timing"
   }

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -153,7 +153,7 @@ resource "aws_cloudwatch_metric_alarm" "healtheck-page-slow-response-critical" {
   alarm_description   = "Healthcheck page response time is above 200ms for 10 minutes"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "2"
-  metric_name         = "production_notifications_app_GET_status_show_status_200"
+  metric_name         = "production_notifications_api_GET_status_show_status_200"
   namespace           = "NotificationCanadaCa"
   period              = "300"
   statistic           = "Average"


### PR DESCRIPTION
Change the metric name to align with new StatsD prefixes

To be merged after https://github.com/cds-snc/notification-api/pull/1183 goes to staging/production