### PR TITLE
fix: move SES inbound Lambda and log group to us-east-1

### DIFF
--- a/aws/common/cloudwatch_log.tf
+++ b/aws/common/cloudwatch_log.tf
@@ -15,6 +15,8 @@ resource "aws_cloudwatch_log_group" "sns_deliveries_failures" {
 }
 
 resource "aws_cloudwatch_log_group" "ses_receiving_emails" {
+  provider = aws.us-east-1
+
   name = "/aws/lambda/${var.lambda_ses_receiving_emails_name}"
 
   retention_in_days = 90

--- a/aws/common/lambda.tf
+++ b/aws/common/lambda.tf
@@ -47,6 +47,11 @@ data "archive_file" "ses_receiving_emails" {
 }
 
 resource "aws_lambda_function" "ses_receiving_emails" {
+  # https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html#region-receive-email
+  # With the exception of Amazon S3 buckets, all of the AWS resources that you use for
+  # receiving email with Amazon SES have to be in the same AWS Region as the Amazon SES endpoint.
+  provider = aws.us-east-1
+
   filename      = data.archive_file.ses_receiving_emails.output_path
   function_name = var.lambda_ses_receiving_emails_name
   role          = aws_iam_role.iam_lambda_to_sqs.arn


### PR DESCRIPTION
Follow up of https://github.com/cds-snc/notification-terraform/pull/180

The [original documentation](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-lambda.html) did not talk about the requirement for the Lambda function to be in the same region.

This [other page](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html#region-receive-email) is clear about it though

> With the exception of Amazon S3 buckets, all of the AWS resources that you use for receiving email with Amazon SES have to be in the same AWS Region as the Amazon SES endpoint.

This PR moves the Lambda function and its log group to the same region than SES inbound email, `us-east-1`.

I've opened an AWS case to update the documentation (Case 7973098751 in the staging account)