### PR TITLE
fix: WAF block based on inputs and IP reputation

### DIFF
--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -13,7 +13,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 1
 
     override_action {
-      count {}
+      none {}
     }
 
     statement {
@@ -57,7 +57,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 3
 
     override_action {
-      count {}
+      none {}
     }
 
     statement {


### PR DESCRIPTION
# Summary
Enable request blocking based on requests that have known bad input
(e.g. the Log4j exploit) or are from IP addresses with a poor
reputation score.

A subsequent PR will be created to enable logging so we can determine
which additional AWS managed rules can be set to block as well.

# Related
* cds-snc/platform-sre-security-support#75