### PR TITLE
chore: reintroduce lambda package recreate flag

### DIFF
--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -47,6 +47,9 @@ env:
   TF_VAR_perf_test_email: ${{ secrets.PERF_TEST_EMAIL }}
   TF_VAR_perf_test_domain: ${{ secrets.PERF_TEST_DOMAIN }}
   TF_VAR_perf_test_auth_header: ${{ secrets.PERF_TEST_AUTH_HEADER }}
+  # Prevents repeated creation of the Slack lambdas if already existing.
+  # See: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/84
+  TF_RECREATE_MISSING_LAMBDA_PACKAGE: false
 
 jobs:
   terraform-apply:

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -41,6 +41,9 @@ env:
   TF_VAR_api_domain_name: ${{ secrets.STAGING_API_DOMAIN_NAME }}
   TF_VAR_api_lambda_domain_name: ${{ secrets.STAGING_API_LAMBDA_DOMAIN_NAME }}
   TF_VAR_new_relic_license_key: ${{ secrets.STAGING_NEW_RELIC_LICENSE_KEY }}
+  # Prevents repeated creation of the Slack lambdas if already existing.
+  # See: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/84
+  TF_RECREATE_MISSING_LAMBDA_PACKAGE: false
   TF_VAR_perf_test_phone_number: ${{ secrets.PERF_TEST_PHONE_NUMBER }}
   TF_VAR_perf_test_email: ${{ secrets.PERF_TEST_EMAIL }}
   TF_VAR_perf_test_domain: ${{ secrets.PERF_TEST_DOMAIN }}


### PR DESCRIPTION
New version of the lambda and slack modules still create unnecessary changes. Bring back the flag that will disable the recreate of the slack lambda.