### PR TITLE
fix: specify SNS spending limit in us-west-2

### DIFF
--- a/env/production/common/terragrunt.hcl
+++ b/env/production/common/terragrunt.hcl
@@ -9,5 +9,6 @@ include {
 }
 
 inputs = {
-  sns_monthly_spend_limit = 10000
+  sns_monthly_spend_limit           = 10000
+  sns_monthly_spend_limit_us_west_2 = 1000
 }


### PR DESCRIPTION
Follow up of #127, we missed a variable in production