### PR TITLE
maintenance: Bump up version of terraform provider from v2 to v3

### DIFF
--- a/aws/cloudfront/cloudfront.tf
+++ b/aws/cloudfront/cloudfront.tf
@@ -55,3 +55,4 @@ resource "aws_cloudfront_distribution" "asset_bucket" {
     CostCenter = "notification-canada-ca-${var.env}"
   }
 }
+

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -192,3 +192,4 @@ resource "aws_cloudwatch_metric_alarm" "no-emails-sent-5-minutes-critical" {
   treat_missing_data  = "breaching"
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
 }
+

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -192,4 +192,3 @@ resource "aws_cloudwatch_metric_alarm" "no-emails-sent-5-minutes-critical" {
   treat_missing_data  = "breaching"
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
 }
-

--- a/aws/dns/ses.tf
+++ b/aws/dns/ses.tf
@@ -70,3 +70,4 @@ resource "aws_ses_identity_notification_topic" "cic-trvapply-vrtdemande-complain
   identity                 = aws_ses_domain_identity.cic-trvapply-vrtdemande[0].domain
   include_original_headers = false
 }
+

--- a/aws/eks/alb.tf
+++ b/aws/eks/alb.tf
@@ -251,3 +251,4 @@ resource "aws_wafv2_web_acl_association" "notification-canada-ca" {
   resource_arn = aws_alb.notification-canada-ca.arn
   web_acl_arn  = aws_wafv2_web_acl.notification-canada-ca.arn
 }
+

--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -77,3 +77,4 @@ resource "aws_db_event_subscription" "notification-canada-ca" {
     "maintenance",
   ]
 }
+

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -20,21 +20,21 @@ generate "provider" {
   contents  = <<EOF
 provider "aws" {
   region              = var.region
-  version             = "~> 2.0"
+  version             = "~> 3.0"
   allowed_account_ids = [var.account_id]
 }
 
 provider "aws" {
   alias               = "us-west-2"
   region              = "us-west-2"
-  version             = "~> 2.0"
+  version             = "~> 3.0"
   allowed_account_ids = [var.account_id]
 }
 
 provider "aws" {
   alias               = "us-east-1"
   region              = "us-east-1"
-  version             = "~> 2.0"
+  version             = "~> 3.0"
   allowed_account_ids = [var.account_id]
 }
 EOF


### PR DESCRIPTION
## Changes 

Upgrade Terraform provider version from v2 to v3. 

### Noteworthy

* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_s3_bucket
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_security_group

## Risk

We need to ensure we upgrade proper components following the migration guide:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade

## Test

* The build pipeline passes and validation command works good locally.