### PR TITLE
fix: don't reply to no-reply senders

### DIFF
--- a/aws/common/lambdas/ses_receiving_emails.py
+++ b/aws/common/lambdas/ses_receiving_emails.py
@@ -69,10 +69,6 @@ def notify_service_in_recipients(recipients):
     return GC_NOTIFY_SERVICE_EMAIL in recipients
 
 
-def no_reply_in_recipients(recipients):
-    return any([email.startswith('no-reply@') for email in recipients])
-
-
 def lambda_handler(event, context):
     sqs = boto3.resource('sqs', region_name=SQS_REGION)
     queue = sqs.get_queue_by_name(QueueName=f"{CELERY_QUEUE_PREFIX}{CELERY_QUEUE}")
@@ -129,8 +125,8 @@ def lambda_handler(event, context):
             print("Not replying because recipients contain the GC Notify service. Stopping.")
             return {'statusCode': 200}
 
-        if no_reply_in_recipients(recipients):
-            print("Not replying because recipients contain a no-reply email address. Stopping.")
+        if sender.startswith('no-reply@'):
+            print("Not replying because sender is a no-reply email address. Stopping.")
             return {'statusCode': 200}
 
         print(


### PR DESCRIPTION
I'm sorry, I got mixed up between `sender` and `recipients` in https://github.com/cds-snc/notification-terraform/pull/207

- `sender`: the sender, the person who's sending the email we're receiving and handling the payload with our Lambda. This is a string.
- `recipients`: us, at least one email address will end with `@notification.canada.ca` but we could see other recipients in To/Cc/Bcc. This is a list of strings.


Got reminded of this difference after looking at log messages like
> Received email addressed to ['get.updates.on.covid19@notification.canada.ca'] from no-reply@amazonses.com with subject Email Feedback Report (Complaint) in reply to 641db7e4-954d-4a34-aab9-dc727e7850e5

https://github.com/cds-snc/notification-terraform/blob/19e68b6bff9a5fe6a3e89221023af96f96ba024a/aws/common/lambdas/ses_receiving_emails.py#L136-L138