### PR TITLE
feat: update how AWS provider is declared

### DIFF
--- a/aws/common/athena.tf
+++ b/aws/common/athena.tf
@@ -1,5 +1,5 @@
 ###
-# Athena deployment configuration for the Notification application
+# Athena deployment configuration for Notify
 ###
 
 resource "aws_athena_database" "notification_athena" {

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -18,23 +18,29 @@ generate "provider" {
   path      = "provider.tf"
   if_exists = "overwrite"
   contents  = <<EOF
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
 provider "aws" {
   region              = var.region
-  version             = "~> 3.0"
   allowed_account_ids = [var.account_id]
 }
 
 provider "aws" {
   alias               = "us-west-2"
   region              = "us-west-2"
-  version             = "~> 3.0"
   allowed_account_ids = [var.account_id]
 }
 
 provider "aws" {
   alias               = "us-east-1"
   region              = "us-east-1"
-  version             = "~> 3.0"
   allowed_account_ids = [var.account_id]
 }
 EOF


### PR DESCRIPTION
As part of [the Terraform upgrade](https://github.com/cds-snc/notification-terraform/pull/157#issuecomment-763047587), we need to change how providers are declared. This PR uses the new way, you can see warnings if you look at previous CI jobs about the old syntax.

Docs:
https://www.terraform.io/upgrade-guides/0-13.html#explicit-provider-source-locations
https://registry.terraform.io/providers/hashicorp/aws/latest/docs#example-usage

Example warning on https://github.com/cds-snc/notification-terraform/runs/1764494719?check_suite_focus=true
![Screen Shot 2021-01-25 at 15 45 22](https://user-images.githubusercontent.com/295709/105763970-5d143980-5f24-11eb-8c94-6a3fd97248f6.png)
