### PR TITLE
feat: do not connect to DB for admin/API liveness probes

### DIFF
--- a/aws/eks/alb.tf
+++ b/aws/eks/alb.tf
@@ -181,7 +181,7 @@ resource "aws_alb_target_group" "notification-canada-ca-api" {
   protocol = "HTTP"
   vpc_id   = var.vpc_id
   health_check {
-    path    = "/_status"
+    path    = "/_status?simple=true"
     matcher = "200"
   }
 }
@@ -237,7 +237,7 @@ resource "aws_alb_target_group" "notification-canada-ca-admin" {
   protocol = "HTTP"
   vpc_id   = var.vpc_id
   health_check {
-    path    = "/_status"
+    path    = "/_status?simple=true"
     matcher = "200"
   }
 }


### PR DESCRIPTION
Do not do database connection checks on health check endpoints used by `livenessProbes` on admin and API pods. The probe should be responsible for assessing if a single pod is healthy, a slow database connection will make the entire service appear to be unhealthy and will create a cascading failure (all API pods and then all admin pods).

We can pass a `simple` query param to admin and API services to skip the database connection https://github.com/cds-snc/notification-api/blob/10df7c236d431f6653c3a9e1990f93cfc4cdc6aa/app/status/healthcheck.py#L16-L19

Demo:
- https://notification.canada.ca/_status?simple=true
- https://api.notification.canada.ca/_status?simple=true

Trello card: https://trello.com/c/yCDSXWsm/305-do-not-connect-to-db-on-liveness-probes

Similar to https://github.com/cds-snc/notification-manifests/pull/252