### PR TITLE
fix: prevent unecessary tf plan output

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -40,6 +40,9 @@ env:
   TF_VAR_api_domain_name: ${{ secrets.PRODUCTION_API_DOMAIN_NAME }}
   TF_VAR_api_lambda_domain_name: ${{ secrets.PRODUCTION_API_LAMBDA_DOMAIN_NAME }}
   TF_VAR_new_relic_license_key: ${{ secrets.PRODUCTION_NEW_RELIC_LICENSE_KEY }}
+  # Prevents repeated creation of the Slack lambdas if already existing.
+  # See: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/84
+  TF_RECREATE_MISSING_LAMBDA_PACKAGE: false
 
 jobs:
   terraform-apply:


### PR DESCRIPTION
Currently all PR's to this repo display the below terraform plan output even when no resources have been modified in the `common` directory. This was due to the missing `TF_RECREATE_MISSING_LAMBDA_PACKAGE` flag not set in the production terraform apply workflow.

This was tested successfully in staging in https://github.com/cds-snc/notification-terraform/pull/405. After this is merged, all subsequent production PR's will no longer output unchanged items.

Cleaning up the terraform plan reduces errors since it's easier to determine what changes will actually occur.

# Unnecessary plan example
![image](https://user-images.githubusercontent.com/85885638/156662311-87d717b0-6d2b-4b83-a00f-343b22c8693c.png)
