### PR TITLE
change platform-admin-looking-at-sensitive-service metric

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -327,3 +327,17 @@ resource "aws_cloudwatch_metric_alarm" "platform-admin-looking-at-sensitive-serv
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_warning_arn]
 }
+
+resource "aws_cloudwatch_metric_alarm" "platform-admin-looking-at-sensitive-service-warning-new" {
+  alarm_name          = "platform-admin-looking-at-sensitive-service-warning-new"
+  alarm_description   = "A platform admin is looking at a sensitive service on the admin (new)"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.platform-admin-looking-at-sensitive-service-new.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.platform-admin-looking-at-sensitive-service-new.metric_transformation[0].namespace
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [var.sns_alert_warning_arn]
+}

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -38,11 +38,26 @@ resource "aws_cloudwatch_log_metric_filter" "platform-admin-looking-at-sensitive
 
   name = "platform-admin-looking-at-sensitive-service"
   # The UUIDv4 is a Notify service ID we are interested in
-  pattern        = "\"Sensitive Admin API request\""
+  pattern        = "\"Admin API request\" \"432cb269-7c85-4e38-8e42-3828ec7e5799\""
   log_group_name = local.eks_application_log_group
 
   metric_transformation {
     name          = "platform-admin-looking-at-sensitive-service"
+    namespace     = "LogMetrics"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "platform-admin-looking-at-sensitive-service-new" {
+
+  name = "platform-admin-looking-at-sensitive-service-new"
+  # The UUIDv4 is a Notify service ID we are interested in
+  pattern        = "\"Sensitive Admin API request\""
+  log_group_name = local.eks_application_log_group
+
+  metric_transformation {
+    name          = "platform-admin-looking-at-sensitive-service-new"
     namespace     = "LogMetrics"
     value         = "1"
     default_value = "0"

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -38,7 +38,7 @@ resource "aws_cloudwatch_log_metric_filter" "platform-admin-looking-at-sensitive
 
   name = "platform-admin-looking-at-sensitive-service"
   # The UUIDv4 is a Notify service ID we are interested in
-  pattern        = "\"Admin API request\" \"432cb269-7c85-4e38-8e42-3828ec7e5799\""
+  pattern        = "\"Sensitive Admin API request\""
   log_group_name = local.eks_application_log_group
 
   metric_transformation {


### PR DESCRIPTION
# Summary | Résumé

Changing the way we alert on viewing sensitive services. Admin will now mark it in the logs (see https://github.com/cds-snc/notification-admin/pull/1205)

Figured I'd leave the old metric / alarm here. This way we can release this code without trying to do the admin release at the same time. After all is good we can go back and delete the old alarm / metric (and maybe get rid of all the "new"'s in the new alarm).
