### PR TITLE
Bump tfsec scan to 2.1.0

### DIFF
--- a/.github/workflows/terraform_static_analysis.yml
+++ b/.github/workflows/terraform_static_analysis.yml
@@ -16,8 +16,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Terraform security scan
-        uses: triat/terraform-security-scan@v2.0.2
-        with:
-          tfsec_version: 'v0.37.1'
+        uses: triat/terraform-security-scan@v2.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
And also stop pinning down the tfsec version, it was a temporary fix made in https://github.com/cds-snc/notification-terraform/pull/172#issuecomment-772781752 when a tfsec release was broken for a short wile