### PR TITLE
feat: rework SMS alarms

### DIFF
--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -119,6 +119,27 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-cr
   }
 }
 
+resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-us-west-2-critical" {
+  provider = aws.us-west-2
+
+  alarm_name          = "sns-sms-success-rate-canadian-numbers-us-west-2-critical"
+  alarm_description   = "SMS success rate to Canadian numbers is below 75% over 2 consecutive periods of 12 hours"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "2"
+  datapoints_to_alarm = "2"
+  metric_name         = "SMSSuccessRate"
+  namespace           = "AWS/SNS"
+  period              = 60 * 60 * 12
+  statistic           = "Average"
+  threshold           = 75 / 100
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical-us-west-2.arn]
+  ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical-us-west-2.arn]
+  dimensions = {
+    SMSType = "Transactional"
+    Country = "CA"
+  }
+}
+
 resource "aws_cloudwatch_metric_alarm" "ses-bounce-rate-warning" {
   alarm_name          = "ses-bounce-rate-warning"
   alarm_description   = "Bounce rate >=5% over the last 12 hours"
@@ -175,34 +196,67 @@ resource "aws_cloudwatch_metric_alarm" "ses-complaint-rate-critical" {
 
 resource "aws_cloudwatch_metric_alarm" "sqs-sms-stuck-in-queue-warning" {
   alarm_name          = "sqs-sms-stuck-in-queue-warning"
-  alarm_description   = "ApproximateAgeOfOldestMessage in SMS queue is older than 3 minutes for 15 minutes"
+  alarm_description   = "ApproximateAgeOfOldestMessage in SMS queue is older than 1 minute in a 5-minute period"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "3"
+  evaluation_periods  = "1"
   metric_name         = "ApproximateAgeOfOldestMessage"
   namespace           = "AWS/SQS"
-  period              = "300"
-  extended_statistic  = "p90"
-  threshold           = 60 * 3
+  period              = 60 * 5
+  statistic           = "Average"
+  threshold           = 60
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
   dimensions = {
-    QueueName = "eks-notification-canada-casend-sms-tasks"
+    QueueName = "${var.celery_queue_prefix}${var.sqs_sms_queue_name}"
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-sms-stuck-in-queue-critical" {
   alarm_name          = "sqs-sms-stuck-in-queue-critical"
-  alarm_description   = "ApproximateAgeOfOldestMessage in SMS queue is older than 5 minutes for 15 minutes"
+  alarm_description   = "ApproximateAgeOfOldestMessage in SMS queue is older than 1 minute for 10 minutes"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "3"
+  evaluation_periods  = "2"
   metric_name         = "ApproximateAgeOfOldestMessage"
   namespace           = "AWS/SQS"
-  period              = "300"
-  extended_statistic  = "p90"
-  threshold           = 60 * 5
+  period              = 60 * 5
+  statistic           = "Average"
+  threshold           = 60
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   dimensions = {
-    QueueName = "eks-notification-canada-casend-sms-tasks"
+    QueueName = "${var.celery_queue_prefix}${var.sqs_sms_queue_name}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "sqs-throttled-sms-stuck-in-queue-warning" {
+  alarm_name          = "sqs-throttled-sms-stuck-in-queue-warning"
+  alarm_description   = "ApproximateAgeOfOldestMessage in throttled SMS queue is older than 1 minute in a 5-minute period"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "ApproximateAgeOfOldestMessage"
+  namespace           = "AWS/SQS"
+  period              = 60 * 5
+  statistic           = "Average"
+  threshold           = 60
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
+  dimensions = {
+    QueueName = "${var.celery_queue_prefix}${var.sqs_throttled_sms_queue_name}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "sqs-throttled-sms-stuck-in-queue-critical" {
+  alarm_name          = "sqs-throttled-sms-stuck-in-queue-critical"
+  alarm_description   = "ApproximateAgeOfOldestMessage in throttled SMS queue is older than 1 minute for 10 minutes"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "ApproximateAgeOfOldestMessage"
+  namespace           = "AWS/SQS"
+  period              = 60 * 5
+  statistic           = "Average"
+  threshold           = 60
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
+  ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
+  dimensions = {
+    QueueName = "${var.celery_queue_prefix}${var.sqs_throttled_sms_queue_name}"
   }
 }
 
@@ -213,8 +267,8 @@ resource "aws_cloudwatch_metric_alarm" "sqs-email-stuck-in-queue-warning" {
   evaluation_periods  = "3"
   metric_name         = "ApproximateAgeOfOldestMessage"
   namespace           = "AWS/SQS"
-  period              = "300"
-  extended_statistic  = "p90"
+  period              = 60 * 5
+  statistic           = "Average"
   threshold           = 60 * 10
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
   dimensions = {
@@ -229,8 +283,8 @@ resource "aws_cloudwatch_metric_alarm" "sqs-email-stuck-in-queue-critical" {
   evaluation_periods  = "3"
   metric_name         = "ApproximateAgeOfOldestMessage"
   namespace           = "AWS/SQS"
-  period              = "300"
-  extended_statistic  = "p90"
+  period              = 60 * 5
+  statistic           = "Average"
   threshold           = 60 * 15
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -74,6 +74,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-wa
   statistic           = "Average"
   threshold           = 85 / 100
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
+  treat_missing_data  = "notBreaching"
   dimensions = {
     SMSType = "Transactional"
     Country = "CA"
@@ -94,6 +95,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-us
   statistic           = "Average"
   threshold           = 85 / 100
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning-us-west-2.arn]
+  treat_missing_data  = "notBreaching"
   dimensions = {
     SMSType = "Transactional"
     Country = "CA"
@@ -113,6 +115,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-cr
   threshold           = 75 / 100
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
+  treat_missing_data  = "notBreaching"
   dimensions = {
     SMSType = "Transactional"
     Country = "CA"
@@ -134,6 +137,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-us
   threshold           = 75 / 100
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical-us-west-2.arn]
   ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical-us-west-2.arn]
+  treat_missing_data  = "notBreaching"
   dimensions = {
     SMSType = "Transactional"
     Country = "CA"

--- a/aws/common/variables.tf
+++ b/aws/common/variables.tf
@@ -45,3 +45,17 @@ variable "celery_queue_prefix" {
   # in https://github.com/cds-snc/notification-manifests/blob/main/base/api-deployment.yaml
   default = "eks-notification-canada-ca"
 }
+
+variable "sqs_sms_queue_name" {
+  type    = string
+  # See QueueNames in
+  # https://github.com/cds-snc/notification-api/blob/master/app/config.py
+  default = "send-sms-tasks"
+}
+
+variable "sqs_throttled_sms_queue_name" {
+  type    = string
+  # See QueueNames in
+  # https://github.com/cds-snc/notification-api/blob/master/app/config.py
+  default = "send-throttled-sms-tasks"
+}

--- a/aws/common/variables.tf
+++ b/aws/common/variables.tf
@@ -47,14 +47,14 @@ variable "celery_queue_prefix" {
 }
 
 variable "sqs_sms_queue_name" {
-  type    = string
+  type = string
   # See QueueNames in
   # https://github.com/cds-snc/notification-api/blob/master/app/config.py
   default = "send-sms-tasks"
 }
 
 variable "sqs_throttled_sms_queue_name" {
-  type    = string
+  type = string
   # See QueueNames in
   # https://github.com/cds-snc/notification-api/blob/master/app/config.py
   default = "send-throttled-sms-tasks"


### PR DESCRIPTION
Our SMS alarms are lagging behind our SLOs and the fact that we now send SMS from multiple AWS regions using SNS.

Let's spend some time to:

- make sure that we have appropriate alarms in ca-central-1 and us-west-2
- reduce warning and critical thresholds for SMS
- add alarms on the throttled queue, used when sending SMS in us-west-2 https://github.com/cds-snc/notification-terraform/issues/106
- recreate a critical alarm we deleted in the past https://github.com/cds-snc/notification-terraform/issues/162

Trello card: https://trello.com/c/TdrBFem1/343-update-thresholds-for-sms-alarms

---

- reduced thresholds for SMS (checked CloudWatch data and we are far from these new thresholds but they are still way above our SLOs)
- refactored code
- add alarms on the throttled SMS queue https://github.com/cds-snc/notification-api/blob/4a0bc8e8847a47347d34fa70f0b6ee851387f8a2/app/notifications/process_notifications.py#L130-L133
- recreated critical alarm in `us-west-2` now that we send more SMS there