### PR TITLE
fix: FF_NOTIFICATION_CELERY_PERSISTENCE to "True"

### DIFF
--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -50,7 +50,7 @@ resource "aws_lambda_function" "api" {
       SQLALCHEMY_DATABASE_URI               = var.sqlalchemy_database_uri
       SQLALCHEMY_POOL_SIZE                  = var.sqlalchemy_pool_size
       DOCUMENT_DOWNLOAD_API_HOST            = var.document_download_api_host
-      FF_NOTIFICATION_CELERY_PERSISTENCE    = "1"
+      FF_NOTIFICATION_CELERY_PERSISTENCE    = "True"
     }
   }
 


### PR DESCRIPTION
# Summary
With the API change in how strings are parsed to booleans the feature flag
value needs to be updated to a recognized `True` string value.

# Related
* cds-snc/notification-api#1474