### PR TITLE
feat: create SES custom sending domains easily

### DIFF
--- a/aws/dns/ses.tf
+++ b/aws/dns/ses.tf
@@ -74,7 +74,14 @@ resource "aws_ses_receipt_rule" "inbound-to-lambda" {
 }
 
 ###
-# Additional sending domains
+# Additional custom sending domains for emails
+# trvapply-vrtdemande.apps.cic.gc.ca is alone for historic reasons
+# and is not refactored to make sure the ressource is not destroyed/recreated.
+# Read the section "Refactoring Can Be Tricky"
+# https://blog.gruntwork.io/terraform-tips-tricks-loops-if-statements-and-gotchas-f739bbae55f9
+#
+# Afterwards there is a more automated way, using the list variable
+# `custom_sending_domains`.
 ###
 
 resource "aws_ses_domain_identity" "cic-trvapply-vrtdemande" {
@@ -111,3 +118,42 @@ resource "aws_ses_identity_notification_topic" "cic-trvapply-vrtdemande-complain
   include_original_headers = false
 }
 
+resource "aws_ses_domain_identity" "custom_sending_domains" {
+  for_each = var.custom_sending_domains
+  domain   = each.value
+}
+
+resource "aws_ses_domain_dkim" "custom_sending_domains" {
+  for_each = var.custom_sending_domains
+  domain   = each.value
+}
+
+resource "aws_ses_identity_notification_topic" "custom_sending_domains_bounce_topic" {
+  for_each                 = var.custom_sending_domains
+  topic_arn                = var.notification_canada_ca_ses_callback_arn
+  notification_type        = "Bounce"
+  identity                 = aws_ses_domain_identity.custom_sending_domains[each.value].domain
+  include_original_headers = false
+}
+
+resource "aws_ses_identity_notification_topic" "custom_sending_domains_delivery_topic" {
+  for_each                 = var.custom_sending_domains
+  topic_arn                = var.notification_canada_ca_ses_callback_arn
+  notification_type        = "Delivery"
+  identity                 = aws_ses_domain_identity.custom_sending_domains[each.value].domain
+  include_original_headers = false
+}
+
+resource "aws_ses_identity_notification_topic" "custom_sending_domains_complaint_topic" {
+  for_each                 = var.custom_sending_domains
+  topic_arn                = var.notification_canada_ca_ses_callback_arn
+  notification_type        = "Complaint"
+  identity                 = aws_ses_domain_identity.custom_sending_domains[each.value].domain
+  include_original_headers = false
+}
+
+resource "aws_ses_domain_mail_from" "custom_sending_domains" {
+  for_each         = var.custom_sending_domains
+  domain           = aws_ses_domain_identity.custom_sending_domains[each.value].domain
+  mail_from_domain = "bounce.${aws_ses_domain_identity.custom_sending_domains[each.value].domain}"
+}

