### PR TITLE
feat: handle no recipients for SES inbound

### DIFF
--- a/aws/common/lambdas/ses_receiving_emails.py
+++ b/aws/common/lambdas/ses_receiving_emails.py
@@ -59,7 +59,7 @@ def to_queue(queue, data):
 
 def parse_recipients(headers, receipt):
     # Gather recipients from our own domain only
-    recipients = headers.get("to", []) + headers.get("cc", []) + headers.get("bcc", []) + receipt.get('recipients', [])
+    recipients = headers.get("to", []) + headers.get("cc", []) + headers.get("bcc", []) + receipt.get("recipients", [])
     recipients = [parseaddr(r)[1] for r in set(recipients)]
 
     return [r for r in recipients if r.endswith(f"@{SENDING_DOMAIN}")]

--- a/aws/common/lambdas/ses_receiving_emails.py
+++ b/aws/common/lambdas/ses_receiving_emails.py
@@ -60,7 +60,7 @@ def to_queue(queue, data):
 def parse_recipients(headers, receipt):
     # Gather recipients from our own domain only
     recipients = headers.get("to", []) + headers.get("cc", []) + headers.get("bcc", []) + receipt.get("recipients", [])
-    recipients = [parseaddr(r)[1] for r in set(recipients)]
+    recipients = [parseaddr(r)[1] for r in set(r.lower() for r in recipients)]
 
     return [r for r in recipients if r.endswith(f"@{SENDING_DOMAIN}")]
 

--- a/aws/common/lambdas/ses_receiving_emails.py
+++ b/aws/common/lambdas/ses_receiving_emails.py
@@ -57,10 +57,10 @@ def to_queue(queue, data):
     queue.send_message(MessageBody=msg)
 
 
-def parse_recipients(headers):
+def parse_recipients(headers, receipt):
     # Gather recipients from our own domain only
-    recipients = headers.get("to", []) + headers.get("cc", []) + headers.get("bcc", [])
-    recipients = [parseaddr(r)[1] for r in recipients]
+    recipients = headers.get("to", []) + headers.get("cc", []) + headers.get("bcc", []) + receipt.get('recipients', [])
+    recipients = [parseaddr(r)[1] for r in set(recipients)]
 
     return [r for r in recipients if r.endswith(f"@{SENDING_DOMAIN}")]
 
@@ -115,7 +115,7 @@ def lambda_handler(event, context):
         if matches:
             messageId = matches.groups()[0]
 
-        recipients = parse_recipients(payload["mail"]["commonHeaders"])
+        recipients = parse_recipients(payload["mail"]["commonHeaders"], payload["receipt"])
 
         # Do not reply to people emailing the GC Notify service.
         # This service has a reply email address set and clients


### PR DESCRIPTION
We've seen payloads in production where To + Cc + Bcc fields are not present in `commonHeaders` but `recipients` is filled from the receipt.

`recipients` is defined as:

> A list of recipients (specifically, the envelope RCPT TO addresses) that were matched by the active receipt rule. The addresses listed here may differ from those listed by the destination field in the mail object.

Use this new field to a build a complete list of recipients

AWS doc: https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-notifications-contents.html
Difference between RCPT TO and TO: https://stackoverflow.com/questions/10822190/in-smtp-must-the-rcpt-to-and-to-match

PS: for Notify developers, I can share JSON payload on request.