### PR TITLE
Block requests identified in the linux rule group

### DIFF
--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -78,10 +78,6 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     name     = "AWSManagedRulesLinuxRuleSet"
     priority = 4
 
-    override_action {
-      block {}
-    }
-
     statement {
       managed_rule_group_statement {
         name        = "AWSManagedRulesLinuxRuleSet"

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -35,7 +35,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 2
 
     override_action {
-      block {}
+      count {}
     }
 
     statement {
@@ -79,7 +79,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 4
 
     override_action {
-      count {}
+      block {}
     }
 
     statement {

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -35,7 +35,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 2
 
     override_action {
-      count {}
+      block {}
     }
 
     statement {


### PR DESCRIPTION
# Summary | Résumé

We got a surge of PHP and github scans in the last week, increasing our suppor time. After a review of last week requests made and how it AWS WAF ACL rules would block or not these requests, it seems quite a fit for us to catch a break.

