### PR TITLE
feat: add WAF Bot control managed rules

### DIFF
--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -119,6 +119,28 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
   }
 
   rule {
+    name     = "AWSManagedRulesBotControlRuleSet"
+    priority = 6
+
+    override_action {
+      count {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesBotControlRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesBotControlRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
     name     = "document_download_invalid_path"
     priority = 10
 


### PR DESCRIPTION
# Summary
Add AWS's Bot control managed rules to the EKS WAF ACL.  These will
be initially set to `count` to determine impact, and then switched over
to `block`.

# Related
* cds-snc/platform-sre-security-support#75