### PR TITLE
change concurrency based on schedule

### DIFF
--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -80,7 +80,8 @@ resource "aws_appautoscaling_scheduled_action" "api-noon" {
   service_namespace  = aws_appautoscaling_target.api.service_namespace
   resource_id        = aws_appautoscaling_target.api.resource_id
   scalable_dimension = aws_appautoscaling_target.api.scalable_dimension
-  schedule           = "cron(0 16 * * ? *)"
+  schedule           = "cron(0 12 * * ? *)"
+  timezone           = "America/Toronto"
   scalable_target_action {
     min_capacity = 2
     max_capacity = 10
@@ -92,7 +93,8 @@ resource "aws_appautoscaling_scheduled_action" "api-5pm" {
   service_namespace  = aws_appautoscaling_target.api.service_namespace
   resource_id        = aws_appautoscaling_target.api.resource_id
   scalable_dimension = aws_appautoscaling_target.api.scalable_dimension
-  schedule           = "cron(0 21 * * ? *)"
+  schedule           = "cron(0 17 * * ? *)"
+  timezone           = "America/Toronto"
   scalable_target_action {
     min_capacity = 1
     max_capacity = 5


### PR DESCRIPTION
# Summary | Résumé

https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/cds-snc/notification-planning/37

Use a time based schedule for the concurrency rather than usage based.

Tested by setting cron job to go off in a few minutes then watching the provisioned concurrency change.

# Test instructions | Instructions pour tester la modification

Basically as mentioned above, 
- change the cron job to go off soon (and maybe increase the `min_capacity` so the change will be noticeable)
- paste the staging env vars from https://cds-snc.awsapps.com/start#/ into your terminal
- run `terragrunt apply` in the `env/staging/lambda-api` directory
- wait for the time specified in the cron job to pass
- observe the change in the "Provisioned concurrency" column in the [lambda configuration](https://ca-central-1.console.aws.amazon.com/lambda/home?region=ca-central-1#/functions/api-staging?tab=configure)


# Help requested | Aide requise


# Unresolved questions / Out of scope | Questions non résolues ou hors sujet


# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Does this meet a user need? | Est-ce que ça répond à un besoin utilisateur?
- [ ] Is it accessible? | Est-ce que c’est accessible?
- [ ] Is it translated between both offical languages? | Est-ce dans les deux
      langues officielles?
- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Should this be split into smaller PRs to decrease change risk? | Est-ce
      que ça devrait être divisé en de plus petites demandes de tirage (« pull
      requests ») afin de réduire le risque lié aux modifications?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
