### PR TITLE
feat: support TLS 1.0 and 1.1 for a few more weeks

### DIFF
--- a/aws/eks/alb.tf
+++ b/aws/eks/alb.tf
@@ -32,6 +32,7 @@ resource "aws_alb_listener" "notification-canada-ca" {
   certificate_arn   = var.aws_acm_notification_canada_ca_arn
   # See https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html#describe-ssl-policies
   # And https://cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062
+  #tfsec:ignore:AWS010 Outdated SSL policy
   ssl_policy        = "ELBSecurityPolicy-2016-08"
 
   default_action {

--- a/aws/eks/alb.tf
+++ b/aws/eks/alb.tf
@@ -32,7 +32,7 @@ resource "aws_alb_listener" "notification-canada-ca" {
   certificate_arn   = var.aws_acm_notification_canada_ca_arn
   # See https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html#describe-ssl-policies
   # And https://cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062
-  ssl_policy        = "ELBSecurityPolicy-FS-1-1-2019-08"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
 
   default_action {
     type             = "forward"

--- a/aws/eks/alb.tf
+++ b/aws/eks/alb.tf
@@ -32,7 +32,7 @@ resource "aws_alb_listener" "notification-canada-ca" {
   certificate_arn   = var.aws_acm_notification_canada_ca_arn
   # See https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html#describe-ssl-policies
   # And https://cyber.gc.ca/en/guidance/guidance-securely-configuring-network-protocols-itsp40062
-  ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2019-08"
+  ssl_policy        = "ELBSecurityPolicy-FS-1-1-2019-08"
 
   default_action {
     type             = "forward"


### PR DESCRIPTION
Reworks https://github.com/cds-snc/notification-terraform/pull/246

TLS 1.2 is causing some troubles for some clients, allow old protocols for a few more weeks while they upgrade.