### PR TITLE
fix: log group is created automatically

### DIFF
--- a/aws/common/cloudwatch_log.tf
+++ b/aws/common/cloudwatch_log.tf
@@ -59,15 +59,6 @@ resource "aws_cloudwatch_log_group" "route53_resolver_query_log" {
   }
 }
 
-resource "aws_cloudwatch_log_group" "batch_saving_emf_logs" {
-  name              = "BatchSaving"
-  retention_in_days = 7
-  tags = {
-    CostCenter  = "notification-canada-ca-${var.env}"
-    Environment = var.env
-  }
-}
-
 ###
 # AWS CloudWatch Logs Metrics
 ###


### PR DESCRIPTION
Log group is auto created by the CloudWatch agent. Not necessary to define in terraform.