### PR TITLE
feat: post Slack message if Terraform apply fails

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -124,3 +124,9 @@ jobs:
         run: |
           cd env/production/heartbeat
           ../../../bin/terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Slack message on failure
+        if: ${{ failure() }}
+        run: |
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":elmo_fire: Terraform apply failed: <https://github.com/cds-snc/notification-terraform/actions/workflows/merge_to_main_production.yml|Merge to main (Production)>"}}]}'
+          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.NOTIFY_DEV_SLACK_WEBHOOK }}          

--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -128,5 +128,5 @@ jobs:
       - name: Slack message on failure
         if: ${{ failure() }}
         run: |
-          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":elmo_fire: Terraform apply failed: <https://github.com/cds-snc/notification-terraform/actions/workflows/merge_to_main_production.yml|Merge to main (Production)>"}}]}'
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Terraform apply failed: <https://github.com/cds-snc/notification-terraform/actions/workflows/merge_to_main_production.yml|Merge to main (Production)>"}}]}'
           curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.NOTIFY_DEV_SLACK_WEBHOOK }}          

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -142,5 +142,5 @@ jobs:
       - name: Slack message on failure
         if: ${{ failure() }}
         run: |
-          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":elmo_fire: Terraform apply failed: <https://github.com/cds-snc/notification-terraform/actions/workflows/merge_to_main_staging.yml|Merge to main (Staging)>"}}]}'
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Terraform apply failed: <https://github.com/cds-snc/notification-terraform/actions/workflows/merge_to_main_staging.yml|Merge to main (Staging)>"}}]}'
           curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.NOTIFY_DEV_SLACK_WEBHOOK }}          

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -138,3 +138,9 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           release_branches: main
+
+      - name: Slack message on failure
+        if: ${{ failure() }}
+        run: |
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":elmo_fire: Terraform apply failed: <https://github.com/cds-snc/notification-terraform/actions/workflows/merge_to_main_staging.yml|Merge to main (Staging)>"}}]}'
+          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.NOTIFY_DEV_SLACK_WEBHOOK }}          


### PR DESCRIPTION
# Summary
Message will be posted to the Notify DEV channel:
![image](https://user-images.githubusercontent.com/2110107/154368940-0381173c-ece9-47d7-8e88-1b4fc5f8ab58.png)


This is a stop-gap until we've had time to update the Terraform provider to fix the issues with creating and updating resources like the WAF ACL and Lambda API function.

# Related
* cds-snc/notification-planning#411