### PR TITLE
Fix cronschedule

### DIFF
--- a/env/production/heartbeat/terragrunt.hcl
+++ b/env/production/heartbeat/terragrunt.hcl
@@ -4,7 +4,7 @@ include {
 
 inputs = {
   billing_tag_value                           = "notification-canada-ca-production"
-  schedule_expression                         = "cron(*/1 * * * *)"
+  schedule_expression                         = "cron(* * * * ? *)"
 }
 
 terraform {

--- a/env/staging/heartbeat/terragrunt.hcl
+++ b/env/staging/heartbeat/terragrunt.hcl
@@ -4,7 +4,7 @@ include {
 
 inputs = {
   billing_tag_value                           = "notification-canada-ca-staging"
-  schedule_expression                         = "cron(*/1 * * * *)"
+  schedule_expression                         = "cron(* * * * ? *)"
 }
 
 terraform {


### PR DESCRIPTION
# Summary | Résumé

Cron schedule needs to have 6 entries.

Fixing this:
```Error: error creating EventBridge Rule (heartbeat_testing): ValidationException: Parameter ScheduleExpression is not valid.
	status code: 400, request id: dc4dde28-28ad-4fd0-aff0-4bf65f5b4348

  on lambda.tf line 23, in resource "aws_cloudwatch_event_rule" "heartbeat_testing":
  23: resource "aws_cloudwatch_event_rule" "heartbeat_testing" {


Releasing state lock. This may take a few moments...
[terragrunt] 2021/12/08 19:16:36 Hit multiple errors:
exit status 1
Error: Process completed with exit code 1.```