### PR TITLE
fix: create SNS topics for alarms in us-west-2

### DIFF
--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -29,7 +29,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-spending-us-west-2-warning" {
   period              = "300"
   statistic           = "Maximum"
   threshold           = 0.8 * var.sns_monthly_spend_limit_us_west_2
-  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning-us-west-2.arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "sns-spending-critical" {
@@ -58,8 +58,8 @@ resource "aws_cloudwatch_metric_alarm" "sns-spending-us-west-2-critical" {
   period              = "300"
   statistic           = "Maximum"
   threshold           = 0.9 * var.sns_monthly_spend_limit_us_west_2
-  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
-  ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical-us-west-2.arn]
+  ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical-us-west-2.arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-warning" {
@@ -91,7 +91,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-us
   period              = 60 * 60 * 24
   statistic           = "Average"
   threshold           = 85 / 100
-  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning-us-west-2.arn]
   dimensions = {
     SMSType = "Transactional"
     Country = "CA"
@@ -128,8 +128,8 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-us
   period              = 60 * 60 * 24
   statistic           = "Average"
   threshold           = 75 / 100
-  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
-  ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical-us-west-2.arn]
+  ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical-us-west-2.arn]
   dimensions = {
     SMSType = "Transactional"
     Country = "CA"

--- a/aws/common/kms.tf
+++ b/aws/common/kms.tf
@@ -21,7 +21,7 @@ resource "aws_kms_key" "notification-canada-ca" {
     {
       "Effect": "Allow",
       "Principal": { "Service": "logs.${var.region}.amazonaws.com" },
-      "Action": [ 
+      "Action": [
         "kms:Encrypt*",
         "kms:Decrypt*",
         "kms:ReEncrypt*",
@@ -54,8 +54,52 @@ resource "aws_kms_key" "notification-canada-ca" {
     ],
     "Resource": "*"
   }
-    
+
   ]
+}
+EOF
+
+  tags = {
+    Name       = "notification-canada-ca"
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}
+
+resource "aws_kms_key" "notification-canada-ca-us-west-2" {
+  provider = aws.us-west-2
+
+  description         = "notification-canada-ca ${var.env} encryption key in us-west-2"
+  enable_key_rotation = true
+
+  policy = <<EOF
+{
+   "Version":"2012-10-17",
+   "Id":"key-default-us-west-2",
+   "Statement":[
+      {
+         "Sid":"Enable IAM User Permissions",
+         "Effect":"Allow",
+         "Principal":{
+            "AWS":"arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+         },
+         "Action":"kms:*",
+         "Resource":"*"
+      },
+      {
+         "Sid":"Allow_CloudWatch_for_CMK",
+         "Effect":"Allow",
+         "Principal":{
+            "Service":[
+               "cloudwatch.amazonaws.com"
+            ]
+         },
+         "Action":[
+            "kms:Decrypt",
+            "kms:GenerateDataKey"
+         ],
+         "Resource":"*"
+      }
+   ]
 }
 EOF
 

--- a/aws/common/sns.tf
+++ b/aws/common/sns.tf
@@ -19,8 +19,7 @@ resource "aws_sns_topic" "notification-canada-ca-alert-warning" {
 resource "aws_sns_topic" "notification-canada-ca-alert-warning-us-west-2" {
   provider = aws.us-west-2
 
-  name              = "alert-warning-us-west-2"
-  kms_master_key_id = aws_kms_key.notification-canada-ca.arn
+  name = "alert-warning-us-west-2"
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
@@ -39,8 +38,7 @@ resource "aws_sns_topic" "notification-canada-ca-alert-critical" {
 resource "aws_sns_topic" "notification-canada-ca-alert-critical-us-west-2" {
   provider = aws.us-west-2
 
-  name              = "alert-critical-us-west-2"
-  kms_master_key_id = aws_kms_key.notification-canada-ca.arn
+  name = "alert-critical-us-west-2"
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"

--- a/aws/common/sns.tf
+++ b/aws/common/sns.tf
@@ -19,7 +19,9 @@ resource "aws_sns_topic" "notification-canada-ca-alert-warning" {
 resource "aws_sns_topic" "notification-canada-ca-alert-warning-us-west-2" {
   provider = aws.us-west-2
 
-  name = "alert-warning-us-west-2"
+  name              = "alert-warning-us-west-2"
+  kms_master_key_id = aws_kms_key.notification-canada-ca-us-west-2.arn
+
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
@@ -38,7 +40,9 @@ resource "aws_sns_topic" "notification-canada-ca-alert-critical" {
 resource "aws_sns_topic" "notification-canada-ca-alert-critical-us-west-2" {
   provider = aws.us-west-2
 
-  name = "alert-critical-us-west-2"
+  name              = "alert-critical-us-west-2"
+  kms_master_key_id = aws_kms_key.notification-canada-ca-us-west-2.arn
+
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"

--- a/aws/common/sns.tf
+++ b/aws/common/sns.tf
@@ -16,8 +16,30 @@ resource "aws_sns_topic" "notification-canada-ca-alert-warning" {
   }
 }
 
+resource "aws_sns_topic" "notification-canada-ca-alert-warning-us-west-2" {
+  provider = aws.us-west-2
+
+  name              = "alert-warning-us-west-2"
+  kms_master_key_id = aws_kms_key.notification-canada-ca.arn
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}
+
 resource "aws_sns_topic" "notification-canada-ca-alert-critical" {
   name              = "alert-critical"
+  kms_master_key_id = aws_kms_key.notification-canada-ca.arn
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}
+
+resource "aws_sns_topic" "notification-canada-ca-alert-critical-us-west-2" {
+  provider = aws.us-west-2
+
+  name              = "alert-critical-us-west-2"
   kms_master_key_id = aws_kms_key.notification-canada-ca.arn
 
   tags = {
@@ -47,6 +69,26 @@ resource "aws_sns_topic_subscription" "ses_sns_to_lambda" {
   depends_on = [aws_lambda_permission.allow_sns]
 }
 
+resource "aws_sns_topic_subscription" "sns_alert_warning_us_west_2_to_lambda" {
+  provider = aws.us-west-2
+
+  topic_arn = aws_sns_topic.notification-canada-ca-alert-warning-us-west-2.arn
+  protocol  = "lambda"
+  endpoint  = module.notify_slack_warning.notify_slack_lambda_function_arn
+
+  depends_on = [aws_lambda_permission.allow_sns]
+}
+
+resource "aws_sns_topic_subscription" "sns_alert_critical_us_west_2_to_lambda" {
+  provider = aws.us-west-2
+
+  topic_arn = aws_sns_topic.notification-canada-ca-alert-critical-us-west-2.arn
+  protocol  = "lambda"
+  endpoint  = module.notify_slack_critical.notify_slack_lambda_function_arn
+
+  depends_on = [aws_lambda_permission.allow_sns]
+}
+
 resource "aws_sns_topic_subscription" "alert_to_sns_to_opsgenie" {
   count = var.env == "production" ? 1 : 0
 
@@ -57,3 +99,12 @@ resource "aws_sns_topic_subscription" "alert_to_sns_to_opsgenie" {
   endpoint_auto_confirms = true
 }
 
+resource "aws_sns_topic_subscription" "alert_critical_us_west_2_to_opsgenie" {
+  count = var.env == "production" ? 1 : 0
+
+  topic_arn              = aws_sns_topic.notification-canada-ca-alert-critical-us-west-2.arn
+  protocol               = "https"
+  endpoint               = var.cloudwatch_opsgenie_alarm_webhook
+  raw_message_delivery   = false
+  endpoint_auto_confirms = true
+}


### PR DESCRIPTION
Follow up of #126 

Turns out alarms require SNS topics to be in the same region, the [CI job failed](https://github.com/cds-snc/notification-terraform/runs/1658834964?check_suite_focus=true) when creating alarms.

> Creating metric alarm failed: ValidationError: Invalid region ca-central-1 specified. Only us-west-2 is supported.

This PR creates SNS topics for alarms in `us-west-2` and subscribes these topics to:
- Lambda functions for Slack webhooks
- Opsgenie in production

SNS topic subscriptions can be cross regions so for us this will be SNS topic used by alarms in `us-west-2` to Lambda functions (Slack integration) in `ca-central-1` + Opsgenie

> Amazon SNS supports the cross-region delivery of notifications to Amazon SQS queues and to AWS Lambda functions.
From https://docs.aws.amazon.com/sns/latest/dg/sns-cross-region-delivery.html