### PR TITLE
down bump production to 0.56.1

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -16,7 +16,7 @@ env:
   # Set the GitHub tag here to update the infrastructure
   # to a new version in production
   # See https://github.com/cds-snc/notification-terraform/releases
-  INFRASTRUCTURE_VERSION: '0.58.0'
+  INFRASTRUCTURE_VERSION: '0.56.1'
 
   # Terraform environment variables
   AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
DOWN bump version from 0.58.0 to 0.56.1 due to terraform order of operations for new sns topic before binding it.

-----

add new sns topic and slack integration (#145)
feat: add new sns topic "alert-general" and ready for slack integration

feat: turn on default encryption for EBS (#149)

feat: IAM config for continuous guardrail scanning (#147)

feat: IAM config for continuous guardrail scanning
Run fmt
Have some read replicas in the staging environment (#146)

test: I need some read replicas in staging to make tests on these
Update env/staging/rds/terragrunt.hcl
fix: Ignore engine version changes for AWS Elasticache Redis v6 (#143)