### PR TITLE
Bump production to 0.53.0

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -16,7 +16,7 @@ env:
   # Set the GitHub tag here to update the infrastructure
   # to a new version in production
   # See https://github.com/cds-snc/notification-terraform/releases
-  INFRASTRUCTURE_VERSION: '0.52.0'
+  INFRASTRUCTURE_VERSION: '0.53.0'
 
   # Terraform environment variables
   AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Releasing https://github.com/cds-snc/notification-terraform/pull/127 for real this time.

Build failed so we made the following fixes
- https://github.com/cds-snc/notification-terraform/pull/136
- https://github.com/cds-snc/notification-terraform/pull/137

This released a new tag so use this latest tag to deploy to production, without errors when applying changes this time.