### PR TITLE
fix: allow SNS topics in us-west-2 to invoke Lambdas

### DIFF
--- a/aws/common/lambda.tf
+++ b/aws/common/lambda.tf
@@ -62,7 +62,7 @@ resource "aws_lambda_permission" "allow_sns" {
 }
 
 resource "aws_lambda_permission" "sns_warning_us_west_2_to_slack_lambda" {
-  statement_id  = "AllowExecutionFromSNS"
+  statement_id  = "AllowExecutionFromSNSWarningUSWest2"
   action        = "lambda:InvokeFunction"
   function_name = module.notify_slack_warning.notify_slack_lambda_function_arn
   principal     = "sns.amazonaws.com"
@@ -70,7 +70,7 @@ resource "aws_lambda_permission" "sns_warning_us_west_2_to_slack_lambda" {
 }
 
 resource "aws_lambda_permission" "sns_critical_us_west_2_to_slack_lambda" {
-  statement_id  = "AllowExecutionFromSNS"
+  statement_id  = "AllowExecutionFromSNSCriticalUSWest2"
   action        = "lambda:InvokeFunction"
   function_name = module.notify_slack_critical.notify_slack_lambda_function_arn
   principal     = "sns.amazonaws.com"

--- a/aws/common/lambda.tf
+++ b/aws/common/lambda.tf
@@ -60,3 +60,19 @@ resource "aws_lambda_permission" "allow_sns" {
   function_name = aws_lambda_function.ses_to_sqs_email_callbacks.function_name
   principal     = "sns.amazonaws.com"
 }
+
+resource "aws_lambda_permission" "sns_warning_us_west_2_to_slack_lambda" {
+  statement_id  = "AllowExecutionFromSNS"
+  action        = "lambda:InvokeFunction"
+  function_name = module.notify_slack_warning.notify_slack_lambda_function_arn
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.notification-canada-ca-alert-warning-us-west-2.arn
+}
+
+resource "aws_lambda_permission" "sns_critical_us_west_2_to_slack_lambda" {
+  statement_id  = "AllowExecutionFromSNS"
+  action        = "lambda:InvokeFunction"
+  function_name = module.notify_slack_critical.notify_slack_lambda_function_arn
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.notification-canada-ca-alert-critical-us-west-2.arn
+}


### PR DESCRIPTION
Follow up of https://github.com/cds-snc/notification-terraform/pull/128. In the previous PR, SNS topics have been created and subscribed to Lambda functions but turns out I need to allow these topics to invoke Lambdas

The existing policy was this one for example

```json
{
  "Version": "2012-10-17",
  "Id": "default",
  "Statement": [
    {
      "Sid": "AllowExecutionFromSNS",
      "Effect": "Allow",
      "Principal": {
        "Service": "sns.amazonaws.com"
      },
      "Action": "lambda:InvokeFunction",
      "Resource": "arn:aws:lambda:ca-central-1:239043911459:function:notify-slack-warning",
      "Condition": {
        "ArnLike": {
          "AWS:SourceArn": "arn:aws:sns:ca-central-1:239043911459:alert-warning"
        }
      }
    }
  ]
}
```

As you can see, only the SNS topic in `ca-central-1` was allowed to invoke the function. This PR adds the required permissions.