### PR TITLE
feat: add lifecycle rule for attachments

### DIFF
--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -222,6 +222,18 @@ resource "aws_s3_bucket" "document_bucket" {
     }
   }
 
+  # Expire files attached directly to emails after a few days.
+  # Those are stored in a `tmp/` folder.
+  # See https://github.com/cds-snc/notification-document-download-api
+  lifecycle_rule {
+    enabled = true
+    prefix  = "tmp/"
+
+    expiration {
+      days = 3
+    }
+  }
+
   logging {
     target_bucket = aws_s3_bucket.document_bucket_logs.bucket
   }


### PR DESCRIPTION
Expire files stored in the document download bucket after 3 days if they are stored in the `tmp/` folder.

Trello: https://trello.com/c/wtkWVPcA/369-let-clients-attach-files-directly-to-emails-with-the-api