### PR TITLE
feat: don't reply to no-reply senders with SES inbound

### DIFF
--- a/aws/common/lambdas/ses_receiving_emails.py
+++ b/aws/common/lambdas/ses_receiving_emails.py
@@ -69,6 +69,10 @@ def notify_service_in_recipients(recipients):
     return GC_NOTIFY_SERVICE_EMAIL in recipients
 
 
+def no_reply_in_recipients(recipients):
+    return any([email.startswith('no-reply@') for email in recipients])
+
+
 def lambda_handler(event, context):
     sqs = boto3.resource('sqs', region_name=SQS_REGION)
     queue = sqs.get_queue_by_name(QueueName=f"{CELERY_QUEUE_PREFIX}{CELERY_QUEUE}")
@@ -123,6 +127,10 @@ def lambda_handler(event, context):
         # Prevent an auto-reply loop.
         if notify_service_in_recipients(recipients):
             print("Not replying because recipients contain the GC Notify service. Stopping.")
+            return {'statusCode': 200}
+
+        if no_reply_in_recipients(recipients):
+            print("Not replying because recipients contain a no-reply email address. Stopping.")
             return {'statusCode': 200}
 
         print(


### PR DESCRIPTION
After looking at [some production data](https://notification.canada.ca/services/d6aa2c68-a2d9-4437-ab19-3ae8eb202553/notifications/email), it seems we currently reply often to no-reply email addresses that are not needed. The most common one by far is `no-reply@amazonses.com`, this happens when [one of our automated services](https://notification.canada.ca/services/e609f6b0-0390-45b0-aaae-f4cc92c713e4/notifications/email) sending emails to `ooto@simulator.amazonses.com`, which [responds with an out of office email](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-simulator.html#send-email-simulator-how-to-use).

Add a tiny check to ensure that we don't send no-reply emails to recipients if there is a no-reply email address in the recipients' list (95% of the time it's only a single item in this list).

![Screen Shot 2021-03-01 at 09 26 48](https://user-images.githubusercontent.com/295709/109510641-435c9980-7a70-11eb-8ff0-1be7dbb19f9c.png)
![Screen Shot 2021-03-01 at 09 25 15](https://user-images.githubusercontent.com/295709/109510558-29bb5200-7a70-11eb-8c0f-299538e235d0.png)
