### PR TITLE
feat: remove encryption for SNS topic used by RDS events

### DIFF
--- a/aws/common/sns.tf
+++ b/aws/common/sns.tf
@@ -52,7 +52,7 @@ resource "aws_sns_topic" "notification-canada-ca-alert-critical-us-west-2" {
 resource "aws_sns_topic" "notification-canada-ca-alert-general" {
   name = "alert-general"
 
-  # tfsec:ignore:AWS016
+  # tfsec:ignore:AWS016 Unencrypted SNS topic
   # > Amazon RDS event notification is only available for unencrypted SNS topics.
   # > If you specify an encrypted SNS topic, event notifications aren't sent for the topic.
   #

--- a/aws/common/sns.tf
+++ b/aws/common/sns.tf
@@ -50,9 +50,13 @@ resource "aws_sns_topic" "notification-canada-ca-alert-critical-us-west-2" {
 }
 
 resource "aws_sns_topic" "notification-canada-ca-alert-general" {
-  name              = "alert-general"
-  kms_master_key_id = aws_kms_key.notification-canada-ca.arn
+  name = "alert-general"
 
+  # tfsec:ignore:AWS016
+  # > Amazon RDS event notification is only available for unencrypted SNS topics.
+  # > If you specify an encrypted SNS topic, event notifications aren't sent for the topic.
+  #
+  # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html#USER_Events.Subscribing
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
   }


### PR DESCRIPTION
RDS event notifications should be delivered to [**unencrypted** SNS topics](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html#USER_Events.Subscribing). Our current SNS topic is encrypted so we missed a few database events.

Fixing that to make sure we receive database notifications.

See AWS case support in staging

> [Case 8080942541] Missing notification for cluster event subscription

Related to https://github.com/cds-snc/notification-terraform/pull/145