### PR TITLE
fix: specific source ARNs for Lambda permissions

### DIFF
--- a/aws/common/cloudwatch_log.tf
+++ b/aws/common/cloudwatch_log.tf
@@ -1,11 +1,6 @@
 resource "aws_cloudwatch_log_group" "sns_deliveries" {
   name = "sns/${var.region}/${var.account_id}/DirectPublishToPhoneNumber"
 
-  depends_on = [
-    aws_lambda_permission.allow_cloudwatch_logs,
-    aws_lambda_permission.allow_cloudwatch_events
-  ]
-
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
   }
@@ -13,11 +8,6 @@ resource "aws_cloudwatch_log_group" "sns_deliveries" {
 
 resource "aws_cloudwatch_log_group" "sns_deliveries_failures" {
   name = "sns/${var.region}/${var.account_id}/DirectPublishToPhoneNumber/Failure"
-
-  depends_on = [
-    aws_lambda_permission.allow_cloudwatch_logs,
-    aws_lambda_permission.allow_cloudwatch_events
-  ]
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
@@ -29,11 +19,6 @@ resource "aws_cloudwatch_log_group" "sns_deliveries_us_west_2" {
 
   name = "sns/us-west-2/${var.account_id}/DirectPublishToPhoneNumber"
 
-  depends_on = [
-    aws_lambda_permission.allow_cloudwatch_logs,
-    aws_lambda_permission.allow_cloudwatch_events
-  ]
-
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
   }
@@ -43,11 +28,6 @@ resource "aws_cloudwatch_log_group" "sns_deliveries_failures_us_west_2" {
   provider = aws.us-west-2
 
   name = "sns/us-west-2/${var.account_id}/DirectPublishToPhoneNumber/Failure"
-
-  depends_on = [
-    aws_lambda_permission.allow_cloudwatch_logs,
-    aws_lambda_permission.allow_cloudwatch_events
-  ]
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"

--- a/aws/common/lambda.tf
+++ b/aws/common/lambda.tf
@@ -40,27 +40,58 @@ resource "aws_lambda_function" "sns_to_sqs_sms_callbacks" {
   }
 }
 
-resource "aws_lambda_permission" "allow_cloudwatch_events" {
-  statement_id  = "AllowExecutionFromCloudWatch"
-  action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.sns_to_sqs_sms_callbacks.function_name
-  principal     = "events.amazonaws.com"
-}
-
-resource "aws_lambda_permission" "allow_cloudwatch_logs" {
-  statement_id  = "AllowExecutionFromCloudWatchLogs"
+##
+# CloudWatch log groups for SNS deliveries in ca-central-1
+##
+resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_successes" {
+  statement_id  = "allow_cloudwatch_logs_sns_successes"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.sns_to_sqs_sms_callbacks.function_name
   principal     = "logs.amazonaws.com"
+  source_arn    = aws_cloudwatch_log_group.sns_deliveries.arn
 }
 
-resource "aws_lambda_permission" "allow_sns" {
-  statement_id  = "AllowExecutionFromSNS"
+resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_failures" {
+  statement_id  = "allow_cloudwatch_logs_sns_failures"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.sns_to_sqs_sms_callbacks.function_name
+  principal     = "logs.amazonaws.com"
+  source_arn    = aws_cloudwatch_log_group.sns_deliveries_failures.arn
+}
+
+##
+# CloudWatch log groups for SNS deliveries in us-west-2
+##
+resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_successes_us_west_2" {
+  statement_id  = "allow_cloudwatch_logs_sns_successes_us_west_2"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.sns_to_sqs_sms_callbacks.function_name
+  principal     = "logs.amazonaws.com"
+  source_arn    = aws_cloudwatch_log_group.sns_deliveries_us_west_2.arn
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_failures_us_west_2" {
+  statement_id  = "allow_cloudwatch_logs_sns_failures_us_west_2"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.sns_to_sqs_sms_callbacks.function_name
+  principal     = "logs.amazonaws.com"
+  source_arn    = aws_cloudwatch_log_group.sns_deliveries_failures_us_west_2.arn
+}
+
+##
+# SNS topic for SES deliveries
+##
+resource "aws_lambda_permission" "allow_sns_ses_callbacks" {
+  statement_id  = "allow_sns_ses_callbacks"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.ses_to_sqs_email_callbacks.function_name
   principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.notification-canada-ca-ses-callback.arn
 }
 
+##
+# SNS topics for CloudWatch alarms in us-west-2
+##
 resource "aws_lambda_permission" "sns_warning_us_west_2_to_slack_lambda" {
   statement_id  = "AllowExecutionFromSNSWarningUSWest2"
   action        = "lambda:InvokeFunction"

--- a/aws/common/lambda.tf
+++ b/aws/common/lambda.tf
@@ -44,7 +44,6 @@ resource "aws_lambda_function" "sns_to_sqs_sms_callbacks" {
 # CloudWatch log groups for SNS deliveries in ca-central-1
 ##
 resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_successes" {
-  statement_id  = "allow_cloudwatch_logs_sns_successes"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.sns_to_sqs_sms_callbacks.function_name
   principal     = "logs.amazonaws.com"
@@ -52,7 +51,6 @@ resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_successes" {
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_failures" {
-  statement_id  = "allow_cloudwatch_logs_sns_failures"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.sns_to_sqs_sms_callbacks.function_name
   principal     = "logs.amazonaws.com"
@@ -63,7 +61,6 @@ resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_failures" {
 # CloudWatch log groups for SNS deliveries in us-west-2
 ##
 resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_successes_us_west_2" {
-  statement_id  = "allow_cloudwatch_logs_sns_successes_us_west_2"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.sns_to_sqs_sms_callbacks.function_name
   principal     = "logs.amazonaws.com"
@@ -71,7 +68,6 @@ resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_successes_us_west_2"
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_failures_us_west_2" {
-  statement_id  = "allow_cloudwatch_logs_sns_failures_us_west_2"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.sns_to_sqs_sms_callbacks.function_name
   principal     = "logs.amazonaws.com"
@@ -82,7 +78,6 @@ resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_failures_us_west_2" 
 # SNS topic for SES deliveries
 ##
 resource "aws_lambda_permission" "allow_sns_ses_callbacks" {
-  statement_id  = "allow_sns_ses_callbacks"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.ses_to_sqs_email_callbacks.function_name
   principal     = "sns.amazonaws.com"
@@ -93,7 +88,6 @@ resource "aws_lambda_permission" "allow_sns_ses_callbacks" {
 # SNS topics for CloudWatch alarms in us-west-2
 ##
 resource "aws_lambda_permission" "sns_warning_us_west_2_to_slack_lambda" {
-  statement_id  = "AllowExecutionFromSNSWarningUSWest2"
   action        = "lambda:InvokeFunction"
   function_name = module.notify_slack_warning.notify_slack_lambda_function_arn
   principal     = "sns.amazonaws.com"
@@ -101,7 +95,6 @@ resource "aws_lambda_permission" "sns_warning_us_west_2_to_slack_lambda" {
 }
 
 resource "aws_lambda_permission" "sns_critical_us_west_2_to_slack_lambda" {
-  statement_id  = "AllowExecutionFromSNSCriticalUSWest2"
   action        = "lambda:InvokeFunction"
   function_name = module.notify_slack_critical.notify_slack_lambda_function_arn
   principal     = "sns.amazonaws.com"

--- a/aws/common/sns.tf
+++ b/aws/common/sns.tf
@@ -67,8 +67,6 @@ resource "aws_sns_topic_subscription" "ses_sns_to_lambda" {
   topic_arn = aws_sns_topic.notification-canada-ca-ses-callback.arn
   protocol  = "lambda"
   endpoint  = aws_lambda_function.ses_to_sqs_email_callbacks.arn
-
-  depends_on = [aws_lambda_permission.allow_sns]
 }
 
 resource "aws_sns_topic_subscription" "sns_alert_warning_us_west_2_to_lambda" {
@@ -77,8 +75,6 @@ resource "aws_sns_topic_subscription" "sns_alert_warning_us_west_2_to_lambda" {
   topic_arn = aws_sns_topic.notification-canada-ca-alert-warning-us-west-2.arn
   protocol  = "lambda"
   endpoint  = module.notify_slack_warning.notify_slack_lambda_function_arn
-
-  depends_on = [aws_lambda_permission.allow_sns]
 }
 
 resource "aws_sns_topic_subscription" "sns_alert_critical_us_west_2_to_lambda" {
@@ -87,8 +83,6 @@ resource "aws_sns_topic_subscription" "sns_alert_critical_us_west_2_to_lambda" {
   topic_arn = aws_sns_topic.notification-canada-ca-alert-critical-us-west-2.arn
   protocol  = "lambda"
   endpoint  = module.notify_slack_critical.notify_slack_lambda_function_arn
-
-  depends_on = [aws_lambda_permission.allow_sns]
 }
 
 resource "aws_sns_topic_subscription" "alert_to_sns_to_opsgenie" {


### PR DESCRIPTION
Restrict invocation privileges for 2 Lambda functions to specific resources by specifying their ARNs.

From https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission, `source_arn`:
> When the principal is an AWS service, the ARN of the specific resource within that service to grant permission to. Without this, any resource from principal will be granted permission – even if that resource is from another account.

This PR keeps `principal` to AWS services (`(logs|sns).amazonaws.com` for us) but specifies ARNs for Cloudwatch log groups and SNS topics which are allowed to execute these Lambdas.

Remove unneeded `depends_on` statements which are now explicit because we cross-reference Lambda permissions/log groups or SNS topics so Terraform will be able to compute an execution plan.