### PR TITLE
feat: add warning alarms for delivery receipts Lambdas

### DIFF
--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -302,3 +302,35 @@ resource "aws_cloudwatch_metric_alarm" "no-emails-sent-5-minutes-critical" {
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
 }
+
+resource "aws_cloudwatch_metric_alarm" "lambda-ses-delivery-receipts-errors-warning" {
+  alarm_name          = "lambda-ses-delivery-receipts-errors-warning"
+  alarm_description   = "5 errors on Lambda ses-to-sqs-email-callbacks in 10 minutes"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Errors"
+  namespace           = "AWS/Lambda"
+  period              = 60 * 10
+  statistic           = "Sum"
+  threshold           = 5
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
+  dimensions = {
+    FunctionName = aws_lambda_function.ses_to_sqs_email_callbacks.function_name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "lambda-sns-delivery-receipts-errors-warning" {
+  alarm_name          = "lambda-sns-delivery-receipts-errors-warning"
+  alarm_description   = "5 errors on Lambda sns-to-sqs-sms-callbacks in 10 minutes"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Errors"
+  namespace           = "AWS/Lambda"
+  period              = 60 * 10
+  statistic           = "Sum"
+  threshold           = 5
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
+  dimensions = {
+    FunctionName = aws_lambda_function.sns_to_sqs_sms_callbacks.function_name
+  }
+}


### PR DESCRIPTION
I recently routed messages to a non-existing SQS queue in a Lambda https://github.com/cds-snc/notification-terraform/pull/171 and we didn't get alarms even if Lambdas were erroring. That's not helpful to debug/fix issues as they arise.

In response to that, I'm adding warning alarms for Lambdas we use for SNS and SES delivery receipts (5 errors in 10 minutes, never happened under normal operations). I don't think adding a critical alarm on this is necessary because more "feature oriented" alarms will trigger if delivery receipts are indeed not working.

![Screen Shot 2021-02-02 at 15 57 42](https://user-images.githubusercontent.com/295709/106662100-f6b89800-656f-11eb-93f0-cf0dac00e89f.png)
