### PR TITLE
feat: add CloudWatch queries

### DIFF
--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -13,7 +13,7 @@ resource "aws_cloudwatch_log_group" "notification-canada-ca-eks-cluster-logs" {
 resource "aws_cloudwatch_log_metric_filter" "web-500-errors" {
   name           = "web-500-errors"
   pattern        = "\"\\\" 500 \""
-  log_group_name = "/aws/containerinsights/${aws_eks_cluster.notification-canada-ca-eks-cluster.name}/application"
+  log_group_name = local.eks_application_log_group
 
   metric_transformation {
     name      = "500-errors"
@@ -25,7 +25,7 @@ resource "aws_cloudwatch_log_metric_filter" "web-500-errors" {
 resource "aws_cloudwatch_log_metric_filter" "celery-error" {
   name           = "celery-error"
   pattern        = "\"ERROR/Worker\""
-  log_group_name = "/aws/containerinsights/${aws_eks_cluster.notification-canada-ca-eks-cluster.name}/application"
+  log_group_name = local.eks_application_log_group
 
   metric_transformation {
     name      = "celery-error"
@@ -37,7 +37,7 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error" {
 resource "aws_cloudwatch_log_metric_filter" "over-daily-rate-limit" {
   name           = "over-daily-rate-limit"
   pattern        = "has been rate limited for daily use sent"
-  log_group_name = "/aws/containerinsights/${aws_eks_cluster.notification-canada-ca-eks-cluster.name}/application"
+  log_group_name = local.eks_application_log_group
 
   metric_transformation {
     name      = "over-daily-rate-limit"

--- a/aws/eks/cloudwatch_queries.tf
+++ b/aws/eks/cloudwatch_queries.tf
@@ -38,7 +38,7 @@ resource "aws_cloudwatch_query_definition" "services-over-daily-rate-limit" {
   ]
 
   query_string = <<QUERY
-fields @timestamp, log
+fields @timestamp, log, @logStream
 | filter strcontains(@message, 'has been rate limited for daily use sent')
 | sort @timestamp desc
 | limit 20

--- a/aws/eks/cloudwatch_queries.tf
+++ b/aws/eks/cloudwatch_queries.tf
@@ -1,15 +1,46 @@
-resource "aws_cloudwatch_query_definition" "admin-api-500-errors" {
-  name = "ADMIN & API - 500 errors"
+resource "aws_cloudwatch_query_definition" "admin-api-50X-errors" {
+  name = "ADMIN & API - 50X errors"
 
   log_group_names = [
     local.eks_application_log_group
   ]
 
-  query_string = <<EOF
+  query_string = <<QUERY
 fields @timestamp, log, kubernetes.labels.app as app, kubernetes.pod_name as pod_name, @logStream
 | filter kubernetes.labels.app like /admin|api/
-| filter strcontains(@message, 'HTTP/1.1\" 500')
+| filter @message like /HTTP\/\d+\.\d+\\" 50\d/
 | sort @timestamp desc
 | limit 20
-EOF
+QUERY
+}
+
+resource "aws_cloudwatch_query_definition" "celery-errors" {
+  name = "Celery errors"
+
+  log_group_names = [
+    local.eks_application_log_group
+  ]
+
+  query_string = <<QUERY
+fields @timestamp, log, kubernetes.labels.app as app, kubernetes.pod_name as pod_name, @logStream
+| filter kubernetes.labels.app like /^celery/
+| filter strcontains(@message, 'ERROR/Worker')
+| sort @timestamp desc
+| limit 20
+QUERY
+}
+
+resource "aws_cloudwatch_query_definition" "services-over-daily-rate-limit" {
+  name = "Services going over daily rate limits"
+
+  log_group_names = [
+    local.eks_application_log_group
+  ]
+
+  query_string = <<QUERY
+fields @timestamp, log
+| filter strcontains(@message, 'has been rate limited for daily use sent')
+| sort @timestamp desc
+| limit 20
+QUERY
 }

--- a/aws/eks/cloudwatch_queries.tf
+++ b/aws/eks/cloudwatch_queries.tf
@@ -1,11 +1,11 @@
 resource "aws_cloudwatch_query_definition" "admin-api-500-errors" {
   name = "ADMIN & API - 500 errors"
 
-  log_groups = [
+  log_group_names = [
     local.eks_application_log_group
   ]
 
-  query = <<EOF
+  query_string = <<EOF
 fields @timestamp, log, kubernetes.labels.app as app, kubernetes.pod_name as pod_name, @logStream
 | filter kubernetes.labels.app like /admin|api/
 | filter strcontains(@message, 'HTTP/1.1\" 500')

--- a/aws/eks/cloudwatch_queries.tf
+++ b/aws/eks/cloudwatch_queries.tf
@@ -1,0 +1,15 @@
+resource "aws_cloudwatch_query_definition" "admin-api-500-errors" {
+  name = "ADMIN & API - 500 errors"
+
+  log_groups = [
+    local.eks_application_log_group
+  ]
+
+  query = <<EOF
+fields @timestamp, log, kubernetes.labels.app as app, kubernetes.pod_name as pod_name, @logStream
+| filter kubernetes.labels.app like /admin|api/
+| filter strcontains(@message, 'HTTP/1.1\" 500')
+| sort @timestamp desc
+| limit 20
+EOF
+}

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -57,3 +57,7 @@ variable "alb_log_bucket" {
 variable "eks_cluster_name" {
   type = string
 }
+
+locals {
+  eks_application_log_group = "/aws/containerinsights/${var.eks_cluster_name}/application"
+}


### PR DESCRIPTION
`aws_cloudwatch_query_definition` is a new resource available on the AWS provider https://github.com/hashicorp/terraform-provider-aws/issues/13223

We had a bunch of queries saved in production, those have been created using the AWS console. Recreate our queries in Terraform to make sure that we have the same queries between staging and production.

Trello: https://trello.com/c/MMknwMKW/420-add-cloudwatch-queries-on-terraform