### PR TITLE
feat: redirect www domain to non www

### DIFF
--- a/aws/eks/alb.tf
+++ b/aws/eks/alb.tf
@@ -242,6 +242,33 @@ resource "aws_alb_target_group" "notification-canada-ca-admin" {
   }
 }
 
+###
+# WWW to non-WWW
+###
+
+resource "aws_lb_listener_rule" "www-domain-host-route" {
+  listener_arn = aws_alb_listener.notification-canada-ca.arn
+  priority     = 50
+
+  action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+      host        = var.domain
+      path        = "/#{path}"
+      query       = "#{query}"
+    }
+  }
+
+  condition {
+    host_header {
+      values = ["www.${var.domain}"]
+    }
+  }
+}
 
 ###
 # WAF


### PR DESCRIPTION
Fixes https://github.com/cds-snc/notification-terraform/issues/117

`priority` on the load balancer is set this way currently:
- values < 100 are for redirect rules
- values > 100 are used to dispatch requests to target groups

DNS PR: https://github.com/cds-snc/dns/pull/171