### PR TITLE
chore: remove unused environment_variables secret

### DIFF
--- a/aws/common/secretsmanager.tf
+++ b/aws/common/secretsmanager.tf
@@ -1,7 +1,0 @@
-resource "aws_secretsmanager_secret" "environment_variables" {
-  name = "environment_variables"
-
-  tags = {
-    CostCenter = "notification-canada-ca-${var.env}"
-  }
-}


### PR DESCRIPTION
# Summary
Going forward, this secret will no longer be used to configure the
Lambda API.

# Related
* #421
* cds-snc/notification-planning#421