### PR TITLE
fix: missing var in prod sns_alert_general_arn

### DIFF
--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -34,6 +34,7 @@ inputs = {
   vpc_public_subnets                     = dependency.common.outputs.vpc_public_subnets
   sns_alert_warning_arn                  = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                 = dependency.common.outputs.sns_alert_critical_arn
+  sns_alert_general_arn                  = dependency.common.outputs.sns_alert_general_arn
   alb_log_bucket                         = dependency.common.outputs.alb_log_bucket
   cloudfront_assets_arn                  = dependency.cloudfront.outputs.cloudfront_assets_arn
   eks_cluster_name                       = "notification-canada-ca-production-eks-cluster"

--- a/env/production/rds/terragrunt.hcl
+++ b/env/production/rds/terragrunt.hcl
@@ -23,5 +23,5 @@ inputs = {
   rds_instance_count        = 3
   rds_instance_type         = "db.t3.medium"
   vpc_private_subnets       = dependency.common.outputs.vpc_private_subnets
-  sns_alert_warning_arn     = dependency.common.outputs.sns_alert_warning_arn
+  sns_alert_general_arn     = dependency.common.outputs.sns_alert_general_arn
 }


### PR DESCRIPTION
The variable `sns_alert_general_arn` was missing in production, it was introduced in https://github.com/cds-snc/notification-terraform/pull/151 and we forgot to add this variable to the `production` environment. This PR adds this variable in EKS and RDS where it's used.

Discovered while merging #176, the [CI job failed](https://github.com/cds-snc/notification-terraform/runs/1830923793)

> Error creating RDS Event Subscription notification-canada-ca-aurora-cluster-events-subscription: InvalidParameterValue: Sns topic is required.