### PR TITLE
bug/set a value for container cpu

### DIFF
--- a/aws/performance-test/container_definitions/perf_test.json.tmpl
+++ b/aws/performance-test/container_definitions/perf_test.json.tmpl
@@ -19,6 +19,7 @@
     "essential": true,
     "name": "performance-tests-container",
     "image": "${ECR_REPOSITORY_URL}",
+    "cpu": 0,
     
     "environment": [
       {


### PR DESCRIPTION
# Summary | Résumé

`terragrunt apply` error
```
Error: ClientException: Invalid 'cpu' setting for task. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide.

  on ecs.tf line 58, in resource "aws_ecs_task_definition" "perf_test_task":
  58: resource "aws_ecs_task_definition" "perf_test_task" {
```

Turns out Fargate clusters need an explicit value for `cpu`.
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition
> cpu - (Optional) Number of cpu units used by the task. If the requires_compatibilities is FARGATE this field is required.

The click-through one
https://ca-central-1.console.aws.amazon.com/ecs/v2/task-definitions/perf-tests/12/json?region=ca-central-1 
uses `"cpu": 0,` so let's try that too. 🤷 

# Test instructions | Instructions pour tester la modification


# Help requested | Aide requise


# Unresolved questions / Out of scope | Questions non résolues ou hors sujet


# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Does this meet a user need? | Est-ce que ça répond à un besoin utilisateur?
- [ ] Is it accessible? | Est-ce que c’est accessible?
- [ ] Is it translated between both offical languages? | Est-ce dans les deux
      langues officielles?
- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Should this be split into smaller PRs to decrease change risk? | Est-ce
      que ça devrait être divisé en de plus petites demandes de tirage (« pull
      requests ») afin de réduire le risque lié aux modifications?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
