### PR TITLE
fix: apply Lambda permission for SES in us-east-1

### DIFF
--- a/aws/common/lambda.tf
+++ b/aws/common/lambda.tf
@@ -139,6 +139,8 @@ resource "aws_lambda_permission" "sns_critical_us_west_2_to_slack_lambda" {
 # SES in us-east-1 for handling incoming emails
 ##
 resource "aws_lambda_permission" "ses_receiving_emails" {
+  provider = aws.us-east-1
+
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.ses_receiving_emails.function_name
   # tfsec:ignore:AWS058 Ensure that lambda function permission has a source arn specified


### PR DESCRIPTION
You know what was missing from https://github.com/cds-snc/notification-terraform/pull/181?

Moving the `aws_lambda_permission` to `us-east-1` as well. This PR does just that.

Discovered when [production CI failed](https://github.com/cds-snc/notification-terraform/runs/1864632580?check_suite_focus=true), it was looking at the Lambda function in the wrong region.