### PR TITLE
feat: route delivery receipts to different queue

### DIFF
--- a/aws/common/lambdas/ses_to_sqs_email_callbacks.py
+++ b/aws/common/lambdas/ses_to_sqs_email_callbacks.py
@@ -7,7 +7,7 @@ import uuid
 def lambda_handler(event, context):
     sqs = boto3.resource('sqs')
     queue = sqs.get_queue_by_name(
-        QueueName='eks-notification-canada-canotify-internal-tasks'
+        QueueName='eks-notification-canada-delivery-receipts'
     )
 
     for record in event["Records"]:
@@ -45,7 +45,7 @@ def lambda_handler(event, context):
                 "delivery_info": {
                     "priority": 0,
                     "exchange": "default",
-                    "routing_key": "notify-internal-tasks"
+                    "routing_key": "delivery-receipts"
                 },
                 "body_encoding": "base64",
                 "delivery_tag": str(uuid.uuid4())

--- a/aws/common/lambdas/sns_to_sqs_sms_callbacks.py
+++ b/aws/common/lambdas/sns_to_sqs_sms_callbacks.py
@@ -42,7 +42,7 @@ def to_queue(queue, message):
             "delivery_info": {
                 "priority": 0,
                 "exchange": "default",
-                "routing_key": "notify-internal-tasks"
+                "routing_key": "delivery-receipts"
             },
             "body_encoding": "base64",
             "delivery_tag": str(uuid.uuid4())
@@ -61,7 +61,7 @@ def lambda_handler(event, context):
     log_events = payload['logEvents']
 
     sqs = boto3.resource('sqs')
-    queue = sqs.get_queue_by_name(QueueName="eks-notification-canada-canotify-internal-tasks")
+    queue = sqs.get_queue_by_name(QueueName="eks-notification-canada-cadelivery-receipts")
 
     for log_event in log_events:
         print(f'LogEvent: {log_event}')


### PR DESCRIPTION
Route SES and SNS delivery receipts to a dedicated queue to not clog the Notify queue.

See the API PR for more details
https://github.com/cds-snc/notification-api/pull/1216

:warning: The API PR needs to be deployed before this one in staging and in production, otherwise no workers will pick up tasks from this queue.