### PR TITLE
feat: adjust alarms for SQS email queue

### DIFF
--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -326,14 +326,15 @@ resource "aws_cloudwatch_metric_alarm" "sqs-throttled-sms-stuck-in-queue-critica
 
 resource "aws_cloudwatch_metric_alarm" "sqs-email-queue-delay-warning" {
   alarm_name          = "sqs-email-queue-delay-warning"
-  alarm_description   = "ApproximateAgeOfOldestMessage in email queue reached 60 seconds"
+  alarm_description   = "ApproximateAgeOfOldestMessage in email queue >= 5 minutes for 5 minutes"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
+  datapoints_to_alarm = "5"
+  evaluation_periods  = "5"
   metric_name         = "ApproximateAgeOfOldestMessage"
   namespace           = "AWS/SQS"
   period              = 60
   statistic           = "Maximum"
-  threshold           = 60
+  threshold           = 60 * 5
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
   dimensions = {
     QueueName = "${var.celery_queue_prefix}send-email-tasks"
@@ -342,9 +343,10 @@ resource "aws_cloudwatch_metric_alarm" "sqs-email-queue-delay-warning" {
 
 resource "aws_cloudwatch_metric_alarm" "sqs-email-queue-delay-critical" {
   alarm_name          = "sqs-email-queue-delay-critical"
-  alarm_description   = "ApproximateAgeOfOldestMessage in email queue reached 10 minutes"
+  alarm_description   = "ApproximateAgeOfOldestMessage in email queue >= 10 minutes for 5 minutes"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
+  datapoints_to_alarm = "5"
+  evaluation_periods  = "5"
   metric_name         = "ApproximateAgeOfOldestMessage"
   namespace           = "AWS/SQS"
   period              = 60


### PR DESCRIPTION
Rework #245

We are not meeting those numbers in staging/production, partly due to the fact that the `ApproximateAgeOfOldestMessage` can jump only when there is a single SQS message that is not visible as we saw recently.

Adjust thresholds for now to have these alarms trigger for no reasons. We'll lileky adjust them again in the future and use other metrics, or a combination of metrics.