### PR TITLE
feat: add alarms for attachments

### DIFF
--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -432,7 +432,7 @@ resource "aws_cloudwatch_metric_alarm" "document-download-bucket-size-warning" {
   namespace           = "AWS/S3"
   period              = 60 * 15
   statistic           = "Average"
-  threshold           = var.alarm_warning_document_download_bucket_size_gb * 1000 * 1000 * 1000 # Convert the GB variable to bytes
+  threshold           = var.alarm_warning_document_download_bucket_size_gb * 1024 * 1024 * 1024 # Convert the GB variable to bytes
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
   dimensions = {
     StorageType = "StandardStorage"

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -422,3 +422,20 @@ resource "aws_cloudwatch_metric_alarm" "contact-3-500-error-15-minutes-critical"
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
 }
+
+resource "aws_cloudwatch_metric_alarm" "document-download-bucket-size-warning" {
+  alarm_name          = "document-download-bucket-size-warning"
+  alarm_description   = "Document download S3 bucket size is larger than ${var.alarm_warning_document_download_bucket_size_gb} GB"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "BucketSizeBytes"
+  namespace           = "AWS/S3"
+  period              = 60 * 15
+  statistic           = "Average"
+  threshold           = var.alarm_warning_document_download_bucket_size_gb * 1000 * 1000 * 1000 # Convert the GB variable to bytes
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
+  dimensions = {
+    StorageType = "StandardStorage"
+    BucketName  = aws_s3_bucket.document_bucket.bucket
+  }
+}

--- a/aws/common/variables.tf
+++ b/aws/common/variables.tf
@@ -59,3 +59,7 @@ variable "sqs_throttled_sms_queue_name" {
   # https://github.com/cds-snc/notification-api/blob/master/app/config.py
   default = "send-throttled-sms-tasks"
 }
+
+variable "alarm_warning_document_download_bucket_size_gb" {
+  type = number
+}

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -75,6 +75,24 @@ resource "aws_cloudwatch_metric_alarm" "load-balancer-10-502-error-5-minutes-cri
   }
 }
 
+resource "aws_cloudwatch_metric_alarm" "document-download-api-high-request-count-warning" {
+  alarm_name          = "document-download-api-high-request-count-warning"
+  alarm_description   = "More than 300 4XX requests in 10 minutes on ${aws_alb_target_group.notification-canada-ca-document-api.name} target group"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "HTTPCode_Target_4XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60 * 10
+  statistic           = "Sum"
+  threshold           = 300
+  alarm_actions       = [var.sns_alert_warning_arn]
+  treat_missing_data  = "notBreaching"
+  dimensions = {
+    LoadBalancer = aws_alb.notification-canada-ca.arn_suffix
+    TargetGroup  = aws_alb_target_group.notification-canada-ca-document-api.arn_suffix
+  }
+}
+
 resource "aws_cloudwatch_metric_alarm" "logs-1-celery-error-1-minute-warning" {
   alarm_name          = "logs-1-celery-error-1-minute-warning"
   alarm_description   = "One Celery error in 1 minute"

--- a/env/staging/common/terragrunt.hcl
+++ b/env/staging/common/terragrunt.hcl
@@ -7,6 +7,7 @@ include {
 }
 
 inputs = {
-  sns_monthly_spend_limit           = 1
-  sns_monthly_spend_limit_us_west_2 = 1
+  sns_monthly_spend_limit                        = 1
+  sns_monthly_spend_limit_us_west_2              = 1
+  alarm_warning_document_download_bucket_size_gb = 0.5
 }


### PR DESCRIPTION
Add 2 new alarms related to attachments:

- watch the S3 bucket size holding file attachments. Not sure about threshold but planned to have a warning alarm at 500 MB on staging and 100 GB in production, as a start
- add a warning alarm when we have more than 300 HTTP 4XX requests on the document download API. 4XX requests will happen when requests are malformed or when documents are not found on S3, may be a sign that people try to guess private links

Trello: https://trello.com/c/eLN4TwTf/402-add-alarms-related-to-attachments