### PR TITLE
feat: update period for SNS success rates' alarms

### DIFF
--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -64,12 +64,13 @@ resource "aws_cloudwatch_metric_alarm" "sns-spending-us-west-2-critical" {
 
 resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-warning" {
   alarm_name          = "sns-sms-success-rate-canadian-numbers-warning"
-  alarm_description   = "SMS success rate to Canadian numbers is below 85% over the last 24 hours"
+  alarm_description   = "SMS success rate to Canadian numbers is below 85% over 2 consecutive periods of 12 hours"
   comparison_operator = "LessThanThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = "2"
+  datapoints_to_alarm = "2"
   metric_name         = "SMSSuccessRate"
   namespace           = "AWS/SNS"
-  period              = 60 * 60 * 24
+  period              = 60 * 60 * 12
   statistic           = "Average"
   threshold           = 85 / 100
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
@@ -83,12 +84,13 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-us
   provider = aws.us-west-2
 
   alarm_name          = "sns-sms-success-rate-canadian-numbers-us-west-2-warning"
-  alarm_description   = "SMS success rate to Canadian numbers is below 85% over the last 24 hours"
+  alarm_description   = "SMS success rate to Canadian numbers is below 85% over 2 consecutive periods of 12 hours"
   comparison_operator = "LessThanThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = "2"
+  datapoints_to_alarm = "2"
   metric_name         = "SMSSuccessRate"
   namespace           = "AWS/SNS"
-  period              = 60 * 60 * 24
+  period              = 60 * 60 * 12
   statistic           = "Average"
   threshold           = 85 / 100
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning-us-west-2.arn]
@@ -100,12 +102,13 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-us
 
 resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-critical" {
   alarm_name          = "sns-sms-success-rate-canadian-numbers-critical"
-  alarm_description   = "SMS success rate to Canadian numbers is below 75% over the last 24 hours"
+  alarm_description   = "SMS success rate to Canadian numbers is below 75% over 2 consecutive periods of 12 hours"
   comparison_operator = "LessThanThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = "2"
+  datapoints_to_alarm = "2"
   metric_name         = "SMSSuccessRate"
   namespace           = "AWS/SNS"
-  period              = 60 * 60 * 24
+  period              = 60 * 60 * 12
   statistic           = "Average"
   threshold           = 75 / 100
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
@@ -120,12 +123,13 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-us
   provider = aws.us-west-2
 
   alarm_name          = "sns-sms-success-rate-canadian-numbers-us-west-2-critical"
-  alarm_description   = "SMS success rate to Canadian numbers is below 75% over the last 24 hours"
+  alarm_description   = "SMS success rate to Canadian numbers is below 75% over 2 consecutive periods of 12 hours"
   comparison_operator = "LessThanThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = "2"
+  datapoints_to_alarm = "2"
   metric_name         = "SMSSuccessRate"
   namespace           = "AWS/SNS"
-  period              = 60 * 60 * 24
+  period              = 60 * 60 * 12
   statistic           = "Average"
   threshold           = 75 / 100
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical-us-west-2.arn]


### PR DESCRIPTION
Previously these alarms were over a sliding window of 24 hours and we saw some issues over the weekend with low volumes.

Changing these alarms to:
- change the period from 24 hours to 12 hours
- trigger only if 2 consecutive periods of 12 hours are below the thresholds (a combination of `datapoints_to_alarm` and `evaluation_periods`)

This should be more robust to low volumes while avoiding a magic delay number or increasing the time it takes to detect a drop in success rate.

This changes 4 alarms: 1 warning and 1 critical alarm in `ca-central-1` (regular region) and the same thing in `us-west-2`(region used by the pool of dedicated long codes)