### PR TITLE
feat: create secret manager resource to store environment variables

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -1,6 +1,8 @@
 name: "Merge to main (Production)"
 
 on:
+  # This will be used to dispatch this workflow from the manifest repo when environment variables change
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -1,6 +1,8 @@
 name: "Merge to main (Staging)"
 
 on:
+  # This will be used to dispatch this workflow from the manifest repo when environment variables change
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -57,3 +57,9 @@ output "s3_bucket_csv_upload_bucket_arn" {
 output "s3_bucket_csv_upload_bucket_name" {
   value = aws_s3_bucket.csv_bucket.bucket
 }
+
+output "environment_variables_current_secret_string" {
+  description = "Environment variables shared between EKS and Lambda"
+  value       = data.aws_secretsmanager_secret_version.environment_variables_current.secret_string
+  sensitive   = true
+}

--- a/aws/common/secretsmanager.tf
+++ b/aws/common/secretsmanager.tf
@@ -6,6 +6,6 @@ resource "aws_secretsmanager_secret" "environment_variables" {
   }
 }
 
-data "aws_secretsmanager_secret_version" "current" {
+data "aws_secretsmanager_secret_version" "environment_variables_current" {
   secret_id = aws_secretsmanager_secret.environment_variables.id
 }


### PR DESCRIPTION
Create secrets manager resource that will house environment variables shared between lambda and k8.

Migration sequence

1. Merge this PR to create secret manager resource `environment_variables`
2. Items in the manfiest repo .env migrated to the newly created `environment_variables` secret
3. Update lambda to use the secrets from secret manager

```hcl
environment {
    variables = jsondecode(data.aws_secretsmanager_secret_version.current.secret_string)
}
```