### PR TITLE
Add custom sending domain for Nova Scotia

### DIFF
--- a/env/production/dns/terragrunt.hcl
+++ b/env/production/dns/terragrunt.hcl
@@ -18,5 +18,5 @@ include {
 inputs = {
   notification_canada_ca_ses_callback_arn = dependency.common.outputs.notification_canada_ca_ses_callback_arn
   lambda_ses_receiving_emails_arn         = dependency.common.outputs.lambda_ses_receiving_emails_arn
-  ses_custom_sending_domains              = ["notification.gov.bc.ca"]
+  ses_custom_sending_domains              = ["notification.gov.bc.ca", "notify.novascotia.ca"]
 }


### PR DESCRIPTION
Create a new custom sending domain for the Nova Scotia government. Will pass DNS records to their team and update services on Platform Admin after.

See client request https://cds-snc.freshdesk.com/a/tickets/7468