### PR TITLE
add subscription to AWS ECR health events

### DIFF
--- a/aws/common/cloudwatch_events.tf
+++ b/aws/common/cloudwatch_events.tf
@@ -16,6 +16,7 @@ resource "aws_cloudwatch_event_rule" "aws_health" {
          "CLOUDFRONT",
          "CLOUDWATCH",
          "EC2",
+         "ECR",
          "EKS",
          "IAM",
          "KMS",


### PR DESCRIPTION
Fixes:
https://github.com/cds-snc/notification-terraform/issues/103

Added Elastic Container Registry to the list of services to whose health events are subscribed to