### PR TITLE
fix: revert EKS private access only

### DIFF
--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -14,9 +14,10 @@ resource "aws_eks_cluster" "notification-canada-ca-eks-cluster" {
     security_group_ids = [
       aws_security_group.notification-canada-ca-worker.id
     ]
-    subnet_ids              = var.vpc_private_subnets
-    endpoint_private_access = true
-    endpoint_public_access  = false
+    subnet_ids = var.vpc_private_subnets
+    # tfsec:ignore:AWS069 EKS Clusters should have the public access disabled
+    # Cannot connect with kubectl if we do this atm, will tackle later
+    # https://github.com/cds-snc/notification-terraform/issues/205
   }
 
   # tfsec:ignore:AWS066 EKS should have the encryption of secrets enabled


### PR DESCRIPTION
Reverts changes introduced in #201 and #204. Logged an issue to tackle this later #205