### PR TITLE
feat: enable more log types on EKS

### DIFF
--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -6,7 +6,7 @@ resource "aws_eks_cluster" "notification-canada-ca-eks-cluster" {
   name     = "notification-canada-ca-${var.env}-eks-cluster"
   role_arn = aws_iam_role.eks-cluster-role.arn
 
-  enabled_cluster_log_types = ["api", "audit"]
+  enabled_cluster_log_types = ["api", "audit", "controllerManager", "scheduler"]
 
   vpc_config {
     security_group_ids = [


### PR DESCRIPTION
In order to understand better why some pods receive a `TERM` signal from Kubernetes while running, we need to have logs. This PR enables additional log types for our EKS cluster.

Relevant AWS documentation: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html