### PR TITLE
version bump 0.82.0, including #218 and #221

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -16,7 +16,7 @@ env:
   # Set the GitHub tag here to update the infrastructure
   # to a new version in production
   # See https://github.com/cds-snc/notification-terraform/releases
-  INFRASTRUCTURE_VERSION: '0.80.1'
+  INFRASTRUCTURE_VERSION: '0.82.0'
 
   # Terraform environment variables
   AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}

--- a/env/production/elasticache/terragrunt.hcl
+++ b/env/production/elasticache/terragrunt.hcl
@@ -23,4 +23,5 @@ inputs = {
   elasticache_node_count    = 1
   elasticache_node_type     = "cache.t3.micro"
   vpc_private_subnets       = dependency.common.outputs.vpc_private_subnets
+  sns_alert_warning_arn     = dependency.common.outputs.sns_alert_warning_arn
 }


### PR DESCRIPTION
version bump 0.82.0, including #218 and #221 - part 1 [includes ElastiCache Redis alarms, output variables for part 2 of s3 policy access]