### PR TITLE
feat: set up default security group

### DIFF
--- a/aws/common/vpc.tf
+++ b/aws/common/vpc.tf
@@ -17,6 +17,14 @@ resource "aws_vpc" "notification-canada-ca" {
 }
 
 ###
+# AWS default security group
+###
+
+resource "aws_default_security_group" "default" {
+  vpc_id = aws_vpc.notification-canada-ca.id
+}
+
+###
 # AWS Internet Gateway
 ###
 


### PR DESCRIPTION
Adresses https://github.com/cds-snc/site-reliability-engineering-internal/issues/104

> Ensure the default security group of every VPC restricts all traffic

Similar than https://github.com/cds-snc/covid-alert-server-staging-terraform/pull/136