### PR TITLE
feat: SES receipt rule subscribe to Lambda

### DIFF
--- a/aws/dns/ses.tf
+++ b/aws/dns/ses.tf
@@ -45,6 +45,28 @@ resource "aws_ses_domain_identity" "notification-canada-ca-receiving" {
   domain = var.domain
 }
 
+resource "aws_ses_receipt_rule_set" "main" {
+  provider = aws.us-east-1
+
+  rule_set_name = "main"
+}
+
+resource "aws_ses_receipt_rule" "inbound-to-lambda" {
+  provider = aws.us-east-1
+
+  name          = "inbound-to-lambda"
+  rule_set_name = aws_ses_receipt_rule_set.main.rule_set_name
+  recipients    = [var.domain]
+  enabled       = true
+  scan_enabled  = true
+
+  lambda_action {
+    function_arn    = var.lambda_ses_receiving_emails_arn
+    invocation_type = "Event"
+    position        = 1
+  }
+}
+
 ###
 # Additional sending domains
 ###

--- a/aws/dns/variables.tf
+++ b/aws/dns/variables.tf
@@ -1,3 +1,7 @@
 variable "notification_canada_ca_ses_callback_arn" {
   type = string
 }
+
+variable "lambda_ses_receiving_emails_arn" {
+  type = string
+}

--- a/env/staging/dns/terragrunt.hcl
+++ b/env/staging/dns/terragrunt.hcl
@@ -10,6 +10,7 @@ dependency "common" {
   mock_outputs_allowed_terraform_commands = ["validate"]
   mock_outputs = {
     notification_canada_ca_ses_callback_arn = ""
+    lambda_ses_receiving_emails_arn         = ""
   }
 }
 
@@ -19,6 +20,7 @@ include {
 
 inputs = {
   notification_canada_ca_ses_callback_arn = dependency.common.outputs.notification_canada_ca_ses_callback_arn
+  lambda_ses_receiving_emails_arn         = dependency.common.outputs.lambda_ses_receiving_emails_arn
 }
 
 terraform {


### PR DESCRIPTION
Follow up of https://github.com/cds-snc/notification-terraform/pull/180 and the fix in https://github.com/cds-snc/notification-terraform/pull/181

This PR is in charge of hooking SES to the previously created Lambda function, through a receipt rule.

Receipt rules have filters based on recipients (we handle all domains coming to our domain) and multiple actions. The only action we are interested in is handling the payload with a Lambda.