### PR TITLE
feat: encrypt all S3 buckets

### DIFF
--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -144,12 +144,19 @@ resource "aws_s3_bucket" "asset_bucket" {
   #tfsec:ignore:AWS001 - Public read access
   acl = "public-read"
 
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
   }
 
   #tfsec:ignore:AWS002 - No logging enabled
-  #tfsec:ignore:AWS017 - Defines an unencrypted S3 bucket
 }
 
 resource "aws_s3_bucket_policy" "asset_bucket_public_read" {
@@ -180,12 +187,19 @@ resource "aws_s3_bucket" "legacy_asset_bucket" {
   #tfsec:ignore:AWS001 - Public read access
   acl = "public-read"
 
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
   }
 
   #tfsec:ignore:AWS002 - No logging enabled
-  #tfsec:ignore:AWS017 - Defines an unencrypted S3 bucket
 }
 
 resource "aws_s3_bucket_policy" "legacy_asset_bucket_public_read" {


### PR DESCRIPTION
The continuous Guardrail scanning is not happy that we have [some S3 buckets without encryption enabled](https://github.com/cds-snc/continuous-guardrail-scanning/blob/a8c6a7051ef69f552db394ce3802b6f13c905fb3/239043911459/2021-01-16.txt#L263). These buckets hold images/logos so it was not _required_ to encrypt them but to follow the requirements and to please the CI scanning, I'm enabling encryption on these buckets.

To know more about the CI scanning #147 