### PR TITLE
Fix alarm when no data

### DIFF
--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -42,6 +42,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-spending-critical" {
   period              = "300"
   statistic           = "Maximum"
   threshold           = 0.9 * var.sns_monthly_spend_limit
+  treat_missing_data  = "notBreaching"
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
 }

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -29,6 +29,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-spending-us-west-2-warning" {
   period              = "300"
   statistic           = "Maximum"
   threshold           = 0.8 * var.sns_monthly_spend_limit_us_west_2
+  treat_missing_data  = "notBreaching"
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning-us-west-2.arn]
 }
 


### PR DESCRIPTION
# Summary | Résumé

At the beginning of the month, the data on each alarm resets. Until the service does work, no data gets collected. This triggers a false alarm in our slack channels. We want this alarm to not page us if there isn't enough data, this PR does that. 

https://trello.com/c/rn2qi3dq/686-make-sure-sns-spending-alarms-handle-missing-states

# Test instructions | Instructions pour tester la modification
- Unsure how to test this in staging.
