### PR TITLE
feat: forward cache-control header

### DIFF
--- a/aws/cloudfront/cloudfront.tf
+++ b/aws/cloudfront/cloudfront.tf
@@ -25,6 +25,8 @@ resource "aws_cloudfront_distribution" "asset_bucket" {
     forwarded_values {
       query_string = false
 
+      headers = ["Cache-Control"]
+
       cookies {
         forward = "none"
       }


### PR DESCRIPTION
I've set `Cache-Control: max-age=604800` (7 days) on files stored on the S3 static assets bucket (GoC logos, images on the homepage etc).

Forward this cache header at the Cloudfront level to tell clients to cache these images

Reference for syntax: https://stackoverflow.com/questions/63934583/what-is-the-syntax-for-headers-in-aws-cloudfront-distribution-forwarded-values