### PR TITLE
feat: track number of services going over the rate limit

### DIFF
--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -33,3 +33,15 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error" {
     value     = "1"
   }
 }
+
+resource "aws_cloudwatch_log_metric_filter" "over-rate-limit" {
+  name           = "over-rate-limit"
+  pattern        = "has been rate limited for daily use sent"
+  log_group_name = "/aws/containerinsights/${aws_eks_cluster.notification-canada-ca-eks-cluster.name}/application"
+
+  metric_transformation {
+    name      = "over-rate-limit"
+    namespace = "LogMetrics"
+    value     = "1"
+  }
+}

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -34,8 +34,8 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error" {
   }
 }
 
-resource "aws_cloudwatch_log_metric_filter" "over-rate-limit" {
-  name           = "over-rate-limit"
+resource "aws_cloudwatch_log_metric_filter" "over-daily-rate-limit" {
+  name           = "over-daily-rate-limit"
   pattern        = "has been rate limited for daily use sent"
   log_group_name = "/aws/containerinsights/${aws_eks_cluster.notification-canada-ca-eks-cluster.name}/application"
 

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -40,7 +40,7 @@ resource "aws_cloudwatch_log_metric_filter" "over-daily-rate-limit" {
   log_group_name = "/aws/containerinsights/${aws_eks_cluster.notification-canada-ca-eks-cluster.name}/application"
 
   metric_transformation {
-    name      = "over-rate-limit"
+    name      = "over-daily-rate-limit"
     namespace = "LogMetrics"
     value     = "1"
   }


### PR DESCRIPTION
### Issue

https://trello.com/c/62gscLJH/169-graph-the-services-going-over-the-daily-rate-limit

### Purpose

As a business owner of the Notify platform.
I want to track services going over the daily rate limit,
so that I can monitor usages and contact the teams overusing the service.

As a sysops responsible for the Notify platform,
I want to track services going over the daily rate limit,
so that I make sure the SLAs are respected and individual services do not hinder usage of overall platform (especially for other unrelated services).

### Changes 

Adds a metric to AWS CloudWatch for us to graph in our Notify accounts. 

### Tests

Creating this branch and see how it runs should tell us if that works out. 