### PR TITLE
feat: refine SQS permissions for Lambdas

### DIFF
--- a/aws/common/iam.tf
+++ b/aws/common/iam.tf
@@ -111,7 +111,8 @@ resource "aws_iam_policy" "lambda_sqs_send" {
     "Statement": [
         {
             "Action": [
-                "sqs:*"
+                "sqs:Get*",
+                "sqs:SendMessage"
             ],
             "Effect": "Allow",
             "Resource": "*"


### PR DESCRIPTION
SQS permissions are too broad for [Lambdas](https://github.com/cds-snc/notification-terraform/tree/main/aws/common/lambdas) at the moment. They only need to:
- get a queue URL
- publish messages

Following the least privilege principle, I'm allowing `Get*` and `PublishMessage`.

More about SQS permissions: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-api-permissions-reference.html