### PR TITLE
bug/security group protocol

### DIFF
--- a/aws/performance-test/security_group.tf
+++ b/aws/performance-test/security_group.tf
@@ -6,7 +6,7 @@ resource "aws_security_group" "perf_test" {
   egress {
     from_port = 443
     to_port   = 443
-    protocol  = "-1"
+    protocol  = "tcp"
     # We need to connect to the staging api server (not managed in terraform)
     # tfsec:ignore:AWS009
     cidr_blocks = ["0.0.0.0/0"]


### PR DESCRIPTION
# Summary | Résumé

new performance test code failing with

```
Error: error updating Security Group (sg-0f636727d5ce88f8b): from_port (443) and to_port (443) must both be 0 to use the 'ALL' "-1" protocol!
```

Looks like need to restrict to `tcp`:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group


# Test instructions | Instructions pour tester la modification

I ran `terraform apply` on the following in a scratch account and it created the vpc and security group.
```
terraform {
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "~> 3.0"
    }
  }
}

provider "aws" {
  profile = "default"
  region  = "ca-central-1"
}

resource "aws_vpc" "main" {
  cidr_block = "10.0.0.0/16"
}

resource "aws_security_group" "perf_test" {
  name        = "perf_test"
  description = "Performance Test Security Group"
  vpc_id      = aws_vpc.main.id

  egress {
    from_port = 443
    to_port   = 443
    protocol  = "tcp"
    # We need to connect to the staging api server (not managed in terraform)
    # tfsec:ignore:AWS009
    cidr_blocks = ["0.0.0.0/0"]
  }
}
```

# Help requested | Aide requise

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet


# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Does this meet a user need? | Est-ce que ça répond à un besoin utilisateur?
- [ ] Is it accessible? | Est-ce que c’est accessible?
- [ ] Is it translated between both offical languages? | Est-ce dans les deux
      langues officielles?
- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Should this be split into smaller PRs to decrease change risk? | Est-ce
      que ça devrait être divisé en de plus petites demandes de tirage (« pull
      requests ») afin de réduire le risque lié aux modifications?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
