### PR TITLE
feat: bind critical alarms to opsgenie via sns topic

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -29,6 +29,7 @@ env:
   TF_VAR_cloudwatch_slack_webhook_critical_topic: ${{ secrets.PRODUCTION_CLOUDWATCH_SLACK_WEBHOOK }}
   TF_VAR_slack_channel_warning_topic: "notification-ops"
   TF_VAR_slack_channel_critical_topic: "notification-ops"
+  TF_VAR_cloudwatch_opsgenie_alarm_webhook: ${{ secrets.PRODUCTION_CLOUDWATCH_OPSGENIE_ALARM_WEBHOOK }}
 
 jobs:
   terraform-apply:

--- a/aws/cloudfront/variables.tf
+++ b/aws/cloudfront/variables.tf
@@ -1,7 +1,7 @@
-variable aws_acm_assets_notification_canada_ca_arn {
+variable "aws_acm_assets_notification_canada_ca_arn" {
   type = string
 }
 
-variable asset_bucket_regional_domain_name {
+variable "asset_bucket_regional_domain_name" {
   type = string
 }

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -28,6 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-spending-critical" {
   statistic           = "Maximum"
   threshold           = 0.9 * var.sns_monthly_spend_limit
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
+  ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-warning" {
@@ -58,6 +59,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-cr
   statistic           = "Average"
   threshold           = 75 / 100
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
+  ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   dimensions = {
     SMSType = "Transactional"
     Country = "CA"
@@ -88,6 +90,7 @@ resource "aws_cloudwatch_metric_alarm" "ses-bounce-rate-critical" {
   statistic           = "Average"
   threshold           = 7 / 100
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
+  ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "ses-complaint-rate-warning" {
@@ -114,6 +117,7 @@ resource "aws_cloudwatch_metric_alarm" "ses-complaint-rate-critical" {
   statistic           = "Average"
   threshold           = 0.4 / 100
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
+  ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-sms-stuck-in-queue-critical" {
@@ -127,6 +131,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-sms-stuck-in-queue-critical" {
   extended_statistic  = "p90"
   threshold           = 60 * 5
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
+  ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   dimensions = {
     QueueName = "eks-notification-canada-casend-sms-tasks"
   }
@@ -143,6 +148,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-email-stuck-in-queue-critical" {
   extended_statistic  = "p90"
   threshold           = 60 * 10
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
+  ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   dimensions = {
     QueueName = "eks-notification-canada-casend-email-tasks"
   }
@@ -159,6 +165,7 @@ resource "aws_cloudwatch_metric_alarm" "healtheck-page-slow-response-critical" {
   statistic           = "Average"
   threshold           = 2
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
+  ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   treat_missing_data  = "breaching"
   dimensions = {
     metric_type = "timing"
@@ -191,4 +198,5 @@ resource "aws_cloudwatch_metric_alarm" "no-emails-sent-5-minutes-critical" {
   threshold           = 1
   treat_missing_data  = "breaching"
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
+  ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
 }

--- a/aws/common/sns.tf
+++ b/aws/common/sns.tf
@@ -40,12 +40,11 @@ resource "aws_sns_topic_subscription" "ses_sns_to_lambda" {
 }
 
 resource "aws_sns_topic_subscription" "alert_to_sns_to_opsgenie" {
-  count  = var.env == "production" ? 1 : 0
+  count = var.env == "production" ? 1 : 0
 
-  topic_arn = aws_sns_topic.notification-canada-ca-alert-critical.arn
-  protocol  = "https"
-  endpoint  = var.cloudwatch_opsgenie_alarm_webhook
+  topic_arn            = aws_sns_topic.notification-canada-ca-alert-critical.arn
+  protocol             = "https"
+  endpoint             = var.cloudwatch_opsgenie_alarm_webhook
   raw_message_delivery = false
-
-  depends_on = [var.cloudwatch_opsgenie_alarm_webhook]
 }
+

--- a/aws/common/sns.tf
+++ b/aws/common/sns.tf
@@ -38,3 +38,14 @@ resource "aws_sns_topic_subscription" "ses_sns_to_lambda" {
 
   depends_on = [aws_lambda_permission.allow_sns]
 }
+
+resource "aws_sns_topic_subscription" "alert_to_sns_to_opsgenie" {
+  count  = var.env == "production" ? 1 : 0
+
+  topic_arn = aws_sns_topic.notification-canada-ca-alert-critical.arn
+  protocol  = "https"
+  endpoint  = var.cloudwatch_opsgenie_alarm_webhook
+  raw_message_delivery = false
+
+  depends_on = [var.cloudwatch_opsgenie_alarm_webhook]
+}

--- a/aws/common/variables.tf
+++ b/aws/common/variables.tf
@@ -1,23 +1,23 @@
-variable sns_monthly_spend_limit {
+variable "sns_monthly_spend_limit" {
   type = number
 }
 
-variable cloudwatch_slack_webhook_warning_topic {
+variable "cloudwatch_slack_webhook_warning_topic" {
   type = string
 }
 
-variable cloudwatch_slack_webhook_critical_topic {
+variable "cloudwatch_slack_webhook_critical_topic" {
   type = string
 }
 
-variable slack_channel_warning_topic {
+variable "slack_channel_warning_topic" {
   type = string
 }
 
-variable slack_channel_critical_topic {
+variable "slack_channel_critical_topic" {
   type = string
 }
 
-variable cloudwatch_opsgenie_alarm_webhook {
+variable "cloudwatch_opsgenie_alarm_webhook" {
   type = string
 }

--- a/aws/common/variables.tf
+++ b/aws/common/variables.tf
@@ -17,3 +17,7 @@ variable slack_channel_warning_topic {
 variable slack_channel_critical_topic {
   type = string
 }
+
+variable cloudwatch_opsgenie_alarm_webhook {
+  type = string
+}

--- a/aws/dns/variables.tf
+++ b/aws/dns/variables.tf
@@ -1,3 +1,3 @@
-variable notification_canada_ca_ses_callback_arn {
+variable "notification_canada_ca_ses_callback_arn" {
   type = string
 }

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -32,6 +32,7 @@ resource "aws_cloudwatch_metric_alarm" "load-balancer-10-500-error-5-minutes-cri
   statistic           = "Sum"
   threshold           = 10
   alarm_actions       = [var.sns_alert_critical_arn]
+  ok_actions          = [var.sns_alert_critical_arn]
   treat_missing_data  = "notBreaching"
 
   dimensions = {
@@ -67,6 +68,7 @@ resource "aws_cloudwatch_metric_alarm" "load-balancer-10-502-error-5-minutes-cri
   statistic           = "Sum"
   threshold           = 10
   alarm_actions       = [var.sns_alert_critical_arn]
+  ok_actions          = [var.sns_alert_critical_arn]
   treat_missing_data  = "notBreaching"
   dimensions = {
     LoadBalancer = aws_alb.notification-canada-ca.arn_suffix
@@ -99,6 +101,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-10-celery-error-1-minute-critical" 
   threshold           = 10
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_critical_arn]
+  ok_actions          = [var.sns_alert_critical_arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-1-500-error-1-minute-warning" {
@@ -127,6 +130,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-10-500-error-5-minutes-critical" {
   threshold           = 10
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_critical_arn]
+  ok_actions          = [var.sns_alert_critical_arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "admin-pods-high-cpu-warning" {
@@ -286,6 +290,7 @@ resource "aws_cloudwatch_metric_alarm" "ddos-detected-load-balancer-critical" {
   threshold           = 1
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_critical_arn]
+  ok_actions          = [var.sns_alert_critical_arn]
   dimensions = {
     ResourceArn = aws_shield_protection.notification-canada-ca.resource_arn
   }

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -1,51 +1,51 @@
-variable aws_acm_notification_canada_ca_arn {
+variable "aws_acm_notification_canada_ca_arn" {
   type = string
 }
 
-variable aws_acm_alt_notification_canada_ca_arn {
+variable "aws_acm_alt_notification_canada_ca_arn" {
   type = string
 }
 
-variable primary_worker_desired_size {
+variable "primary_worker_desired_size" {
   type = number
 }
 
-variable primary_worker_instance_types {
-  type = list
+variable "primary_worker_instance_types" {
+  type = list(any)
 }
 
-variable primary_worker_max_size {
+variable "primary_worker_max_size" {
   type = number
 }
 
-variable primary_worker_min_size {
+variable "primary_worker_min_size" {
   type = number
 }
 
-variable vpc_id {
+variable "vpc_id" {
   type = string
 }
 
-variable vpc_private_subnets {
-  type = list
+variable "vpc_private_subnets" {
+  type = list(any)
 }
 
-variable vpc_public_subnets {
-  type = list
+variable "vpc_public_subnets" {
+  type = list(any)
 }
 
-variable sns_alert_warning_arn {
+variable "sns_alert_warning_arn" {
   type = string
 }
 
-variable sns_alert_critical_arn {
+variable "sns_alert_critical_arn" {
   type = string
 }
 
-variable cloudfront_assets_arn {
+variable "cloudfront_assets_arn" {
   type = string
 }
 
-variable alb_log_bucket {
+variable "alb_log_bucket" {
   type = string
 }

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -1,24 +1,24 @@
-variable eks_cluster_securitygroup {
+variable "eks_cluster_securitygroup" {
   type = string
 }
 
-variable rds_cluster_password {
+variable "rds_cluster_password" {
   type = string
 }
 
-variable rds_instance_count {
+variable "rds_instance_count" {
   type    = number
   default = 1
 }
 
-variable rds_instance_type {
+variable "rds_instance_type" {
   type = string
 }
 
-variable vpc_private_subnets {
-  type = list
+variable "vpc_private_subnets" {
+  type = list(any)
 }
 
-variable sns_alert_warning_arn {
+variable "sns_alert_warning_arn" {
   type = string
 }


### PR DESCRIPTION
**Issue**
https://trello.com/c/p8A8pAKS/187-set-up-cloudwatch-to-opsgenie-integration-in-production

closes #104 

In order to forward critical alarms via sns to opsgenie, a topic subscription was added.
Set to create in production only when env var PRODUCTION_CLOUDWATCH_OPSGENIE_ALARM_WEBHOOK is set.

Additionally all critical alarms are set to hit the same sns topic once they arrive to ok state.