### PR TITLE
fix: wrong copy/paste for CELERY_QUEUE_PREFIX

### DIFF
--- a/aws/common/lambdas/ses_receiving_emails.py
+++ b/aws/common/lambdas/ses_receiving_emails.py
@@ -8,7 +8,7 @@ from email.utils import parseaddr
 
 SENDING_DOMAIN = os.environ['NOTIFY_SENDING_DOMAIN']
 SQS_REGION = os.environ['SQS_REGION']
-CELERY_QUEUE_PREFIX = os.environ['SQS_REGION']
+CELERY_QUEUE_PREFIX = os.environ['CELERY_QUEUE_PREFIX']
 CELERY_QUEUE = 'notify-internal-tasks'
 CELERY_TASK_NAME = 'send-notify-no-reply'
 


### PR DESCRIPTION
Reworks https://github.com/cds-snc/notification-terraform/pull/188

I'm very sorry for making a stupid mistake like this. That's what you get for doing "one last final refactor" before submitting your PR.

I've confirmed in staging that this change is enough to fix things.