### PR TITLE
Bump production to 0.77.0

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -16,7 +16,7 @@ env:
   # Set the GitHub tag here to update the infrastructure
   # to a new version in production
   # See https://github.com/cds-snc/notification-terraform/releases
-  INFRASTRUCTURE_VERSION: '0.76.0'
+  INFRASTRUCTURE_VERSION: '0.77.0'
 
   # Terraform environment variables
   AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}

--- a/env/production/dns/terragrunt.hcl
+++ b/env/production/dns/terragrunt.hcl
@@ -18,4 +18,5 @@ include {
 inputs = {
   notification_canada_ca_ses_callback_arn = dependency.common.outputs.notification_canada_ca_ses_callback_arn
   lambda_ses_receiving_emails_arn         = dependency.common.outputs.lambda_ses_receiving_emails_arn
+  ses_custom_sending_domains              = ["notification.gov.bc.ca"]
 }


### PR DESCRIPTION
Release https://github.com/cds-snc/notification-terraform/pull/210 to production.

Setting up the domain `notification.gov.bc.ca` for the BC gov in production.