### PR TITLE
feat: create SES domain identity in us-east-1

### DIFF
--- a/aws/dns/ses.tf
+++ b/aws/dns/ses.tf
@@ -32,6 +32,18 @@ resource "aws_ses_domain_mail_from" "notification-canada-ca" {
   mail_from_domain = "bounce.${aws_ses_domain_identity.notification-canada-ca.domain}"
 }
 
+###
+# Receiving emails
+###
+
+resource "aws_ses_domain_identity" "notification-canada-ca-receiving" {
+  # Email receiving with SES is available in only 3 regions
+  # so we use us-east-1
+  # https://docs.aws.amazon.com/general/latest/gr/ses.html
+  provider = aws.us-east-1
+
+  domain = var.domain
+}
 
 ###
 # Additional sending domains


### PR DESCRIPTION
Toward receiving emails with SES. This PR creates a domain identity in `us-east-1`, one of the 3 AWS regions where it's possible to receive emails.

After this has been merged, we'll need to verify the domain with DNS records. Notify DNS records [are managed elsewhere](https://github.com/cds-snc/dns/blob/master/terraform/notification.canada.ca-zone.tf) so I'll submit a PR there just after, to verify our domain and the next changes required.

Trello card: https://trello.com/c/PpAuHXEM/271-replies-to-notify-should-quickly-communicate-that-they-dont-work
AWS doc: https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-getting-started.html (this is step 2)