### PR TITLE
Removed alert around admin looking at sensitive services

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -313,31 +313,3 @@ resource "aws_cloudwatch_metric_alarm" "ddos-detected-load-balancer-critical" {
     ResourceArn = aws_shield_protection.notification-canada-ca.resource_arn
   }
 }
-
-resource "aws_cloudwatch_metric_alarm" "platform-admin-looking-at-sensitive-service-warning" {
-  alarm_name          = "platform-admin-looking-at-sensitive-service-warning"
-  alarm_description   = "A platform admin is looking at a sensitive service on the admin"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.platform-admin-looking-at-sensitive-service.metric_transformation[0].name
-  namespace           = aws_cloudwatch_log_metric_filter.platform-admin-looking-at-sensitive-service.metric_transformation[0].namespace
-  period              = "60"
-  statistic           = "Sum"
-  threshold           = 1
-  treat_missing_data  = "notBreaching"
-  alarm_actions       = [var.sns_alert_warning_arn]
-}
-
-resource "aws_cloudwatch_metric_alarm" "platform-admin-looking-at-sensitive-service-warning-new" {
-  alarm_name          = "platform-admin-looking-at-sensitive-service-warning-new"
-  alarm_description   = "A platform admin is looking at a sensitive service on the admin (new)"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.platform-admin-looking-at-sensitive-service-new.metric_transformation[0].name
-  namespace           = aws_cloudwatch_log_metric_filter.platform-admin-looking-at-sensitive-service-new.metric_transformation[0].namespace
-  period              = "60"
-  statistic           = "Sum"
-  threshold           = 1
-  treat_missing_data  = "notBreaching"
-  alarm_actions       = [var.sns_alert_warning_arn]
-}

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -33,33 +33,3 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error" {
     value     = "1"
   }
 }
-
-resource "aws_cloudwatch_log_metric_filter" "platform-admin-looking-at-sensitive-service" {
-
-  name = "platform-admin-looking-at-sensitive-service"
-  # The UUIDv4 is a Notify service ID we are interested in
-  pattern        = "\"Admin API request\" \"432cb269-7c85-4e38-8e42-3828ec7e5799\""
-  log_group_name = local.eks_application_log_group
-
-  metric_transformation {
-    name          = "platform-admin-looking-at-sensitive-service"
-    namespace     = "LogMetrics"
-    value         = "1"
-    default_value = "0"
-  }
-}
-
-resource "aws_cloudwatch_log_metric_filter" "platform-admin-looking-at-sensitive-service-new" {
-
-  name = "platform-admin-looking-at-sensitive-service-new"
-  # The UUIDv4 is a Notify service ID we are interested in
-  pattern        = "\"Sensitive Admin API request\""
-  log_group_name = local.eks_application_log_group
-
-  metric_transformation {
-    name          = "platform-admin-looking-at-sensitive-service-new"
-    namespace     = "LogMetrics"
-    value         = "1"
-    default_value = "0"
-  }
-}


### PR DESCRIPTION
# Summary | Résumé

Due to the sheer amount of alerts we get and how these alerts are not actionables for now, we decided to remove the alerts around admins looking at sensitive services. The important part for us is to log it so that we can trace it back if necessary.

[A new Zenhub card was created](https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/cds-snc/notification-planning/325) to surface this information in a more effective way.

# Test instructions | Instructions pour tester la modification

We'll know soon enough if that works or not. 😅 
