### PR TITLE
feat: tmp delete SNS failure critical alarm in us-west-2

### DIFF
--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -119,27 +119,6 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-cr
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-us-west-2-critical" {
-  provider = aws.us-west-2
-
-  alarm_name          = "sns-sms-success-rate-canadian-numbers-us-west-2-critical"
-  alarm_description   = "SMS success rate to Canadian numbers is below 75% over 2 consecutive periods of 12 hours"
-  comparison_operator = "LessThanThreshold"
-  evaluation_periods  = "2"
-  datapoints_to_alarm = "2"
-  metric_name         = "SMSSuccessRate"
-  namespace           = "AWS/SNS"
-  period              = 60 * 60 * 12
-  statistic           = "Average"
-  threshold           = 75 / 100
-  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical-us-west-2.arn]
-  ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical-us-west-2.arn]
-  dimensions = {
-    SMSType = "Transactional"
-    Country = "CA"
-  }
-}
-
 resource "aws_cloudwatch_metric_alarm" "ses-bounce-rate-warning" {
   alarm_name          = "ses-bounce-rate-warning"
   alarm_description   = "Bounce rate >=5% over the last 12 hours"


### PR DESCRIPTION
We risk getting paged while we have low volume in this region + we need to push a fix for SMS senders.

Disable temporarily this critical alarm in us-west-2 for the sanity of the team.

Related to https://github.com/cds-snc/notification-api/pull/1204