### PR TITLE
fix: use variables for daily-service-rate-limit alarm

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -296,8 +296,8 @@ resource "aws_cloudwatch_metric_alarm" "daily-service-rate-limit-error-5-minutes
   alarm_description   = "The daily rate limit has been reached for a service"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.over-daily-rate-limit.name
-  namespace           = "LogMetrics"
+  metric_name         = aws_cloudwatch_log_metric_filter.over-daily-rate-limit.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.over-daily-rate-limit.metric_transformation[0].namespace
   period              = "300"
   statistic           = "Sum"
   threshold           = 1


### PR DESCRIPTION
Use the appropriate variables to avoid hardcoding metric name and namespace

Follow up of https://github.com/cds-snc/notification-terraform/pull/108#discussion_r544365833