### PR TITLE
fix: add region in principal for Lambda permissions

### DIFF
--- a/aws/common/lambda.tf
+++ b/aws/common/lambda.tf
@@ -46,14 +46,14 @@ resource "aws_lambda_function" "sns_to_sqs_sms_callbacks" {
 resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_successes" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.sns_to_sqs_sms_callbacks.function_name
-  principal     = "logs.amazonaws.com"
+  principal     = "logs.${var.region}.amazonaws.com"
   source_arn    = "${aws_cloudwatch_log_group.sns_deliveries.arn}:*"
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_failures" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.sns_to_sqs_sms_callbacks.function_name
-  principal     = "logs.amazonaws.com"
+  principal     = "logs.${var.region}.amazonaws.com"
   source_arn    = "${aws_cloudwatch_log_group.sns_deliveries_failures.arn}:*"
 }
 
@@ -63,14 +63,14 @@ resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_failures" {
 resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_successes_us_west_2" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.sns_to_sqs_sms_callbacks.function_name
-  principal     = "logs.amazonaws.com"
+  principal     = "logs.us-west-2.amazonaws.com"
   source_arn    = "${aws_cloudwatch_log_group.sns_deliveries_us_west_2.arn}:*"
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_failures_us_west_2" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.sns_to_sqs_sms_callbacks.function_name
-  principal     = "logs.amazonaws.com"
+  principal     = "logs.us-west-2.amazonaws.com"
   source_arn    = "${aws_cloudwatch_log_group.sns_deliveries_failures_us_west_2.arn}:*"
 }
 


### PR DESCRIPTION
Follow up of #134.

AWS Lambda permissions don't accept a generic principal like `logs.amazonaws.com` but require regional endpoints.

Relevant documentation: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters.html

> Grant CloudWatch Logs the permission to execute your function.

```
aws lambda add-permission \
    --function-name "helloworld" \
    --statement-id "helloworld" \
    --principal "logs.region.amazonaws.com" \
    --action "lambda:InvokeFunction" \
    --source-arn "arn:aws:logs:region:123456789123:log-group:TestLambda:*" \
    --source-account "123456789012"
````