### PR TITLE
feat: detect when SMS are marked as spam or carrier is unavailable

### DIFF
--- a/.github/workflows/terraform_static_analysis.yml
+++ b/.github/workflows/terraform_static_analysis.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Terraform security scan
         uses: triat/terraform-security-scan@v2.2.1
         with:
-          tfsec_version: 'v0.39.0'
+          tfsec_version: 'v0.39.21'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/terraform_static_analysis.yml
+++ b/.github/workflows/terraform_static_analysis.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Terraform security scan
-        uses: triat/terraform-security-scan@v2.1.0
+        uses: triat/terraform-security-scan@v2.2.1
         with:
           tfsec_version: 'v0.39.0'
         env:

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -158,10 +158,10 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-blocked-as-spam-warning" {
   treat_missing_data  = "notBreaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "us-west-2-sns-sms-blocked-as-spam-warning" {
+resource "aws_cloudwatch_metric_alarm" "sns-sms-blocked-as-spam-us-west-2-warning" {
   provider = aws.us-west-2
 
-  alarm_name          = "us-west-2-sns-sms-blocked-as-spam-warning"
+  alarm_name          = "sns-sms-blocked-as-spam-us-west-2-warning"
   alarm_description   = "More than 10 SMS have been blocked as spam over 12 hours"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -188,10 +188,10 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-phone-carrier-unavailable-warnin
   treat_missing_data  = "notBreaching"
 }
 
-resource "aws_cloudwatch_metric_alarm" "us-west-2-sns-sms-phone-carrier-unavailable-warning" {
+resource "aws_cloudwatch_metric_alarm" "sns-sms-phone-carrier-unavailable-us-west-2-warning" {
   provider = aws.us-west-2
 
-  alarm_name          = "us-west-2-sns-sms-phone-carrier-unavailable-warning"
+  alarm_name          = "sns-sms-phone-carrier-unavailable-us-west-2-warning"
   alarm_description   = "More than 10 SMS failed because a phone carrier is unavailable over 6 hours"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -144,6 +144,66 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-us
   }
 }
 
