### PR TITLE
fix: SNS topic subscription in us-west-2

### DIFF
--- a/aws/common/sns.tf
+++ b/aws/common/sns.tf
@@ -96,6 +96,8 @@ resource "aws_sns_topic_subscription" "alert_to_sns_to_opsgenie" {
 }
 
 resource "aws_sns_topic_subscription" "alert_critical_us_west_2_to_opsgenie" {
+  provider = aws.us-west-2
+
   count = var.env == "production" ? 1 : 0
 
   topic_arn              = aws_sns_topic.notification-canada-ca-alert-critical-us-west-2.arn


### PR DESCRIPTION
The SNS topic subscription in `us-west-2` to OpsGenie should be executed from the appropriate provider (`us-west-2`). Terraform tried to create the ressource from `ca-central-1` and this does not work.