### PR TITLE
feat: output ALB log bucket

### DIFF
--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -25,3 +25,7 @@ output "sns_alert_critical_arn" {
 output "asset_bucket_regional_domain_name" {
   value = aws_s3_bucket.asset_bucket.bucket_regional_domain_name
 }
+
+output "alb_log_bucket" {
+  value = aws_s3_bucket.alb_log_bucket.bucket
+}

--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -288,8 +288,12 @@ resource "aws_s3_bucket" "alb_log_bucket" {
     }
   }
 
-  logging {
-    target_bucket = aws_s3_bucket.document_bucket_logs.bucket
+  lifecycle_rule {
+    enabled = true
+
+    expiration {
+      days = 90
+    }
   }
 
   tags = {


### PR DESCRIPTION
Towards #94

In order to set up [access logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb#access_logs) for the load balancer, we need to output the name of the bucket to reuse it in the other module (S3 bucket in the `common` module while the load balancer is in the `eks` module).

I've adjusted the lifecycle rule to delete logs after 90 days - we keep cluster logs forever, I'm not sure we need that much to troubleshoot.