### PR TITLE
chore: remove Lambda API feature flag secrets

### DIFF
--- a/.github/workflows/terragrunt_plan_production.yml
+++ b/.github/workflows/terragrunt_plan_production.yml
@@ -12,9 +12,6 @@ env:
   AWS_REGION: ca-central-1
   TERRAFORM_VERSION: 0.14.4
   TERRAGRUNT_VERSION: 0.35.13
-  TF_VAR_ff_batch_insertion: ${{ secrets.PRODUCTION_FF_BATCH_INSERTION }}
-  TF_VAR_ff_redis_batch_saving: ${{ secrets.PRODUCTION_FF_REDIS_BATCH_SAVING }}
-  TF_VAR_ff_cloudwatch_metrics_enabled: ${{ secrets.PRODUCTION_FF_CLOUDWATCH_METRICS_ENABLED }}
   TF_VAR_heartbeat_api_key: ${{ secrets.PRODUCTION_HEARTBEAT_API_KEY }}
   TF_VAR_heartbeat_base_url: ${{ secrets.PRODUCTION_HEARTBEAT_BASE_URL }}
   TF_VAR_heartbeat_template_id: ${{ secrets.PRODUCTION_HEARTBEAT_TEMPLATE_ID }}

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -16,9 +16,6 @@ env:
   AWS_REGION: ca-central-1
   TERRAFORM_VERSION: 0.14.4
   TERRAGRUNT_VERSION: 0.35.13
-  TF_VAR_ff_batch_insertion: ${{ secrets.STAGING_FF_BATCH_INSERTION }}
-  TF_VAR_ff_redis_batch_saving: ${{ secrets.STAGING_FF_REDIS_BATCH_SAVING }}
-  TF_VAR_ff_cloudwatch_metrics_enabled: ${{ secrets.STAGING_FF_CLOUDWATCH_METRICS_ENABLED }}
   TF_VAR_heartbeat_api_key: ${{ secrets.STAGING_HEARTBEAT_API_KEY }}
   TF_VAR_heartbeat_base_url: ${{ secrets.STAGING_HEARTBEAT_BASE_URL }}
   TF_VAR_heartbeat_template_id: ${{ secrets.STAGING_HEARTBEAT_TEMPLATE_ID }}

--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -33,8 +33,6 @@ resource "aws_lambda_function" "api" {
       DANGEROUS_SALT                        = var.dangerous_salt
       DOCUMENTS_BUCKET                      = var.documents_bucket
       ENVIRONMENT                           = var.env
-      FF_BATCH_INSERTION                    = var.ff_batch_insertion
-      FF_REDIS_BATCH_SAVING                 = var.ff_redis_batch_saving
       MLWR_HOST                             = var.mlwr_host
       NEW_RELIC_APP_NAME                    = var.new_relic_app_name
       NEW_RELIC_DISTRIBUTED_TRACING_ENABLED = var.new_relic_distribution_tracing_enabled
@@ -50,8 +48,10 @@ resource "aws_lambda_function" "api" {
       SQLALCHEMY_DATABASE_URI               = var.sqlalchemy_database_uri
       SQLALCHEMY_POOL_SIZE                  = var.sqlalchemy_pool_size
       DOCUMENT_DOWNLOAD_API_HOST            = var.document_download_api_host
-      FF_NOTIFICATION_CELERY_PERSISTENCE    = "True"
+      FF_BATCH_INSERTION                    = var.ff_batch_insertion
+      FF_REDIS_BATCH_SAVING                 = var.ff_redis_batch_saving
       FF_CLOUDWATCH_METRICS_ENABLED         = var.ff_cloudwatch_metrics_enabled
+      FF_NOTIFICATION_CELERY_PERSISTENCE    = var.ff_notification_celery_persistence
     }
   }
 

--- a/aws/lambda-api/variables.tf
+++ b/aws/lambda-api/variables.tf
@@ -160,3 +160,7 @@ variable "ff_redis_batch_saving" {
 variable "ff_cloudwatch_metrics_enabled" {
   type = bool
 }
+
+variable "ff_notification_celery_persistence" {
+  type = bool
+}

--- a/env/production/lambda-api/terragrunt.hcl
+++ b/env/production/lambda-api/terragrunt.hcl
@@ -82,4 +82,8 @@ inputs = {
   certificate_arn                        = dependency.dns.outputs.aws_acm_notification_canada_ca_arn
   sns_alert_warning_arn                  = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                 = dependency.common.outputs.sns_alert_critical_arn
+  ff_batch_insertion                     = "true"
+  ff_redis_batch_saving                  = "true"
+  ff_cloudwatch_metrics_enabled          = "true"
+  ff_notification_celery_persistence     = "true"
 }

--- a/env/staging/lambda-api/terragrunt.hcl
+++ b/env/staging/lambda-api/terragrunt.hcl
@@ -76,6 +76,10 @@ inputs = {
   certificate_arn                        = dependency.dns.outputs.aws_acm_notification_canada_ca_arn
   sns_alert_warning_arn                  = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                 = dependency.common.outputs.sns_alert_critical_arn
+  ff_batch_insertion                     = "true"
+  ff_redis_batch_saving                  = "true"
+  ff_cloudwatch_metrics_enabled          = "true"
+  ff_notification_celery_persistence     = "true"
 }
 
 terraform {


### PR DESCRIPTION
# Summary
The Lambda API feature flags can be hardcoded in the terragrunt.hcl
for more clarity around the Lambda's configuration.

This is also the first step towards releasing batch saving in Production.

# Related
* cds-snc/notification-planning#421
* cds-snc/notification-planning#424