### PR TITLE
Added queue alarms around database tasks

### DIFF
--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -445,6 +445,39 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-throttled-sms-tasks-receive-rat
   }
 }
 
+resource "aws_cloudwatch_metric_alarm" "sqs-db-tasks-stuck-in-queue-warning" {
+  alarm_name          = "sqs-db-tasks-stuck-in-queue-warning"
+  alarm_description   = "ApproximateAgeOfOldestMessage in DB tasks queue is older than 1 minute in a 5-minute period"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "ApproximateAgeOfOldestMessage"
+  namespace           = "AWS/SQS"
+  period              = 60 * 5
+  statistic           = "Average"
+  threshold           = 60
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
+  dimensions = {
+    QueueName = "${var.celery_queue_prefix}${var.sqs_db_tasks_queue_name}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "sqs-db-tasks-stuck-in-queue-critical" {
+  alarm_name          = "sqs-db-tasks-stuck-in-queue-critical"
+  alarm_description   = "ApproximateAgeOfOldestMessage in DB tasks queue is older than 1 minute for 10 minutes"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "10"
+  metric_name         = "ApproximateAgeOfOldestMessage"
+  namespace           = "AWS/SQS"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 60
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
+  ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
+  dimensions = {
+    QueueName = "${var.celery_queue_prefix}${var.sqs_db_tasks_queue_name}"
+  }
+}
+
 resource "aws_cloudwatch_metric_alarm" "healtheck-page-slow-response-warning" {
   alarm_name          = "healtheck-page-slow-response-warning"
   alarm_description   = "Healthcheck page response time is above 100ms for 10 minutes"

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -453,7 +453,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-db-tasks-stuck-in-queue-warning" {
   metric_name         = "ApproximateAgeOfOldestMessage"
   namespace           = "AWS/SQS"
   period              = 60 * 5
-  statistic           = "Average"
+  statistic           = "Maximum"
   threshold           = 60
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
   dimensions = {
@@ -469,8 +469,8 @@ resource "aws_cloudwatch_metric_alarm" "sqs-db-tasks-stuck-in-queue-critical" {
   metric_name         = "ApproximateAgeOfOldestMessage"
   namespace           = "AWS/SQS"
   period              = 60
-  statistic           = "Average"
-  threshold           = 60
+  statistic           = "Maximum"
+  threshold           = 60 * 10
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   dimensions = {

--- a/aws/common/variables.tf
+++ b/aws/common/variables.tf
@@ -60,6 +60,13 @@ variable "sqs_throttled_sms_queue_name" {
   default = "send-throttled-sms-tasks"
 }
 
+variable "sqs_db_tasks_queue_name" {
+  type = string
+  # See QueueNames in
+  # https://github.com/cds-snc/notification-api/blob/master/app/config.py
+  default = "database-tasks"
+}
+
 variable "alarm_warning_document_download_bucket_size_gb" {
   type = number
 }


### PR DESCRIPTION
# Summary | Résumé

Added an alert around the db tasks operations, including saving ones.

# Test instructions | Instructions pour tester la modification

Let's push to staging environment and see if the alert works correctly.
