### PR TITLE
fix: enable private access on EKS cluster

### DIFF
--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -14,8 +14,9 @@ resource "aws_eks_cluster" "notification-canada-ca-eks-cluster" {
     security_group_ids = [
       aws_security_group.notification-canada-ca-worker.id
     ]
-    subnet_ids             = var.vpc_private_subnets
-    endpoint_public_access = false
+    subnet_ids              = var.vpc_private_subnets
+    endpoint_private_access = true
+    endpoint_public_access  = false
   }
 
   # tfsec:ignore:AWS066 EKS should have the encryption of secrets enabled


### PR DESCRIPTION
Follow up of #201, CI failed when applying

> Both private and public endpoint access cannot be false

Turned on private access, following the documentation https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster#vpc_config

Was confused because I followed the "secure example" on [tfsec documentation](https://tfsec.dev/docs/aws/AWS069/) and this failed.