### PR TITLE
Add DescribeDBClusters permission for inspec

### DIFF
--- a/aws/common/iam.tf
+++ b/aws/common/iam.tf
@@ -219,6 +219,7 @@ resource "aws_iam_group_policy" "inspec_cloud_guard_rails" {
             "iam:ListUserPolicies",
             "iam:ListUsers",
             "iam:ListVirtualMFADevices",
+            "rds:DescribeDBClusters",
             "rds:DescribeDBInstances",
             "s3:GetBucketLocation",
             "s3:GetBucketTagging",


### PR DESCRIPTION
Add the `rds:DescribeDBClusters` permission to the `inspec` user, running [continuous guardrails scanning](https://github.com/cds-snc/continuous-guardrail-scanning).


Will send a PR soon to the other repository, listing database clusters and making sure that deletion protection is always enabled. Submitting this PR in advance to make sure we have the required permissions when the CI will be updated.

This is an incident action item.