### PR TITLE
Bump production to 0.46

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -16,7 +16,7 @@ env:
   # Set the GitHub tag here to update the infrastructure
   # to a new version in production
   # See https://github.com/cds-snc/notification-terraform/releases
-  INFRASTRUCTURE_VERSION: '0.44.1'
+  INFRASTRUCTURE_VERSION: '0.46.0'
 
   # Terraform environment variables
   AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Compare URL https://github.com/cds-snc/notification-terraform/compare/v0.44.1...v0.46.0

This will release to production: a new metric filter already tested in staging by @jimleroyer and a bunch of firewall rules on the load balancer. No requests will be blocked yet - blocked that would have been blocked will only be counted for the moment, we'll review rules if necessary (as we did in #107)