### PR TITLE
feat: output the KMS's ARN

### DIFF
--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -33,3 +33,7 @@ output "asset_bucket_regional_domain_name" {
 output "alb_log_bucket" {
   value = aws_s3_bucket.alb_log_bucket.bucket
 }
+
+output "kms_arn" {
+  value = aws_kms_key.notification-canada-ca.arn
+}


### PR DESCRIPTION
Output the KMS' ARN in order to use this value in another PR, #169.

Outputs should be available in the Terraform state beforehand, otherwise `terraform plan` will fail when adding a dependency between modules (the variable will not exist yet and Terraform will complain).