### PR TITLE
feat: bumping version, adding prod definitions for alarms and s3 policy

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -16,7 +16,7 @@ env:
   # Set the GitHub tag here to update the infrastructure
   # to a new version in production
   # See https://github.com/cds-snc/notification-terraform/releases
-  INFRASTRUCTURE_VERSION: '0.80.1'
+  INFRASTRUCTURE_VERSION: '0.84.0'
 
   # Terraform environment variables
   AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}

--- a/env/production/cloudfront/terragrunt.hcl
+++ b/env/production/cloudfront/terragrunt.hcl
@@ -18,5 +18,7 @@ include {
 
 inputs = {
   asset_bucket_regional_domain_name         = dependency.common.outputs.asset_bucket_regional_domain_name
+  s3_bucket_asset_bucket_id                 = dependency.common.outputs.s3_bucket_asset_bucket_id
+  s3_bucket_asset_bucket_arn                = dependency.common.outputs.s3_bucket_asset_bucket_arn
   aws_acm_assets_notification_canada_ca_arn = dependency.dns.outputs.aws_acm_assets_notification_canada_ca_arn
 }

--- a/env/production/elasticache/terragrunt.hcl
+++ b/env/production/elasticache/terragrunt.hcl
@@ -23,4 +23,5 @@ inputs = {
   elasticache_node_count    = 1
   elasticache_node_type     = "cache.t3.micro"
   vpc_private_subnets       = dependency.common.outputs.vpc_private_subnets
+  sns_alert_warning_arn     = dependency.common.outputs.sns_alert_warning_arn
 }


### PR DESCRIPTION
Release #222 , #223, #224 to production. 
PRs are related S3 policy update (to not be public) and lifecycle rules for `/tmp`