### PR TITLE
fix: set OpsGenie and Slack variables as senstive

### DIFF
--- a/aws/common/variables.tf
+++ b/aws/common/variables.tf
@@ -1,17 +1,25 @@
 variable "cloudwatch_opsgenie_alarm_webhook" {
-  type = string
+  desdescription = "OpsGenie webhook used to trigger a page when there is a critical alarm."
+  type           = string
+  sensitive      = true
 }
 
 variable "cloudwatch_slack_webhook_critical_topic" {
-  type = string
+  desdescription = "Slack webhook used to post critical alarm notifications."
+  type           = string
+  sensitive      = true
 }
 
 variable "cloudwatch_slack_webhook_warning_topic" {
-  type = string
+  desdescription = "Slack webhook used to post warning alarm notifications."
+  type           = string
+  sensitive      = true
 }
 
 variable "cloudwatch_slack_webhook_general_topic" {
-  type = string
+  desdescription = "Slack webhook used to post general alarm notifications."
+  type           = string
+  sensitive      = true
 }
 
 variable "slack_channel_critical_topic" {

--- a/aws/common/variables.tf
+++ b/aws/common/variables.tf
@@ -1,25 +1,25 @@
 variable "cloudwatch_opsgenie_alarm_webhook" {
-  desdescription = "OpsGenie webhook used to trigger a page when there is a critical alarm."
-  type           = string
-  sensitive      = true
+  description = "OpsGenie webhook used to trigger a page when there is a critical alarm."
+  type        = string
+  sensitive   = true
 }
 
 variable "cloudwatch_slack_webhook_critical_topic" {
-  desdescription = "Slack webhook used to post critical alarm notifications."
-  type           = string
-  sensitive      = true
+  description = "Slack webhook used to post critical alarm notifications."
+  type        = string
+  sensitive   = true
 }
 
 variable "cloudwatch_slack_webhook_warning_topic" {
-  desdescription = "Slack webhook used to post warning alarm notifications."
-  type           = string
-  sensitive      = true
+  description = "Slack webhook used to post warning alarm notifications."
+  type        = string
+  sensitive   = true
 }
 
 variable "cloudwatch_slack_webhook_general_topic" {
-  desdescription = "Slack webhook used to post general alarm notifications."
-  type           = string
-  sensitive      = true
+  description = "Slack webhook used to post general alarm notifications."
+  type        = string
+  sensitive   = true
 }
 
 variable "slack_channel_critical_topic" {


### PR DESCRIPTION
# Summary
This will prevent the variable values from appearing in the GitHub
workflow logs.

# ⚠️  Note
The Slack webhook has been regenerated and updated in the:
* AWS console Lambda configuration,
* GitHub secret, and
* LastPast note.

The reason for manually updating the webhook using the AWS console
was to prevent a gap in webhook regeneration and notifications to
Slack while we waited for the `terraform apply`.