### PR TITLE
support: Increased the threshold for alarm about queue message age

### DIFF
--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -139,14 +139,14 @@ resource "aws_cloudwatch_metric_alarm" "sqs-sms-stuck-in-queue-critical" {
 
 resource "aws_cloudwatch_metric_alarm" "sqs-email-stuck-in-queue-critical" {
   alarm_name          = "sqs-email-stuck-in-queue-critical"
-  alarm_description   = "ApproximateAgeOfOldestMessage in email queue is older than 10 minutes for 15 minutes"
+  alarm_description   = "ApproximateAgeOfOldestMessage in email queue is older than 12 minutes for 15 minutes"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "3"
   metric_name         = "ApproximateAgeOfOldestMessage"
   namespace           = "AWS/SQS"
   period              = "300"
   extended_statistic  = "p90"
-  threshold           = 60 * 10
+  threshold           = 60 * 12
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   dimensions = {

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -139,14 +139,14 @@ resource "aws_cloudwatch_metric_alarm" "sqs-sms-stuck-in-queue-critical" {
 
 resource "aws_cloudwatch_metric_alarm" "sqs-email-stuck-in-queue-critical" {
   alarm_name          = "sqs-email-stuck-in-queue-critical"
-  alarm_description   = "ApproximateAgeOfOldestMessage in email queue is older than 12 minutes for 15 minutes"
+  alarm_description   = "ApproximateAgeOfOldestMessage in email queue is older than 15 minutes for 15 minutes"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "3"
   metric_name         = "ApproximateAgeOfOldestMessage"
   namespace           = "AWS/SQS"
   period              = "300"
   extended_statistic  = "p90"
-  threshold           = 60 * 12
+  threshold           = 60 * 15
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   dimensions = {


### PR DESCRIPTION
# Summary | Résumé

Increase the alarm threshold for queue age so it does not trigger too much. With the recent switch of the *get covid updates* services from CSV bulk upload to using the NodeJS client, we receive a bigger hit of notifications every day. Reducing the noise of the alarm would be beneficial as the main goal of it is to inform about potential stalls but here we simply have more messages in the queue being reported.   

# Test instructions | Instructions pour tester la modification

There is no easy way to test this that comes to mind, other than creating an alarm with a low threshold which would defeat the purpose of this change. We know the alarm worked before; I am simply increasing the threshold.

# Help requested | Aide requise

Make sure the covered period of the existing alarm works good with the new updated threshold.

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their review | Voici une suggestion de liste de vérification comprenant des questions que les réviseurs pourraient poser pendant leur examen :

- [ ] Does this meet a user need? | Est-ce que ça répond à un besoin utilisateur?
- [ ] Is it accessible? | Est-ce que c’est accessible?
- [ ] Is it translated between both official languages? | Est-ce dans les deux langues officielles?
- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une fonctionnalité existante?
- [ ] Should this be split into smaller PRs to decrease change risk? | Est-ce que ça devrait être divisé en de plus petites demandes de tirage (« pull requests ») afin de réduire le risque lié aux modifications?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce changement (fichier README, etc.)?
