### PR TITLE
fix: appropriate ARNs for log groups to Lambda

### DIFF
--- a/aws/common/lambda.tf
+++ b/aws/common/lambda.tf
@@ -47,14 +47,14 @@ resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_successes" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.sns_to_sqs_sms_callbacks.function_name
   principal     = "logs.amazonaws.com"
-  source_arn    = aws_cloudwatch_log_group.sns_deliveries.arn
+  source_arn    = "${aws_cloudwatch_log_group.sns_deliveries.arn}:*"
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_failures" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.sns_to_sqs_sms_callbacks.function_name
   principal     = "logs.amazonaws.com"
-  source_arn    = aws_cloudwatch_log_group.sns_deliveries_failures.arn
+  source_arn    = "${aws_cloudwatch_log_group.sns_deliveries_failures.arn}:*"
 }
 
 ##
@@ -64,14 +64,14 @@ resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_successes_us_west_2"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.sns_to_sqs_sms_callbacks.function_name
   principal     = "logs.amazonaws.com"
-  source_arn    = aws_cloudwatch_log_group.sns_deliveries_us_west_2.arn
+  source_arn    = "${aws_cloudwatch_log_group.sns_deliveries_us_west_2.arn}:*"
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_failures_us_west_2" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.sns_to_sqs_sms_callbacks.function_name
   principal     = "logs.amazonaws.com"
-  source_arn    = aws_cloudwatch_log_group.sns_deliveries_failures_us_west_2.arn
+  source_arn    = "${aws_cloudwatch_log_group.sns_deliveries_failures_us_west_2.arn}:*"
 }
 
 ##


### PR DESCRIPTION
Follow up of #132.

According to https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group for the `arn` output:

> The Amazon Resource Name (ARN) specifying the log group. Any `:*` suffix added by the API, denoting all CloudWatch Log Streams under the CloudWatch Log Group, is removed for greater compatibility with other AWS services that do not accept the suffix.

The suffix seems to be needed to allow the invocation of Lambda functions. This has the effect of allowing log messages to trigger to the Lambda and not the log group, which is indeed what we want.

This PR adds the required suffix to CloudWatch log groups ARNs.