### PR TITLE
feat: bump tfsec to 2.0.2 and fix violations

### DIFF
--- a/.github/workflows/terraform_static_analysis.yml
+++ b/.github/workflows/terraform_static_analysis.yml
@@ -16,6 +16,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Terraform security scan
-        uses: triat/terraform-security-scan@v1.2.2
+        uses: triat/terraform-security-scan@v2.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/aws/cloudfront/cloudfront.tf
+++ b/aws/cloudfront/cloudfront.tf
@@ -39,9 +39,11 @@ resource "aws_cloudfront_distribution" "asset_bucket" {
 
   viewer_certificate {
     acm_certificate_arn      = var.aws_acm_assets_notification_canada_ca_arn
-    minimum_protocol_version = "TLSv1.2_2018"
+    minimum_protocol_version = "TLSv1.2_2019"
     ssl_support_method       = "sni-only"
   }
+
+  web_acl_id = aws_wafv2_web_acl.assets_cdn.arn
 
   price_class = "PriceClass_100"
 

--- a/aws/cloudfront/waf.tf
+++ b/aws/cloudfront/waf.tf
@@ -1,0 +1,22 @@
+resource "aws_wafv2_web_acl" "assets_cdn" {
+  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl#scope
+  # > To work with CloudFront, you must also specify the region us-east-1 (N. Virginia) on the AWS provider.
+  provider = aws.us-east-1
+
+  name  = "assets_cdn"
+  scope = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "assets_cdn"
+    sampled_requests_enabled   = false
+  }
+}

--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -14,15 +14,16 @@ resource "aws_db_subnet_group" "notification-canada-ca" {
 }
 
 resource "aws_rds_cluster_instance" "notification-canada-ca-instances" {
-  count                        = var.rds_instance_count
-  identifier                   = "notification-canada-ca-${var.env}-instance-${count.index}"
-  cluster_identifier           = aws_rds_cluster.notification-canada-ca.id
-  instance_class               = var.rds_instance_type
-  db_subnet_group_name         = aws_db_subnet_group.notification-canada-ca.name
-  engine                       = aws_rds_cluster.notification-canada-ca.engine
-  engine_version               = aws_rds_cluster.notification-canada-ca.engine_version
-  performance_insights_enabled = true
-  preferred_maintenance_window = "wed:04:00-wed:04:30"
+  count                           = var.rds_instance_count
+  identifier                      = "notification-canada-ca-${var.env}-instance-${count.index}"
+  cluster_identifier              = aws_rds_cluster.notification-canada-ca.id
+  instance_class                  = var.rds_instance_type
+  db_subnet_group_name            = aws_db_subnet_group.notification-canada-ca.name
+  engine                          = aws_rds_cluster.notification-canada-ca.engine
+  engine_version                  = aws_rds_cluster.notification-canada-ca.engine_version
+  performance_insights_enabled    = true
+  performance_insights_kms_key_id = var.kms_arn
+  preferred_maintenance_window    = "wed:04:00-wed:04:30"
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
@@ -41,6 +42,7 @@ resource "aws_rds_cluster" "notification-canada-ca" {
   preferred_backup_window      = "07:00-09:00"
   preferred_maintenance_window = "wed:04:00-wed:04:30"
   db_subnet_group_name         = aws_db_subnet_group.notification-canada-ca.name
+  #tfsec:ignore:AWS051 - database is encrypted without a custom key and that's fine
   storage_encrypted            = true
   deletion_protection          = true
 

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -22,3 +22,7 @@ variable "vpc_private_subnets" {
 variable "sns_alert_general_arn" {
   type = string
 }
+
+variable "kms_arn" {
+  type = string
+}

--- a/env/staging/rds/terragrunt.hcl
+++ b/env/staging/rds/terragrunt.hcl
@@ -15,6 +15,7 @@ dependency "common" {
       "subnet-0af8b8402f1d605ff",
     ]
     sns_alert_general_arn = ""
+    kms_arn               = ""
   }
 }
 
@@ -39,6 +40,7 @@ inputs = {
   rds_instance_type         = "db.t3.medium"
   vpc_private_subnets       = dependency.common.outputs.vpc_private_subnets
   sns_alert_general_arn     = dependency.common.outputs.sns_alert_general_arn
+  kms_arn                   = dependency.common.outputs.kms_arn
 }
 
 terraform {


### PR DESCRIPTION
Fixes #168 

This PR updates [tfsec](https://github.com/tfsec/tfsec) to the latest version and addresses new security violations found:
- too old certificate on CloudFront
- not encrypting performance insights on RDS (requires a KMS key from `common`, added in #170)
- adding a web application firewall in front of assets served by CloudFront (does nothing at the moment but it'll be there and we could add rules)
- tfsec complained about [AWS051](https://tfsec.dev/docs/aws/AWS051/) (no encryption on RDS cluster) but it's safe to ignore as we're okay using AWS managed keys and our specific KMS key - checked with @maxneuvians 