### PR TITLE
feat: cloudwatch embedded metrics feature flag and log group

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -19,6 +19,7 @@ env:
   TERRAGRUNT_VERSION: 0.35.13
   TF_VAR_ff_batch_insertion: ${{ secrets.PRODUCTION_FF_BATCH_INSERTION }}
   TF_VAR_ff_redis_batch_saving: ${{ secrets.PRODUCTION_FF_REDIS_BATCH_SAVING }}
+  TF_VAR_ff_cloudwatch_metrics_enabled: ${{ secrets.PRODUCTION_FF_CLOUDWATCH_METRICS_ENABLED }}
   TF_VAR_heartbeat_api_key: ${{ secrets.PRODUCTION_HEARTBEAT_API_KEY }}
   TF_VAR_heartbeat_base_url: ${{ secrets.PRODUCTION_HEARTBEAT_BASE_URL }}
   TF_VAR_heartbeat_template_id: ${{ secrets.PRODUCTION_HEARTBEAT_TEMPLATE_ID }}

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -22,6 +22,7 @@ env:
   TERRAGRUNT_VERSION: 0.35.13
   TF_VAR_ff_batch_insertion: ${{ secrets.STAGING_FF_BATCH_INSERTION }}
   TF_VAR_ff_redis_batch_saving: ${{ secrets.STAGING_FF_REDIS_BATCH_SAVING }}
+  TF_VAR_ff_cloudwatch_metrics_enabled: ${{ secrets.STAGING_FF_CLOUDWATCH_METRICS_ENABLED }}
   TF_VAR_heartbeat_api_key: ${{ secrets.STAGING_HEARTBEAT_API_KEY }}
   TF_VAR_heartbeat_base_url: ${{ secrets.STAGING_HEARTBEAT_BASE_URL }}
   TF_VAR_heartbeat_template_id: ${{ secrets.STAGING_HEARTBEAT_TEMPLATE_ID }}

--- a/.github/workflows/terragrunt_plan_production.yml
+++ b/.github/workflows/terragrunt_plan_production.yml
@@ -14,6 +14,7 @@ env:
   TERRAGRUNT_VERSION: 0.35.13
   TF_VAR_ff_batch_insertion: ${{ secrets.PRODUCTION_FF_BATCH_INSERTION }}
   TF_VAR_ff_redis_batch_saving: ${{ secrets.PRODUCTION_FF_REDIS_BATCH_SAVING }}
+  TF_VAR_ff_cloudwatch_metrics_enabled: ${{ secrets.PRODUCTION_FF_CLOUDWATCH_METRICS_ENABLED }}
   TF_VAR_heartbeat_api_key: ${{ secrets.PRODUCTION_HEARTBEAT_API_KEY }}
   TF_VAR_heartbeat_base_url: ${{ secrets.PRODUCTION_HEARTBEAT_BASE_URL }}
   TF_VAR_heartbeat_template_id: ${{ secrets.PRODUCTION_HEARTBEAT_TEMPLATE_ID }}

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -18,6 +18,7 @@ env:
   TERRAGRUNT_VERSION: 0.35.13
   TF_VAR_ff_batch_insertion: ${{ secrets.STAGING_FF_BATCH_INSERTION }}
   TF_VAR_ff_redis_batch_saving: ${{ secrets.STAGING_FF_REDIS_BATCH_SAVING }}
+  TF_VAR_ff_cloudwatch_metrics_enabled: ${{ secrets.STAGING_FF_CLOUDWATCH_METRICS_ENABLED }}
   TF_VAR_heartbeat_api_key: ${{ secrets.STAGING_HEARTBEAT_API_KEY }}
   TF_VAR_heartbeat_base_url: ${{ secrets.STAGING_HEARTBEAT_BASE_URL }}
   TF_VAR_heartbeat_template_id: ${{ secrets.STAGING_HEARTBEAT_TEMPLATE_ID }}

--- a/aws/common/cloudwatch_log.tf
+++ b/aws/common/cloudwatch_log.tf
@@ -59,6 +59,15 @@ resource "aws_cloudwatch_log_group" "route53_resolver_query_log" {
   }
 }
 
+resource "aws_cloudwatch_log_group" "batch_saving_emf_logs" {
+  name              = "BatchSaving"
+  retention_in_days = 7
+  tags = {
+    CostCenter  = "notification-canada-ca-${var.env}"
+    Environment = var.env
+  }
+}
+
 ###
 # AWS CloudWatch Logs Metrics
 ###

--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -51,6 +51,7 @@ resource "aws_lambda_function" "api" {
       SQLALCHEMY_POOL_SIZE                  = var.sqlalchemy_pool_size
       DOCUMENT_DOWNLOAD_API_HOST            = var.document_download_api_host
       FF_NOTIFICATION_CELERY_PERSISTENCE    = "True"
+      FF_CLOUDWATCH_METRICS_ENABLED         = var.ff_cloudwatch_metrics_enabled
     }
   }
 

--- a/aws/lambda-api/variables.tf
+++ b/aws/lambda-api/variables.tf
@@ -156,3 +156,7 @@ variable "ff_batch_insertion" {
 variable "ff_redis_batch_saving" {
   type = bool
 }
+
+variable "ff_cloudwatch_metrics_enabled" {
+  type = bool
+}


### PR DESCRIPTION
Ensure that the batch saving log group is created so that a retention period of 7 days is set instead of the default. This also introduces the feature flag that can be used to toggle metrics on/off.

Related: cds-snc/notification-manifests#948