### PR TITLE
feat: add base Lambda for ses_receiving_emails

### DIFF
--- a/aws/common/cloudwatch_log.tf
+++ b/aws/common/cloudwatch_log.tf
@@ -15,7 +15,7 @@ resource "aws_cloudwatch_log_group" "sns_deliveries_failures" {
 }
 
 resource "aws_cloudwatch_log_group" "ses_receiving_emails" {
-  name = "/aws/lambda/${aws_lambda_function.ses_receiving_emails.function_name}"
+  name = "/aws/lambda/${var.lambda_ses_receiving_emails_name}"
 
   retention_in_days = 90
 

--- a/aws/common/cloudwatch_log.tf
+++ b/aws/common/cloudwatch_log.tf
@@ -14,6 +14,16 @@ resource "aws_cloudwatch_log_group" "sns_deliveries_failures" {
   }
 }
 
+resource "aws_cloudwatch_log_group" "ses_receiving_emails" {
+  name = "/aws/lambda/${aws_lambda_function.ses_receiving_emails.function_name}"
+
+  retention_in_days = 90
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}
+
 resource "aws_cloudwatch_log_group" "sns_deliveries_us_west_2" {
   provider = aws.us-west-2
 

--- a/aws/common/lambda.tf
+++ b/aws/common/lambda.tf
@@ -48,7 +48,7 @@ data "archive_file" "ses_receiving_emails" {
 
 resource "aws_lambda_function" "ses_receiving_emails" {
   filename      = data.archive_file.ses_receiving_emails.output_path
-  function_name = "ses-receiving-emails"
+  function_name = var.lambda_ses_receiving_emails_name
   role          = aws_iam_role.iam_lambda_to_sqs.arn
   handler       = "ses_receiving_emails.lambda_handler"
 

--- a/aws/common/lambda.tf
+++ b/aws/common/lambda.tf
@@ -62,6 +62,8 @@ resource "aws_lambda_function" "ses_receiving_emails" {
     }
   }
 
+  depends_on = [aws_cloudwatch_log_group.ses_receiving_emails]
+
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
   }

--- a/aws/common/lambda.tf
+++ b/aws/common/lambda.tf
@@ -40,6 +40,33 @@ resource "aws_lambda_function" "sns_to_sqs_sms_callbacks" {
   }
 }
 
+data "archive_file" "ses_receiving_emails" {
+  type        = "zip"
+  source_file = "${path.module}/lambdas/ses_receiving_emails.py"
+  output_path = "${path.module}/lambdas/ses_receiving_emails.zip"
+}
+
+resource "aws_lambda_function" "ses_receiving_emails" {
+  filename      = data.archive_file.ses_receiving_emails.output_path
+  function_name = "ses-receiving-emails"
+  role          = aws_iam_role.iam_lambda_to_sqs.arn
+  handler       = "ses_receiving_emails.lambda_handler"
+
+  source_code_hash = data.archive_file.ses_receiving_emails.output_base64sha256
+
+  runtime = "python3.8"
+
+  environment {
+    variables = {
+      NOTIFY_SENDING_DOMAIN = var.domain
+    }
+  }
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}
+
 ##
 # CloudWatch log groups for SNS deliveries in ca-central-1
 ##
@@ -99,4 +126,17 @@ resource "aws_lambda_permission" "sns_critical_us_west_2_to_slack_lambda" {
   function_name = module.notify_slack_critical.notify_slack_lambda_function_arn
   principal     = "sns.amazonaws.com"
   source_arn    = aws_sns_topic.notification-canada-ca-alert-critical-us-west-2.arn
+}
+
+##
+# SES in us-east-1 for handling incoming emails
+##
+resource "aws_lambda_permission" "ses_receiving_emails" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.ses_receiving_emails.function_name
+  # tfsec:ignore:AWS058 Ensure that lambda function permission has a source arn specified
+  # The `principal` is our own AWS account ID so it's fine to not specify `source_arn`.
+  # We do not specify `source_arn` because SES is in another module, with a dependency
+  # already on this module, this would create a circular dependency.
+  principal = var.account_id
 }

--- a/aws/common/lambdas/ses_receiving_emails.py
+++ b/aws/common/lambdas/ses_receiving_emails.py
@@ -1,0 +1,59 @@
+import os
+import re
+
+from email.utils import parseaddr
+
+
+def parse_recipients(headers):
+    SENDING_DOMAIN = os.environ['NOTIFY_SENDING_DOMAIN']
+
+    # Gather recipients from our own domain only
+    recipients = headers.get("to", []) + headers.get("cc", []) + headers.get("bcc", [])
+    recipients = [parseaddr(r)[1] for r in recipients]
+
+    return [r for r in recipients if r.endswith(f"@{SENDING_DOMAIN}")]
+
+
+def lambda_handler(event, context):
+    # See the payload documentation
+    # https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-lambda-event.html
+    # https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-notifications-contents.html
+    for record in event["Records"]:
+        payload = record["ses"]
+        spam_verdict = payload["receipt"]["spamVerdict"]
+        virus_verdict = payload["receipt"]["virusVerdict"]
+
+        # Check for potential spam or virus and do not reply
+        if spam_verdict == "FAIL" or virus_verdict == "FAIL":
+            return {'statusCode': 200}
+
+        # Get the sender
+        source = payload["mail"]["source"]
+        parsed = parseaddr(source)[1]
+        if parsed == '':
+            print(f"Error: could not parse source {source}")
+        source = parsed
+
+        # Get the subject
+        subject = payload["mail"]["commonHeaders"]["subject"]
+
+        # Get the optional messageId (UUID v4) they replied to
+        messageId = None
+        matches = re.search(
+            r"([0-9a-f]{8}\-[0-9a-f]{4}\-4[0-9a-f]{3}\-[89ab][0-9a-f]{3}\-[0-9a-f]{12})",
+            payload["mail"]["commonHeaders"]["messageId"],
+            re.IGNORECASE
+        )
+        if matches:
+            messageId = matches.groups()[0]
+
+        recipients = parse_recipients(payload["mail"]["commonHeaders"])
+
+        print(f"Full payload {payload}")
+        print(
+            f"Received email addressed to {recipients} from {source} with subject {subject} in reply to {messageId}"
+        )
+
+    return {
+        'statusCode': 200,
+    }

--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -37,3 +37,7 @@ output "alb_log_bucket" {
 output "kms_arn" {
   value = aws_kms_key.notification-canada-ca.arn
 }
+
+output "lambda_ses_receiving_emails_arn" {
+  value = aws_lambda_function.ses_receiving_emails.arn
+}

--- a/aws/common/variables.tf
+++ b/aws/common/variables.tf
@@ -33,3 +33,8 @@ variable "sns_monthly_spend_limit" {
 variable "sns_monthly_spend_limit_us_west_2" {
   type = number
 }
+
+variable "lambda_ses_receiving_emails_name" {
+  type    = string
+  default = "ses-receiving-emails"
+}


### PR DESCRIPTION
Follow up of https://github.com/cds-snc/notification-terraform/pull/178.

This PR is about creating a base Lambda, to handle SES incoming emails events after. We need to ship this first part now because we'll need to plug the Lambda ARN on SES, part of the `dns` module.

The next steps will be to:
- write a `ses_receipt_rule` to link SES to this Lambda https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_receipt_rule
- rework the Lambda function to post messages to a SQS queue that will trigger a Celery task on the API