### PR TITLE
feat: prevent auto reply loops with inbound emails

### DIFF
--- a/aws/common/lambda.tf
+++ b/aws/common/lambda.tf
@@ -63,9 +63,10 @@ resource "aws_lambda_function" "ses_receiving_emails" {
 
   environment {
     variables = {
-      CELERY_QUEUE_PREFIX   = var.celery_queue_prefix
-      NOTIFY_SENDING_DOMAIN = var.domain
-      SQS_REGION            = var.region
+      CELERY_QUEUE_PREFIX     = var.celery_queue_prefix
+      NOTIFY_SENDING_DOMAIN   = var.domain
+      SQS_REGION              = var.region
+      GC_NOTIFY_SERVICE_EMAIL = "gc.notify.gc.notification@${var.domain}"
     }
   }
 


### PR DESCRIPTION
Preventing "out of office/auto-reply loops" with the Notify auto-reply feature.

Some recipients reply to the Notify default auto-reply to the sender address and not the return path. Since the sender address is still a @notification.canada.ca, this email goes again through the same process. On and on. This is because we + the recipient implement poorly a defense mechanism to prevent this.

After looking at probematic payloads, we should be identify those in multiple ways:
1. the recipient is the GC Notify service `gc.notify.gc.notification@notification.canada.ca` in production
1. a `Precedence` header is set. This is not a real email standard but it seems used to identify automated responses/bulk emails
1. the subject contains specific words like "auto-reply"/"out of office" and the like

The PR relies on the `Precedence` header but we should look at other measures to prevent this in the future.