### PR TITLE
Bump production to 0.86.0

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -16,7 +16,7 @@ env:
   # Set the GitHub tag here to update the infrastructure
   # to a new version in production
   # See https://github.com/cds-snc/notification-terraform/releases
-  INFRASTRUCTURE_VERSION: '0.85.0'
+  INFRASTRUCTURE_VERSION: '0.86.0'
 
   # Terraform environment variables
   AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}

--- a/env/production/common/terragrunt.hcl
+++ b/env/production/common/terragrunt.hcl
@@ -9,6 +9,7 @@ include {
 }
 
 inputs = {
-  sns_monthly_spend_limit           = 10000
-  sns_monthly_spend_limit_us_west_2 = 1000
+  sns_monthly_spend_limit                        = 10000
+  sns_monthly_spend_limit_us_west_2              = 1000
+  alarm_warning_document_download_bucket_size_gb = 100
 }


### PR DESCRIPTION
Release #229 to production, set the threshold for production.

Checked alarms in staging. The [S3 one](https://ca-central-1.console.aws.amazon.com/cloudwatch/home?region=ca-central-1#alarmsV2:alarm/document-download-bucket-size-warning?) is marked as insufficient data, maybe we can treat missing data as "not breaching" and change the period afterwards, this metric is not published often it seems.