--- a/aws/dns/ses.tf
+++ b/aws/dns/ses.tf
@@ -81,7 +81,7 @@ resource "aws_ses_receipt_rule" "inbound-to-lambda" {
 # https://blog.gruntwork.io/terraform-tips-tricks-loops-if-statements-and-gotchas-f739bbae55f9
 #
 # Afterwards there is a more automated way, using the list variable
-# `custom_sending_domains`.
+# `ses_custom_sending_domains`.
 ###
 
 resource "aws_ses_domain_identity" "cic-trvapply-vrtdemande" {
@@ -119,17 +119,17 @@ resource "aws_ses_identity_notification_topic" "cic-trvapply-vrtdemande-complain
 }
 
 resource "aws_ses_domain_identity" "custom_sending_domains" {
-  for_each = var.custom_sending_domains
+  for_each = var.ses_custom_sending_domains
   domain   = each.value
 }
 
 resource "aws_ses_domain_dkim" "custom_sending_domains" {
-  for_each = var.custom_sending_domains
+  for_each = var.ses_custom_sending_domains
   domain   = each.value
 }
 
 resource "aws_ses_identity_notification_topic" "custom_sending_domains_bounce_topic" {
-  for_each                 = var.custom_sending_domains
+  for_each                 = var.ses_custom_sending_domains
   topic_arn                = var.notification_canada_ca_ses_callback_arn
   notification_type        = "Bounce"
   identity                 = aws_ses_domain_identity.custom_sending_domains[each.value].domain
@@ -137,7 +137,7 @@ resource "aws_ses_identity_notification_topic" "custom_sending_domains_bounce_to
 }
 
 resource "aws_ses_identity_notification_topic" "custom_sending_domains_delivery_topic" {
-  for_each                 = var.custom_sending_domains
+  for_each                 = var.ses_custom_sending_domains
   topic_arn                = var.notification_canada_ca_ses_callback_arn
   notification_type        = "Delivery"
   identity                 = aws_ses_domain_identity.custom_sending_domains[each.value].domain
@@ -145,7 +145,7 @@ resource "aws_ses_identity_notification_topic" "custom_sending_domains_delivery_
 }
 
 resource "aws_ses_identity_notification_topic" "custom_sending_domains_complaint_topic" {
-  for_each                 = var.custom_sending_domains
+  for_each                 = var.ses_custom_sending_domains
   topic_arn                = var.notification_canada_ca_ses_callback_arn
   notification_type        = "Complaint"
   identity                 = aws_ses_domain_identity.custom_sending_domains[each.value].domain
@@ -153,7 +153,7 @@ resource "aws_ses_identity_notification_topic" "custom_sending_domains_complaint
 }
 
 resource "aws_ses_domain_mail_from" "custom_sending_domains" {
-  for_each         = var.custom_sending_domains
+  for_each         = var.ses_custom_sending_domains
   domain           = aws_ses_domain_identity.custom_sending_domains[each.value].domain
   mail_from_domain = "bounce.${aws_ses_domain_identity.custom_sending_domains[each.value].domain}"
 }

--- a/aws/dns/ses.tf
+++ b/aws/dns/ses.tf
@@ -80,7 +80,7 @@ resource "aws_ses_receipt_rule" "inbound-to-lambda" {
 # Read the section "Refactoring Can Be Tricky"
 # https://blog.gruntwork.io/terraform-tips-tricks-loops-if-statements-and-gotchas-f739bbae55f9
 #
-# Afterwards there is a more automated way, using the list variable
+# Afterwards there is a more automated way, using the set variable
 # `ses_custom_sending_domains`.
 ###
 

--- a/aws/dns/variables.tf
+++ b/aws/dns/variables.tf
@@ -6,6 +6,6 @@ variable "lambda_ses_receiving_emails_arn" {
   type = string
 }
 
-variable "custom_sending_domains" {
+variable "ses_custom_sending_domains" {
   type = set(string)
 }

--- a/aws/dns/variables.tf
+++ b/aws/dns/variables.tf
@@ -5,3 +5,7 @@ variable "notification_canada_ca_ses_callback_arn" {
 variable "lambda_ses_receiving_emails_arn" {
   type = string
 }
+
+variable "custom_sending_domains" {
+  type = set(string)
+}

--- a/env/staging/dns/terragrunt.hcl
+++ b/env/staging/dns/terragrunt.hcl
@@ -21,7 +21,7 @@ include {
 inputs = {
   notification_canada_ca_ses_callback_arn = dependency.common.outputs.notification_canada_ca_ses_callback_arn
   lambda_ses_receiving_emails_arn         = dependency.common.outputs.lambda_ses_receiving_emails_arn
-  ses_custom_sending_domains              = ["custom-sending-domain.staging.notification.cdssandbox.xyz", "test.example.com"]
+  ses_custom_sending_domains              = ["custom-sending-domain.staging.notification.cdssandbox.xyz"]
 }
 
 terraform {

--- a/env/staging/dns/terragrunt.hcl
+++ b/env/staging/dns/terragrunt.hcl
@@ -21,7 +21,7 @@ include {
 inputs = {
   notification_canada_ca_ses_callback_arn = dependency.common.outputs.notification_canada_ca_ses_callback_arn
   lambda_ses_receiving_emails_arn         = dependency.common.outputs.lambda_ses_receiving_emails_arn
-  ses_custom_sending_domains              = ["custom-sending-domain.staging.notification.cdssandbox.xyz"]
+  ses_custom_sending_domains              = ["custom-sending-domain.staging.notification.cdssandbox.xyz", "test.example.com"]
 }
 
 terraform {

--- a/env/staging/dns/terragrunt.hcl
+++ b/env/staging/dns/terragrunt.hcl
@@ -21,7 +21,7 @@ include {
 inputs = {
   notification_canada_ca_ses_callback_arn = dependency.common.outputs.notification_canada_ca_ses_callback_arn
   lambda_ses_receiving_emails_arn         = dependency.common.outputs.lambda_ses_receiving_emails_arn
-  custom_sending_domains                  = ["custom-sending-domain.staging.notification.cdssandbox.xyz"]
+  ses_custom_sending_domains              = ["custom-sending-domain.staging.notification.cdssandbox.xyz"]
 }
 
 terraform {

--- a/env/staging/dns/terragrunt.hcl
+++ b/env/staging/dns/terragrunt.hcl
@@ -21,7 +21,7 @@ include {
 inputs = {
   notification_canada_ca_ses_callback_arn = dependency.common.outputs.notification_canada_ca_ses_callback_arn
   lambda_ses_receiving_emails_arn         = dependency.common.outputs.lambda_ses_receiving_emails_arn
-  custom_sending_domains                  = ["notification.gov.bc.ca", "test.example.com"]
+  custom_sending_domains                  = ["custom-sending-domain.staging.notification.cdssandbox.xyz"]
 }
 
 terraform {

--- a/env/staging/dns/terragrunt.hcl
+++ b/env/staging/dns/terragrunt.hcl
@@ -21,6 +21,7 @@ include {
 inputs = {
   notification_canada_ca_ses_callback_arn = dependency.common.outputs.notification_canada_ca_ses_callback_arn
   lambda_ses_receiving_emails_arn         = dependency.common.outputs.lambda_ses_receiving_emails_arn
+  custom_sending_domains                  = ["notification.gov.bc.ca", "test.example.com"]
 }
 
 terraform {


### PR DESCRIPTION
**What / The story**

Notify offers the ability to send emails using the domain `notification.canada.ca` or a custom sending domain. Service owners can leverage a domain they own and use Notify to send emails.

At the moment we only have 1 service using this feature in production but more are coming - British Columbia wants to use a custom sending domain in the coming days. We need to streamline the process of letting them use custom sending domains and make it easier for the Notify team to do the required configuration changes.

**Why / The RoadMap link** BC gov raised this need in a Freshdesk ticket (attached)

**Done when / Output we want**

It's straightforward to add custom sending domains on our Terraform repository.


Trello card: https://trello.com/c/IU34UhxJ/359-create-custom-ses-sending-domains-easily