### PR TITLE
fix: add bucket policy for S3 ALB bucket

### DIFF
--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -322,7 +322,7 @@ resource "aws_s3_bucket_policy" "alb_log_bucket_allow_elb_account" {
     {
       "Effect": "Allow",
       "Principal": {
-        "AWS": "arn:aws:iam::${var.elb-account-ids[var.region]}:root"
+        "AWS": "arn:aws:iam::${var.elb_account_ids[var.region]}:root"
       },
       "Action": "s3:PutObject",
       "Resource":"${aws_s3_bucket.alb_log_bucket.arn}/*"

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -8,6 +8,10 @@ inputs = {
   alt_domain = "${local.vars.inputs.alt_domain}"
   env        = "${local.vars.inputs.env}"
   region     = "ca-central-1"
+  # See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-logging-bucket-permissions
+  elb-account-ids = {
+    "ca-central-1" = "985666609251"
+  }
 }
 
 generate "provider" {

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -9,7 +9,7 @@ inputs = {
   env        = "${local.vars.inputs.env}"
   region     = "ca-central-1"
   # See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-logging-bucket-permissions
-  elb-account-ids = {
+  elb_account_ids = {
     "ca-central-1" = "985666609251"
   }
 }
@@ -67,6 +67,12 @@ variable env {
 variable region {
   description = "The current AWS region"
   type        = string
+}
+
+# https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-logging-bucket-permissions
+variable elb_account_ids {
+  description = "AWS account IDs used by load balancers"
+  type        = map(string)
 }
 EOF
 }


### PR DESCRIPTION
Turns out #97 is not enough, the [CI job failed](https://github.com/cds-snc/notification-terraform/actions/runs/398860370). So still working on #94 

After [reading the doc](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-logging-bucket-permissions) one more time, we need to grant permissions to some AWS-owned accounts to allow load balancers to write objects in our bucket