### PR TITLE
feat: bind topic to eks, rds plus add slack module

### DIFF
--- a/aws/common/slack.tf
+++ b/aws/common/slack.tf
@@ -34,3 +34,20 @@ module "notify_slack_critical" {
 
   depends_on = [aws_sns_topic.notification-canada-ca-alert-critical]
 }
+
+module "notify_slack_general" {
+  source  = "terraform-aws-modules/notify-slack/aws"
+  version = "~> 4.0"
+
+  create_sns_topic = false
+  sns_topic_name   = aws_sns_topic.notification-canada-ca-alert-general.name
+
+  slack_webhook_url = var.cloudwatch_slack_webhook_general_topic
+  slack_channel     = var.slack_channel_general_topic
+  slack_username    = "[GENERAL] AWS Cloudwatch"
+  slack_emoji       = ":loudspeaker:"
+
+  lambda_function_name                   = "notify-slack-general"
+  cloudwatch_log_group_retention_in_days = 90
+
+}

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -64,6 +64,7 @@ inputs = {
   vpc_public_subnets                     = dependency.common.outputs.vpc_public_subnets
   sns_alert_warning_arn                  = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                 = dependency.common.outputs.sns_alert_critical_arn
+  sns_alert_general_arn                  = dependency.common.outputs.sns_alert_general_arn
   alb_log_bucket                         = dependency.common.outputs.alb_log_bucket
   cloudfront_assets_arn                  = dependency.cloudfront.outputs.cloudfront_assets_arn
 }

--- a/env/staging/rds/terragrunt.hcl
+++ b/env/staging/rds/terragrunt.hcl
@@ -38,6 +38,7 @@ inputs = {
   rds_instance_count        = 2
   rds_instance_type         = "db.t3.medium"
   vpc_private_subnets       = dependency.common.outputs.vpc_private_subnets
+  sns_alert_general_arn     = dependency.common.outputs.sns_alert_general_arn
 }
 
 terraform {


### PR DESCRIPTION
closes #102 
Part 2 of #145 

Includes bindings for sns topic to inputs on terragrunt and slack module integration

-----
https://trello.com/c/4e58AlOx/178-sns-warning-topic-should-only-be-used-by-alarms

* Added new topic "notification-canada-ca-alert-general"
* Re-assigned to new topic:
  * aws_health
  * rds
* Added new slack module "notify_slack_general"
  * bind to new general sns topic
  * new env vars for webhook and channel, copied values similar to existing slack integrations
