### PR TITLE
Bump production to 0.68.1

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -16,7 +16,7 @@ env:
   # Set the GitHub tag here to update the infrastructure
   # to a new version in production
   # See https://github.com/cds-snc/notification-terraform/releases
-  INFRASTRUCTURE_VERSION: '0.66.0'
+  INFRASTRUCTURE_VERSION: '0.68.1'
 
   # Terraform environment variables
   AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Release
https://github.com/cds-snc/notification-terraform/pull/178
https://github.com/cds-snc/notification-terraform/pull/180
https://github.com/cds-snc/notification-terraform/pull/181

to production.

This is a good waypoint because after merging this in production we'll need add DNS records to verify the domain in `us-east-1` and we will have a new output for the Lambda ARN.