### PR TITLE
Disabled IAM auth with RDS proxy connections

### DIFF
--- a/aws/rds/rds_proxy.tf
+++ b/aws/rds/rds_proxy.tf
@@ -33,6 +33,7 @@ module "rds_proxy" {
   version = "~> 2.0"
 
   name                    = "rds-proxy"
+  iam_auth                = "DISABLED"
   iam_role_name           = "rds-proxy-to-secrets-role"
   iam_policy_name         = "rds-proxy-to-secrets-policy"
 
@@ -73,6 +74,9 @@ module "rds_proxy" {
   target_db_cluster     = true
   db_cluster_identifier = aws_rds_cluster.notification-canada-ca.cluster_identifier
 
+  proxy_tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
   }


### PR DESCRIPTION
# Summary | Résumé

The [Terraform plan failed to apply](https://github.com/cds-snc/notification-terraform/runs/3198156545?check_suite_focus=true) with [previous changes to enable RDS proxy connection](https://github.com/cds-snc/notification-terraform/pull/282):

```
Error: Error creating DB Proxy: InvalidParameterValue: Must enable TLS, when IAM Auth is required
	status code: 400, request id: 1216fd06-8200-4795-8035-14b99dad2396
```

By default, [the rds-module](https://registry.terraform.io/modules/clowdhaus/rds-proxy/aws/latest#input_iam_auth) has the IAM authentication enabled along with TLS. This is an ideal we would like to reach but for now, keeping the configuration minimal and considering it's not enabled in production, we will disable it at the moment.

# Terraform Plan

```
Terraform will perform the following actions:

  # aws_rds_cluster.notification-canada-ca will be updated in-place
  ~ resource "aws_rds_cluster" "notification-canada-ca" {
        id                                  = "notification-canada-ca-staging-cluster"
      ~ master_password                     = (sensitive value)
        tags                                = {
            "CostCenter" = "notification-canada-ca-staging"
        }
        # (35 unchanged attributes hidden)
    }

  # aws_secretsmanager_secret_version.database_user must be replaced
-/+ resource "aws_secretsmanager_secret_version" "database_user" {
      ~ arn            = "arn:aws:secretsmanager:ca-central-1:239043911459:secret:postgres-eDOk4f" -> (known after apply)
      ~ id             = "arn:aws:secretsmanager:ca-central-1:239043911459:secret:postgres-eDOk4f|3B2AC1A2-5C2C-4A21-9A74-008CBD70699A" -> (known after apply)
      - secret_binary  = (sensitive value)
      ~ secret_string  = (sensitive value)
      ~ version_id     = "3B2AC1A2-5C2C-4A21-9A74-008CBD70699A" -> (known after apply)
      ~ version_stages = [
          - "AWSCURRENT",
        ] -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.rds_proxy.aws_db_proxy.this[0] will be created
  + resource "aws_db_proxy" "this" {
      + arn                    = (known after apply)
      + debug_logging          = false
      + endpoint               = (known after apply)
      + engine_family          = "POSTGRESQL"
      + id                     = (known after apply)
      + idle_client_timeout    = 600
      + name                   = "rds-proxy"
      + require_tls            = false
      + role_arn               = "arn:aws:iam::239043911459:role/rds-proxy-to-secrets-role"
      + tags                   = {
          + "CostCenter" = "notification-canada-ca-staging"
        }
      + tags_all               = {
          + "CostCenter" = "notification-canada-ca-staging"
        }
      + vpc_security_group_ids = [
          + "sg-0e2c3ef6c5c75b74c",
        ]
      + vpc_subnet_ids         = [
          + "subnet-001e585d12cce4d1e",
          + "subnet-08de34a9e1a7458dc",
          + "subnet-0af8b8402f1d605ff",
        ]

      + auth {
          + auth_scheme = "SECRETS"
          + description = "Database superuser postgres, database connection values"
          + iam_auth    = "DISABLED"
          + secret_arn  = "arn:aws:secretsmanager:ca-central-1:239043911459:secret:postgres-eDOk4f"
        }
    }

  # module.rds_proxy.aws_db_proxy_default_target_group.this[0] will be created
  + resource "aws_db_proxy_default_target_group" "this" {
      + arn           = (known after apply)
      + db_proxy_name = "rds-proxy"
      + id            = (known after apply)
      + name          = (known after apply)

      + connection_pool_config {
          + connection_borrow_timeout    = 120
          + max_connections_percent      = 90
          + max_idle_connections_percent = 50
        }
    }

  # module.rds_proxy.aws_db_proxy_endpoint.this["read_only"] will be created
  + resource "aws_db_proxy_endpoint" "this" {
      + arn                    = (known after apply)
      + db_proxy_endpoint_name = "read-only-endpoint"
      + db_proxy_name          = "rds-proxy"
      + endpoint               = (known after apply)
      + id                     = (known after apply)
      + is_default             = (known after apply)
      + tags                   = {
          + "CostCenter" = "notification-canada-ca-staging"
        }
      + tags_all               = {
          + "CostCenter" = "notification-canada-ca-staging"
        }
      + target_role            = "READ_ONLY"
      + vpc_id                 = (known after apply)
      + vpc_security_group_ids = [
          + "sg-0e2c3ef6c5c75b74c",
        ]
      + vpc_subnet_ids         = [
          + "subnet-001e585d12cce4d1e",
          + "subnet-08de34a9e1a7458dc",
          + "subnet-0af8b8402f1d605ff",
        ]
    }

  # module.rds_proxy.aws_db_proxy_endpoint.this["read_write"] will be created
  + resource "aws_db_proxy_endpoint" "this" {
      + arn                    = (known after apply)
      + db_proxy_endpoint_name = "read-write-endpoint"
      + db_proxy_name          = "rds-proxy"
      + endpoint               = (known after apply)
      + id                     = (known after apply)
      + is_default             = (known after apply)
      + tags                   = {
          + "CostCenter" = "notification-canada-ca-staging"
        }
      + tags_all               = {
          + "CostCenter" = "notification-canada-ca-staging"
        }
      + target_role            = "READ_WRITE"
      + vpc_id                 = (known after apply)
      + vpc_security_group_ids = [
          + "sg-0e2c3ef6c5c75b74c",
        ]
      + vpc_subnet_ids         = [
          + "subnet-001e585d12cce4d1e",
          + "subnet-08de34a9e1a7458dc",
          + "subnet-0af8b8402f1d605ff",
        ]
    }

  # module.rds_proxy.aws_db_proxy_target.db_cluster[0] will be created
  + resource "aws_db_proxy_target" "db_cluster" {
      + db_cluster_identifier = "notification-canada-ca-staging-cluster"
      + db_proxy_name         = "rds-proxy"
      + endpoint              = (known after apply)
      + id                    = (known after apply)
      + port                  = (known after apply)
      + rds_resource_id       = (known after apply)
      + target_arn            = (known after apply)
      + target_group_name     = (known after apply)
      + tracked_cluster_id    = (known after apply)
      + type                  = (known after apply)
    }
```

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Does this meet a user need? | Est-ce que ça répond à un besoin utilisateur?
- [ ] Is it accessible? | Est-ce que c’est accessible?
- [ ] Is it translated between both offical languages? | Est-ce dans les deux
      langues officielles?
- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Should this be split into smaller PRs to decrease change risk? | Est-ce
      que ça devrait être divisé en de plus petites demandes de tirage (« pull
      requests ») afin de réduire le risque lié aux modifications?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
