### PR TITLE
Double threshold for carrier error alert

### DIFF
--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -203,7 +203,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-phone-carrier-unavailable-us-wes
   namespace           = aws_cloudwatch_log_metric_filter.sns-sms-phone-carrier-unavailable-us-west-2.metric_transformation[0].namespace
   period              = 60 * 60 * 3
   statistic           = "Sum"
-  threshold           = 20
+  threshold           = 100
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning-us-west-2.arn]
   treat_missing_data  = "notBreaching"
 }

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -180,14 +180,14 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-blocked-as-spam-us-west-2-warnin
 
 resource "aws_cloudwatch_metric_alarm" "sns-sms-phone-carrier-unavailable-warning" {
   alarm_name          = "sns-sms-phone-carrier-unavailable-warning"
-  alarm_description   = "More than 20 SMS failed because a phone carrier is unavailable over 6 hours"
+  alarm_description   = "More than 100 SMS failed because a phone carrier is unavailable over 3 hours"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = aws_cloudwatch_log_metric_filter.sns-sms-phone-carrier-unavailable.metric_transformation[0].name
   namespace           = aws_cloudwatch_log_metric_filter.sns-sms-phone-carrier-unavailable.metric_transformation[0].namespace
-  period              = 60 * 60 * 6
+  period              = 60 * 60 * 3
   statistic           = "Sum"
-  threshold           = 20
+  threshold           = 100
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
   treat_missing_data  = "notBreaching"
 }
@@ -196,12 +196,12 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-phone-carrier-unavailable-us-wes
   provider = aws.us-west-2
 
   alarm_name          = "sns-sms-phone-carrier-unavailable-us-west-2-warning"
-  alarm_description   = "More than 20 SMS failed because a phone carrier is unavailable over 6 hours"
+  alarm_description   = "More than 100 SMS failed because a phone carrier is unavailable over 3 hours"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = aws_cloudwatch_log_metric_filter.sns-sms-phone-carrier-unavailable-us-west-2.metric_transformation[0].name
   namespace           = aws_cloudwatch_log_metric_filter.sns-sms-phone-carrier-unavailable-us-west-2.metric_transformation[0].namespace
-  period              = 60 * 60 * 6
+  period              = 60 * 60 * 3
   statistic           = "Sum"
   threshold           = 20
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning-us-west-2.arn]

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -180,14 +180,14 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-blocked-as-spam-us-west-2-warnin
 
 resource "aws_cloudwatch_metric_alarm" "sns-sms-phone-carrier-unavailable-warning" {
   alarm_name          = "sns-sms-phone-carrier-unavailable-warning"
-  alarm_description   = "More than 10 SMS failed because a phone carrier is unavailable over 6 hours"
+  alarm_description   = "More than 20 SMS failed because a phone carrier is unavailable over 6 hours"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = aws_cloudwatch_log_metric_filter.sns-sms-phone-carrier-unavailable.metric_transformation[0].name
   namespace           = aws_cloudwatch_log_metric_filter.sns-sms-phone-carrier-unavailable.metric_transformation[0].namespace
   period              = 60 * 60 * 6
   statistic           = "Sum"
-  threshold           = 10
+  threshold           = 20
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
   treat_missing_data  = "notBreaching"
 }
@@ -196,14 +196,14 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-phone-carrier-unavailable-us-wes
   provider = aws.us-west-2
 
   alarm_name          = "sns-sms-phone-carrier-unavailable-us-west-2-warning"
-  alarm_description   = "More than 10 SMS failed because a phone carrier is unavailable over 6 hours"
+  alarm_description   = "More than 20 SMS failed because a phone carrier is unavailable over 6 hours"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = aws_cloudwatch_log_metric_filter.sns-sms-phone-carrier-unavailable-us-west-2.metric_transformation[0].name
   namespace           = aws_cloudwatch_log_metric_filter.sns-sms-phone-carrier-unavailable-us-west-2.metric_transformation[0].namespace
   period              = 60 * 60 * 6
   statistic           = "Sum"
-  threshold           = 10
+  threshold           = 20
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning-us-west-2.arn]
   treat_missing_data  = "notBreaching"
 }


### PR DESCRIPTION
# Summary | Résumé

Doubled the threshold for carrier error from 10 to 20. Let's see how that reduce the noise and readjust if need be.

