### PR TITLE
HOT-FIX: Replace timestamp() to "2012-10-17"

### DIFF
--- a/aws/performance-test/lambda.tf
+++ b/aws/performance-test/lambda.tf
@@ -63,7 +63,7 @@ resource "aws_iam_role" "performance-test" {
   # Terraform's "jsonencode" function converts a
   # Terraform expression result to valid JSON syntax.
   assume_role_policy = jsonencode({
-    Version = timestamp()
+    Version = "2012-10-17"
     Statement = [
       {
         Action = "sts:AssumeRole"


### PR DESCRIPTION
# Summary | Résumé

This HOT-FIX seeks to replace timestamp() with "2012-10-17", this
should fix this error [1]

[1] https://github.com/cds-snc/notification-terraform/runs/4071306016?check_suite_focus=true#step:15:80
