### PR TITLE
feat: specify SSL policy for ALB

### DIFF
--- a/aws/eks/alb.tf
+++ b/aws/eks/alb.tf
@@ -30,6 +30,7 @@ resource "aws_alb_listener" "notification-canada-ca" {
   port              = 443
   protocol          = "HTTPS"
   certificate_arn   = var.aws_acm_notification_canada_ca_arn
+  ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2019-08"
 
   default_action {
     type             = "forward"

--- a/aws/eks/alb.tf
+++ b/aws/eks/alb.tf
@@ -30,6 +30,8 @@ resource "aws_alb_listener" "notification-canada-ca" {
   port              = 443
   protocol          = "HTTPS"
   certificate_arn   = var.aws_acm_notification_canada_ca_arn
+  # See https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html#describe-ssl-policies
+  # And https://cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062
   ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2019-08"
 
   default_action {


### PR DESCRIPTION
Pick an appropriate SSL policy for the load balancer, according to:

- recommendations: https://canada-ca.github.io/cloud-guardrails/EN/07_Protect-Data-in-Transit.html
- what other teams do: https://github.com/cds-snc/covid-alert-server-staging-terraform/blob/6232ad547cba9d4dd57300ea4377b2e3821442e7/server/aws/lb.tf#L82

See https://aws.amazon.com/about-aws/whats-new/2019/10/application-load-balancer-and-network-load-balancer-add-new-security-policies-for-forward-secrecy-with-more-strigent-protocols-and-ciphers/