+resource "aws_cloudwatch_metric_alarm" "sns-sms-blocked-as-spam-warning" {
+  alarm_name          = "sns-sms-blocked-as-spam-warning"
+  alarm_description   = "More than 10 SMS have been blocked as spam over 12 hours"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.sns-sms-blocked-as-spam.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.sns-sms-blocked-as-spam.metric_transformation[0].namespace
+  period              = 60 * 60 * 12
+  statistic           = "Sum"
+  threshold           = 10
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
+  treat_missing_data  = "notBreaching"
+}
+
+resource "aws_cloudwatch_metric_alarm" "us-west-2-sns-sms-blocked-as-spam-warning" {
+  provider = aws.us-west-2
+
+  alarm_name          = "us-west-2-sns-sms-blocked-as-spam-warning"
+  alarm_description   = "More than 10 SMS have been blocked as spam over 12 hours"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.us-west-2-sns-sms-blocked-as-spam.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.us-west-2-sns-sms-blocked-as-spam.metric_transformation[0].namespace
+  period              = 60 * 60 * 12
+  statistic           = "Sum"
+  threshold           = 10
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning-us-west-2.arn]
+  treat_missing_data  = "notBreaching"
+}
+
+resource "aws_cloudwatch_metric_alarm" "sns-sms-phone-carrier-unavailable-warning" {
+  alarm_name          = "sns-sms-phone-carrier-unavailable-warning"
+  alarm_description   = "More than 10 SMS failed because a phone carrier is unavailable over 6 hours"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.sns-sms-phone-carrier-unavailable.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.sns-sms-phone-carrier-unavailable.metric_transformation[0].namespace
+  period              = 60 * 60 * 6
+  statistic           = "Sum"
+  threshold           = 10
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
+  treat_missing_data  = "notBreaching"
+}
+
+resource "aws_cloudwatch_metric_alarm" "us-west-2-sns-sms-phone-carrier-unavailable-warning" {
+  provider = aws.us-west-2
+
+  alarm_name          = "us-west-2-sns-sms-phone-carrier-unavailable-warning"
+  alarm_description   = "More than 10 SMS failed because a phone carrier is unavailable over 6 hours"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.us-west-2-sns-sms-phone-carrier-unavailable.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.us-west-2-sns-sms-phone-carrier-unavailable.metric_transformation[0].namespace
+  period              = 60 * 60 * 6
+  statistic           = "Sum"
+  threshold           = 10
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning-us-west-2.arn]
+  treat_missing_data  = "notBreaching"
+}
+
 resource "aws_cloudwatch_metric_alarm" "ses-bounce-rate-warning" {
   alarm_name          = "ses-bounce-rate-warning"
   alarm_description   = "Bounce rate >=5% over the last 12 hours"

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -165,8 +165,8 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-blocked-as-spam-us-west-2-warnin
   alarm_description   = "More than 10 SMS have been blocked as spam over 12 hours"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.us-west-2-sns-sms-blocked-as-spam.metric_transformation[0].name
-  namespace           = aws_cloudwatch_log_metric_filter.us-west-2-sns-sms-blocked-as-spam.metric_transformation[0].namespace
+  metric_name         = aws_cloudwatch_log_metric_filter.sns-sms-blocked-as-spam-us-west-2.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.sns-sms-blocked-as-spam-us-west-2.metric_transformation[0].namespace
   period              = 60 * 60 * 12
   statistic           = "Sum"
   threshold           = 10
@@ -195,8 +195,8 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-phone-carrier-unavailable-us-wes
   alarm_description   = "More than 10 SMS failed because a phone carrier is unavailable over 6 hours"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.us-west-2-sns-sms-phone-carrier-unavailable.metric_transformation[0].name
-  namespace           = aws_cloudwatch_log_metric_filter.us-west-2-sns-sms-phone-carrier-unavailable.metric_transformation[0].namespace
+  metric_name         = aws_cloudwatch_log_metric_filter.sns-sms-phone-carrier-unavailable-us-west-2.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.sns-sms-phone-carrier-unavailable-us-west-2.metric_transformation[0].namespace
   period              = 60 * 60 * 6
   statistic           = "Sum"
   threshold           = 10

--- a/aws/common/cloudwatch_log.tf
+++ b/aws/common/cloudwatch_log.tf
@@ -1,3 +1,6 @@
+###
+# AWS CloudWatch Log Groups
+###
 resource "aws_cloudwatch_log_group" "sns_deliveries" {
   name = "sns/${var.region}/${var.account_id}/DirectPublishToPhoneNumber"
 
@@ -46,6 +49,72 @@ resource "aws_cloudwatch_log_group" "sns_deliveries_failures_us_west_2" {
   }
 }
 
+###
+# AWS CloudWatch Logs Metrics
+###
+resource "aws_cloudwatch_log_metric_filter" "sns-sms-blocked-as-spam" {
+  name = "sns-sms-blocked-as-spam"
+  # See https://docs.amazonaws.cn/en_us/sns/latest/dg/sms_stats_cloudwatch.html#sms_stats_delivery_fail_reasons
+  pattern        = "{ $.delivery.providerResponse = \"Blocked as spam by phone carrier\" }"
+  log_group_name = aws_cloudwatch_log_group.sns_deliveries_failures.name
+
+  metric_transformation {
+    name          = "sns-sms-blocked-as-spam"
+    namespace     = "LogMetrics"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "us-west-2-sns-sms-blocked-as-spam" {
+  provider = aws.us-west-2
+
+  name = "us-west-2-sns-sms-blocked-as-spam"
+  # See https://docs.amazonaws.cn/en_us/sns/latest/dg/sms_stats_cloudwatch.html#sms_stats_delivery_fail_reasons
+  pattern        = "{ $.delivery.providerResponse = \"Blocked as spam by phone carrier\" }"
+  log_group_name = aws_cloudwatch_log_group.sns_deliveries_failures_us_west_2.name
+
+  metric_transformation {
+    name          = "us-west-2-sns-sms-blocked-as-spam"
+    namespace     = "LogMetrics"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "sns-sms-phone-carrier-unavailable" {
+  name = "sns-sms-phone-carrier-unavailable"
+  # See https://docs.amazonaws.cn/en_us/sns/latest/dg/sms_stats_cloudwatch.html#sms_stats_delivery_fail_reasons
+  pattern        = "{ $.delivery.providerResponse = \"Phone carrier is currently unreachable/unavailable\" }"
+  log_group_name = aws_cloudwatch_log_group.sns_deliveries_failures.name
+
+  metric_transformation {
+    name          = "sns-sms-phone-carrier-unavailable"
+    namespace     = "LogMetrics"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "us-west-2-sns-sms-phone-carrier-unavailable" {
+  provider = aws.us-west-2
+
+  name = "us-west-2-sns-sms-phone-carrier-unavailable"
+  # See https://docs.amazonaws.cn/en_us/sns/latest/dg/sms_stats_cloudwatch.html#sms_stats_delivery_fail_reasons
+  pattern        = "{ $.delivery.providerResponse = \"Phone carrier is currently unreachable/unavailable\" }"
+  log_group_name = aws_cloudwatch_log_group.sns_deliveries_failures_us_west_2.name
+
+  metric_transformation {
+    name          = "us-west-2-sns-sms-phone-carrier-unavailable"
+    namespace     = "LogMetrics"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+###
+# AWS CloudWatch Logs Subscriptions
+###
 resource "aws_cloudwatch_log_subscription_filter" "sns_to_lambda" {
   name            = "sns_to_lambda"
   log_group_name  = aws_cloudwatch_log_group.sns_deliveries.name

--- a/aws/common/cloudwatch_log.tf
+++ b/aws/common/cloudwatch_log.tf
@@ -66,16 +66,16 @@ resource "aws_cloudwatch_log_metric_filter" "sns-sms-blocked-as-spam" {
   }
 }
 
-resource "aws_cloudwatch_log_metric_filter" "us-west-2-sns-sms-blocked-as-spam" {
+resource "aws_cloudwatch_log_metric_filter" "sns-sms-blocked-as-spam-us-west-2" {
   provider = aws.us-west-2
 
-  name = "us-west-2-sns-sms-blocked-as-spam"
+  name = "sns-sms-blocked-as-spam-us-west-2"
   # See https://docs.amazonaws.cn/en_us/sns/latest/dg/sms_stats_cloudwatch.html#sms_stats_delivery_fail_reasons
   pattern        = "{ $.delivery.providerResponse = \"Blocked as spam by phone carrier\" }"
   log_group_name = aws_cloudwatch_log_group.sns_deliveries_failures_us_west_2.name
 
   metric_transformation {
-    name          = "us-west-2-sns-sms-blocked-as-spam"
+    name          = "sns-sms-blocked-as-spam-us-west-2"
     namespace     = "LogMetrics"
     value         = "1"
     default_value = "0"
@@ -96,16 +96,16 @@ resource "aws_cloudwatch_log_metric_filter" "sns-sms-phone-carrier-unavailable" 
   }
 }
 
-resource "aws_cloudwatch_log_metric_filter" "us-west-2-sns-sms-phone-carrier-unavailable" {
+resource "aws_cloudwatch_log_metric_filter" "sns-sms-phone-carrier-unavailable-us-west-2" {
   provider = aws.us-west-2
 
-  name = "us-west-2-sns-sms-phone-carrier-unavailable"
+  name = "sns-sms-phone-carrier-unavailable-us-west-2"
   # See https://docs.amazonaws.cn/en_us/sns/latest/dg/sms_stats_cloudwatch.html#sms_stats_delivery_fail_reasons
   pattern        = "{ $.delivery.providerResponse = \"Phone carrier is currently unreachable/unavailable\" }"
   log_group_name = aws_cloudwatch_log_group.sns_deliveries_failures_us_west_2.name
 
   metric_transformation {
-    name          = "us-west-2-sns-sms-phone-carrier-unavailable"
+    name          = "sns-sms-phone-carrier-unavailable-us-west-2"
     namespace     = "LogMetrics"
     value         = "1"
     default_value = "0"


### PR DESCRIPTION
Add log metric filters to detect when:
- SMS are marked as spam by a phone carrier
- when a phone carrier is unavailable

from SNS SMS log groups, in 2 AWS regions where we send SMS.

Add **warning alarms** using these new metrics:
- More than 10 SMS have been blocked as spam over 12 hours
- More than 10 SMS failed because a phone carrier is unavailable over 6 hours

Trello: https://trello.com/c/wzAeiXeO/365-be-alerted-when-phone-carriers-are-having-issues