### PR TITLE
feat: turn on default encryption for EBS

### DIFF
--- a/aws/eks/ebs.tf
+++ b/aws/eks/ebs.tf
@@ -1,0 +1,3 @@
+resource "aws_ebs_encryption_by_default" "notification-canada-ca" {
+  enabled = true
+}


### PR DESCRIPTION
The continuous Guardrail scanning is not happy that we have [disks that are not encrypted](https://github.com/cds-snc/continuous-guardrail-scanning/blob/master/239043911459/2021-01-16.txt#L260-L262). These disks are used by EC2 machines running on Kubernetes cluster in staging (we run 3 nodes in staging).

Turning on encryption for EBS volumes will make sure that new disks will be encrypted. This will not solve the problem for the current machines, but these nodes will be replaced when we will upgrade our Kubernetes cluster version so it'll be fixed eventually.

PR fixing other Guardrail issues: #148