### PR TITLE
turn on FF_NOTIFICATION_CELERY_PERSISTENCE in lambda

### DIFF
--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -48,6 +48,7 @@ resource "aws_lambda_function" "api" {
       SQLALCHEMY_DATABASE_URI               = var.sqlalchemy_database_uri
       SQLALCHEMY_POOL_SIZE                  = var.sqlalchemy_pool_size
       DOCUMENT_DOWNLOAD_API_HOST            = var.document_download_api_host
+      FF_NOTIFICATION_CELERY_PERSISTENCE    = "1"
     }
   }
 


### PR DESCRIPTION
# Summary | Résumé

api lambda was missing `FF_NOTIFICATION_CELERY_PERSISTENCE` in both staging and prod.


