### PR TITLE
fix: update Celery error logs pattern

### DIFF
--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -24,7 +24,7 @@ resource "aws_cloudwatch_log_metric_filter" "web-500-errors" {
 
 resource "aws_cloudwatch_log_metric_filter" "celery-error" {
   name           = "celery-error"
-  pattern        = "\"ERROR/Worker\""
+  pattern        = "?\"ERROR/Worker\" ?\"ERROR/ForkPoolWorker\""
   log_group_name = local.eks_application_log_group
 
   metric_transformation {


### PR DESCRIPTION
We've seen that Celery error can start with
- ERROR/Worker
- ERROR/ForkPoolWorker

The current pattern does not match the 2nd case for now, this PR makes sure it matches as well.

The `OR` pattern is a bit weird to write, see [the documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html#matching-terms-events)

Evidence that this pattern matches
![Screen Shot 2021-04-19 at 14 05 52](https://user-images.githubusercontent.com/295709/115282655-73dbbe00-a118-11eb-9fdd-e986869767d2.png)
