### PR TITLE
fix: add lambda_ses_receiving_emails_arn in production

### DIFF
--- a/env/production/dns/terragrunt.hcl
+++ b/env/production/dns/terragrunt.hcl
@@ -17,4 +17,5 @@ include {
 
 inputs = {
   notification_canada_ca_ses_callback_arn = dependency.common.outputs.notification_canada_ca_ses_callback_arn
+  lambda_ses_receiving_emails_arn         = dependency.common.outputs.lambda_ses_receiving_emails_arn
 }


### PR DESCRIPTION
Fixes #190

[CI job failed](https://github.com/cds-snc/notification-terraform/runs/1880365146?check_suite_focus=true) because I forgot to map the output in production like we did [in staging](https://github.com/cds-snc/notification-terraform/blob/main/env/staging/dns/terragrunt.hcl).

A version bump is not necessary, the Terraform code is fine, only production envs/variable need to be fixed.