### PR TITLE
Bump production to 0.48.0

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -16,7 +16,7 @@ env:
   # Set the GitHub tag here to update the infrastructure
   # to a new version in production
   # See https://github.com/cds-snc/notification-terraform/releases
-  INFRASTRUCTURE_VERSION: '0.47.3'
+  INFRASTRUCTURE_VERSION: '0.48.0'
 
   # Terraform environment variables
   AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Would include changes introduced in #118 and #119.

Tested that the www redirection works fine in staging
```
$ curl -I https://www.staging.notification.cdssandbox.xyz
HTTP/2 301 
server: awselb/2.0
date: Tue, 22 Dec 2020 08:27:16 GMT
content-type: text/html
content-length: 134
location: https://staging.notification.cdssandbox.xyz:443
```