### PR TITLE
Reduce noise on the database-tasks critical alert 

### DIFF
--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -447,14 +447,14 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-throttled-sms-tasks-receive-rat
 
 resource "aws_cloudwatch_metric_alarm" "sqs-db-tasks-stuck-in-queue-warning" {
   alarm_name          = "sqs-db-tasks-stuck-in-queue-warning"
-  alarm_description   = "ApproximateAgeOfOldestMessage in DB tasks queue is older than 1 minute in a 5-minute period"
+  alarm_description   = "ApproximateAgeOfOldestMessage in DB tasks queue is older than 5 minutes in a 1-minute period"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = "ApproximateAgeOfOldestMessage"
   namespace           = "AWS/SQS"
-  period              = 60 * 5
+  period              = 60
   statistic           = "Maximum"
-  threshold           = 60
+  threshold           = 60 * 5
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
   dimensions = {
     QueueName = "${var.celery_queue_prefix}${var.sqs_db_tasks_queue_name}"

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -463,14 +463,14 @@ resource "aws_cloudwatch_metric_alarm" "sqs-db-tasks-stuck-in-queue-warning" {
 
 resource "aws_cloudwatch_metric_alarm" "sqs-db-tasks-stuck-in-queue-critical" {
   alarm_name          = "sqs-db-tasks-stuck-in-queue-critical"
-  alarm_description   = "ApproximateAgeOfOldestMessage in DB tasks queue is older than 1 minute for 10 minutes"
+  alarm_description   = "ApproximateAgeOfOldestMessage in DB tasks queue is older than 15 minute for 1 minute"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "10"
+  evaluation_periods  = "15"
   metric_name         = "ApproximateAgeOfOldestMessage"
   namespace           = "AWS/SQS"
   period              = 60
   statistic           = "Maximum"
-  threshold           = 60 * 10
+  threshold           = 60 * 15
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   ok_actions          = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   dimensions = {


### PR DESCRIPTION
# Summary | Résumé

We currently have the database-tasks queue being the bottleneck and its related critical alert easily gets triggered as we are not operating under Notify's SLOs. We are working to improve this but in the meantime, we will modify the alert to level with current Notify's performance expectations.

