### PR TITLE
feat: dispatch messages to SQS from SES inbound Lambda

### DIFF
--- a/aws/common/lambda.tf
+++ b/aws/common/lambda.tf
@@ -63,7 +63,9 @@ resource "aws_lambda_function" "ses_receiving_emails" {
 
   environment {
     variables = {
+      CELERY_QUEUE_PREFIX   = var.celery_queue_prefix
       NOTIFY_SENDING_DOMAIN = var.domain
+      SQS_REGION            = var.region
     }
   }
 
@@ -141,9 +143,9 @@ resource "aws_lambda_permission" "sns_critical_us_west_2_to_slack_lambda" {
 resource "aws_lambda_permission" "ses_receiving_emails" {
   provider = aws.us-east-1
 
-  action         = "lambda:InvokeFunction"
-  function_name  = aws_lambda_function.ses_receiving_emails.function_name
-  principal      = "ses.amazonaws.com"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.ses_receiving_emails.function_name
+  principal     = "ses.amazonaws.com"
   # tfsec:ignore:AWS058 Ensure that lambda function permission has a source arn specified
   # can ignore this because we specify `source_account` instead of `source_arn`
   source_account = var.account_id

--- a/aws/common/lambdas/ses_receiving_emails.py
+++ b/aws/common/lambdas/ses_receiving_emails.py
@@ -84,7 +84,8 @@ def lambda_handler(event, context):
         sender = payload["mail"]["source"]
         parsed = parseaddr(sender)[1]
         if parsed == '':
-            print(f"Error: could not parse sender {sender}")
+            print(f"Error: could not parse sender {sender}. Stopping.")
+            return {'statusCode': 200}
         sender = parsed
 
         # Get the subject

--- a/aws/common/lambdas/ses_receiving_emails.py
+++ b/aws/common/lambdas/ses_receiving_emails.py
@@ -1,12 +1,62 @@
+import json
+import base64
+import boto3
+import uuid
 import os
 import re
-
 from email.utils import parseaddr
+
+SENDING_DOMAIN = os.environ['NOTIFY_SENDING_DOMAIN']
+SQS_REGION = os.environ['SQS_REGION']
+CELERY_QUEUE_PREFIX = os.environ['SQS_REGION']
+CELERY_QUEUE = 'notify-internal-tasks'
+CELERY_TASK_NAME = 'send-notify-no-reply'
+
+
+def to_queue(queue, data):
+    task = {
+        "task": CELERY_TASK_NAME,
+        "id": str(uuid.uuid4()),
+        "args": [json.dumps(data)],
+        "kwargs": {},
+        "retries": 0,
+        "eta": None,
+        "expires": None,
+        "utc": True,
+        "callbacks": None,
+        "errbacks": None,
+        "timelimit": [
+            None,
+            None
+        ],
+        "taskset": None,
+        "chord": None
+    }
+    print(f'Sending task {task}')
+
+    envelope = {
+        "body": base64.b64encode(bytes(json.dumps(task), 'utf-8')).decode("utf-8"),
+        "content-encoding": "utf-8",
+        "content-type": "application/json",
+        "headers": {},
+        "properties": {
+            "reply_to": str(uuid.uuid4()),
+            "correlation_id": str(uuid.uuid4()),
+            "delivery_mode": 2,
+            "delivery_info": {
+                "priority": 0,
+                "exchange": "default",
+                "routing_key": CELERY_QUEUE,
+            },
+            "body_encoding": "base64",
+            "delivery_tag": str(uuid.uuid4())
+        }
+    }
+    msg = base64.b64encode(bytes(json.dumps(envelope), 'utf-8')).decode("utf-8")
+    queue.send_message(MessageBody=msg)
 
 
 def parse_recipients(headers):
-    SENDING_DOMAIN = os.environ['NOTIFY_SENDING_DOMAIN']
-
     # Gather recipients from our own domain only
     recipients = headers.get("to", []) + headers.get("cc", []) + headers.get("bcc", [])
     recipients = [parseaddr(r)[1] for r in recipients]
@@ -15,6 +65,9 @@ def parse_recipients(headers):
 
 
 def lambda_handler(event, context):
+    sqs = boto3.resource('sqs', region_name=SQS_REGION)
+    queue = sqs.get_queue_by_name(QueueName=f"{CELERY_QUEUE_PREFIX}{CELERY_QUEUE}")
+
     # See the payload documentation
     # https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-lambda-event.html
     # https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-notifications-contents.html
@@ -28,11 +81,11 @@ def lambda_handler(event, context):
             return {'statusCode': 200}
 
         # Get the sender
-        source = payload["mail"]["source"]
-        parsed = parseaddr(source)[1]
+        sender = payload["mail"]["source"]
+        parsed = parseaddr(sender)[1]
         if parsed == '':
-            print(f"Error: could not parse source {source}")
-        source = parsed
+            print(f"Error: could not parse sender {sender}")
+        sender = parsed
 
         # Get the subject
         subject = payload["mail"]["commonHeaders"]["subject"]
@@ -51,8 +104,15 @@ def lambda_handler(event, context):
 
         print(f"Full payload {payload}")
         print(
-            f"Received email addressed to {recipients} from {source} with subject {subject} in reply to {messageId}"
+            f"Received email addressed to {recipients} from {sender} with subject {subject} in reply to {messageId}"
         )
+
+        to_queue(queue, {
+            'messageId': messageId,
+            'recipients': recipients,
+            'sender': sender,
+            'subject': subject,
+        })
 
     return {
         'statusCode': 200,

--- a/aws/common/variables.tf
+++ b/aws/common/variables.tf
@@ -38,3 +38,10 @@ variable "lambda_ses_receiving_emails_name" {
   type    = string
   default = "ses-receiving-emails"
 }
+
+variable "celery_queue_prefix" {
+  type = string
+  # Matches the env NOTIFICATION_QUEUE_PREFIX
+  # in https://github.com/cds-snc/notification-manifests/blob/main/base/api-deployment.yaml
+  default = "eks-notification-canada-ca"
+}


### PR DESCRIPTION
Update the SES inbound Lambda to dispatch a message to SQS to trigger the Celery task introduced in https://github.com/cds-snc/notification-api/pull/1233

Still related to this [Trello card](https://trello.com/c/PpAuHXEM/271-replies-to-notify-should-quickly-communicate-that-they-dont-work) and PRs starting with #178