### PR TITLE
Api lambda concurrency

### DIFF
--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -60,8 +60,8 @@ resource "aws_lambda_permission" "api_1" {
   source_arn    = "${aws_api_gateway_rest_api.api.execution_arn}/*/*"
 }
 
-# resource "aws_lambda_provisioned_concurrency_config" "api" {
-#   function_name                     = aws_lambda_function.api.function_name
-#   provisioned_concurrent_executions = 2
-#   qualifier                         = aws_lambda_function.api.version
-# }
+resource "aws_lambda_provisioned_concurrency_config" "api" {
+  function_name                     = aws_lambda_function.api.function_name
+  provisioned_concurrent_executions = 1
+  qualifier                         = aws_lambda_function.api.version
+}


### PR DESCRIPTION
# Summary | Résumé

Add provisioned concurrency and autoscaling to the lamba api.

This means that AWS will warm up an extra lambda when we are using 70% of the lambdas already warmed up.

# Test instructions | Instructions pour tester la modification

# Help requested | Aide requise

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Does this meet a user need? | Est-ce que ça répond à un besoin utilisateur?
- [ ] Is it accessible? | Est-ce que c’est accessible?
- [ ] Is it translated between both offical languages? | Est-ce dans les deux
      langues officielles?
- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Should this be split into smaller PRs to decrease change risk? | Est-ce
      que ça devrait être divisé en de plus petites demandes de tirage (« pull
      requests ») afin de réduire le risque lié aux modifications?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
