### PR TITLE
feat: use manifest envs as base for lambda envs

### DIFF
--- a/aws/lambda-api/variables.tf
+++ b/aws/lambda-api/variables.tf
@@ -153,6 +153,11 @@ variable "new_relic_account_id" {
   type = string
 }
 
+variable "manifest_environment_variables" {
+  type      = string
+  sensitive = true
+}
+
 variable "ff_batch_insertion" {
   type = bool
 }

--- a/env/production/lambda-api/terragrunt.hcl
+++ b/env/production/lambda-api/terragrunt.hcl
@@ -82,6 +82,7 @@ inputs = {
   certificate_arn                        = dependency.dns.outputs.aws_acm_notification_canada_ca_arn
   sns_alert_warning_arn                  = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                 = dependency.common.outputs.sns_alert_critical_arn
+  manifest_environment_variables         = dependency.common.outputs.environment_variables_current_secret_string
   ff_batch_insertion                     = "true"
   ff_redis_batch_saving                  = "true"
   ff_cloudwatch_metrics_enabled          = "true"

--- a/env/staging/lambda-api/terragrunt.hcl
+++ b/env/staging/lambda-api/terragrunt.hcl
@@ -76,6 +76,7 @@ inputs = {
   certificate_arn                        = dependency.dns.outputs.aws_acm_notification_canada_ca_arn
   sns_alert_warning_arn                  = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                 = dependency.common.outputs.sns_alert_critical_arn
+  manifest_environment_variables         = dependency.common.outputs.environment_variables_current_secret_string
   ff_batch_insertion                     = "true"
   ff_redis_batch_saving                  = "true"
   ff_cloudwatch_metrics_enabled          = "true"


### PR DESCRIPTION
Retrieve common environment variables from secretsmanager and then override any lambda specific environment variables. This will ensure that the k8s and lambda api remain in sync.