### PR TITLE
Added an warn alarm for when the daily rate limit has been reached

### DIFF
--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -192,3 +192,17 @@ resource "aws_cloudwatch_metric_alarm" "no-emails-sent-5-minutes-critical" {
   treat_missing_data  = "breaching"
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
 }
+
+resource "aws_cloudwatch_metric_alarm" "daily-rate-limit-error-1-minute-warning" {
+  alarm_name          = "daily-rate-limit-error-1-minute-warning"
+  alarm_description   = "The daily rate limit has been reached."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "over-daily-rate-limit"
+  namespace           = "LogMetrics"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
+}

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -192,17 +192,3 @@ resource "aws_cloudwatch_metric_alarm" "no-emails-sent-5-minutes-critical" {
   treat_missing_data  = "breaching"
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
 }
-
-resource "aws_cloudwatch_metric_alarm" "daily-rate-limit-error-1-minute-warning" {
-  alarm_name          = "daily-rate-limit-error-1-minute-warning"
-  alarm_description   = "The daily rate limit has been reached."
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
-  metric_name         = "over-daily-rate-limit"
-  namespace           = "LogMetrics"
-  period              = "60"
-  statistic           = "Sum"
-  threshold           = 1
-  treat_missing_data  = "notBreaching"
-  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
-}

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -297,7 +297,7 @@ resource "aws_cloudwatch_metric_alarm" "daily-service-rate-limit-error-1-minute-
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = aws_cloudwatch_log_metric_filter.over-daily-rate-limit.name
-  namespace           = "LogMetrics"
+  namespace           = aws_cloudwatch_log_metric_filter.over-daily-rate-limit.namespace
   period              = "300"
   statistic           = "Sum"
   threshold           = 1

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -293,7 +293,7 @@ resource "aws_cloudwatch_metric_alarm" "ddos-detected-load-balancer-critical" {
 
 resource "aws_cloudwatch_metric_alarm" "daily-service-rate-limit-error-5-minutes-warning" {
   alarm_name          = "daily-service-rate-limit-error-5-minutes-warning"
-  alarm_description   = "The daily rate limit has been reached."
+  alarm_description   = "The daily rate limit has been reached for a service"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = aws_cloudwatch_log_metric_filter.over-daily-rate-limit.name

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -290,3 +290,17 @@ resource "aws_cloudwatch_metric_alarm" "ddos-detected-load-balancer-critical" {
     ResourceArn = aws_shield_protection.notification-canada-ca.resource_arn
   }
 }
+
+resource "aws_cloudwatch_metric_alarm" "daily-service-rate-limit-error-1-minute-warning" {
+  alarm_name          = "daily-service-rate-limit-error-1-minute-warning"
+  alarm_description   = "The daily rate limit has been reached."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.over-daily-rate-limit.name
+  namespace           = "LogMetrics"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
+}

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -302,5 +302,5 @@ resource "aws_cloudwatch_metric_alarm" "daily-service-rate-limit-error-1-minute-
   statistic           = "Sum"
   threshold           = 1
   treat_missing_data  = "notBreaching"
-  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
+  alarm_actions       = [var.sns_alert_warning_arn]
 }

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -297,7 +297,7 @@ resource "aws_cloudwatch_metric_alarm" "daily-service-rate-limit-error-5-minutes
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = aws_cloudwatch_log_metric_filter.over-daily-rate-limit.name
-  namespace           = aws_cloudwatch_log_metric_filter.over-daily-rate-limit.namespace
+  namespace           = "LogMetrics"
   period              = "300"
   statistic           = "Sum"
   threshold           = 1


### PR DESCRIPTION
## Changes

Added a warning alarm for when the daily rate limit has been reached.

## Issue

https://trello.com/c/62gscLJH/169-graph-the-services-going-over-the-daily-rate-limit

## Test 

* A similar alarm has been created in staging and has been tested. This is the infrastructure code to automate the alarm creation.
* Once this has been merged and deployed to staging, I will trigger the alarm manually with a test service. 