### PR TITLE
feat: update healthcheck alarms' unit

### DIFF
--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -401,7 +401,7 @@ resource "aws_cloudwatch_metric_alarm" "healtheck-page-slow-response-warning" {
   namespace           = "NotificationCanadaCa"
   period              = "300"
   statistic           = "Average"
-  threshold           = 1
+  threshold           = 100
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
   treat_missing_data  = "breaching"
   dimensions = {
@@ -418,7 +418,7 @@ resource "aws_cloudwatch_metric_alarm" "healtheck-page-slow-response-critical" {
   namespace           = "NotificationCanadaCa"
   period              = "300"
   statistic           = "Average"
-  threshold           = 2
+  threshold           = 200
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   treat_missing_data  = "breaching"


### PR DESCRIPTION
The value was not reported in milliseconds on StatsD in the past, this PR fixed the bug https://github.com/cds-snc/notification-utils/pull/82#discussion_r625875476 and now this alarm needs to be updated.