### PR TITLE
Block requests matching AWSManagedRulesLinuxRuleSet on lambda-api

### DIFF
--- a/aws/lambda-api/waf.tf
+++ b/aws/lambda-api/waf.tf
@@ -79,7 +79,7 @@ resource "aws_wafv2_web_acl" "api_lambda" {
     priority = 4
 
     override_action {
-      count {}
+      none {}
     }
 
     statement {


### PR DESCRIPTION
# Summary | Résumé

Added WAF ACL rule on lambda API to block requests matching AWSManagedRulesLinuxRuleSet. This replicates changes [performed in this PR](https://github.com/cds-snc/notification-terraform/pull/381).

# Test instructions | Instructions pour tester la modification

* Emulating a scan request for a php admin console should work for recent AWS ACL changes such as `GET /wp-login.php`.