### PR TITLE
fix: appropriate Lambda permission for SES

### DIFF
--- a/aws/common/lambda.tf
+++ b/aws/common/lambda.tf
@@ -144,5 +144,7 @@ resource "aws_lambda_permission" "ses_receiving_emails" {
   action         = "lambda:InvokeFunction"
   function_name  = aws_lambda_function.ses_receiving_emails.function_name
   principal      = "ses.amazonaws.com"
+  # tfsec:ignore:AWS058 Ensure that lambda function permission has a source arn specified
+  # can ignore this because we specify `source_account` instead of `source_arn`
   source_account = var.account_id
 }

--- a/aws/common/lambda.tf
+++ b/aws/common/lambda.tf
@@ -141,11 +141,8 @@ resource "aws_lambda_permission" "sns_critical_us_west_2_to_slack_lambda" {
 resource "aws_lambda_permission" "ses_receiving_emails" {
   provider = aws.us-east-1
 
-  action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.ses_receiving_emails.function_name
-  # tfsec:ignore:AWS058 Ensure that lambda function permission has a source arn specified
-  # The `principal` is our own AWS account ID so it's fine to not specify `source_arn`.
-  # We do not specify `source_arn` because SES is in another module, with a dependency
-  # already on this module, this would create a circular dependency.
-  principal = var.account_id
+  action         = "lambda:InvokeFunction"
+  function_name  = aws_lambda_function.ses_receiving_emails.function_name
+  principal      = "ses.amazonaws.com"
+  source_account = var.account_id
 }


### PR DESCRIPTION
SES was not allowed to invoke the Lambda function, this PR fixes it.

Turns out that `source_account` is a special parameter used by S3 and SES.
> This parameter is used for S3 and SES. The AWS account ID (without a hyphen) of the source owner

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission#source_account

The [SES documentation](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html#receiving-email-permissions-lambda) confirms that the expected payload is

```json
{
  "Action": "lambda:InvokeFunction",
  "Principal": "ses.amazonaws.com",
  "SourceAccount": "111122223333",
  "StatementId": "GiveSESPermissionToInvokeFunction"
}
```