### PR TITLE
feat: policy to allow retrieval of environment param

### DIFF
--- a/aws/lambda-api/iam.tf
+++ b/aws/lambda-api/iam.tf
@@ -75,7 +75,9 @@ data "aws_iam_policy_document" "api_policies" {
     actions = [
       "ssm:ssm:GetParameters",
     ]
-    resources = "arn:aws:ssm:${var.region}:${var.account_id}:parameter/ENVIRONMENT_VARIABLES"
+    resources = [
+      "arn:aws:ssm:${var.region}:${var.account_id}:parameter/ENVIRONMENT_VARIABLES"
+    ]
   }
 }
 

--- a/aws/lambda-api/iam.tf
+++ b/aws/lambda-api/iam.tf
@@ -61,6 +61,22 @@ data "aws_iam_policy_document" "api_policies" {
     ]
     resources = ["*"]
   }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ssm:DescribeParameters",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ssm:ssm:GetParameters",
+    ]
+    resources = "arn:aws:ssm:${var.region}:${var.account_id}:parameter/ENVIRONMENT_VARIABLES"
+  }
 }
 
 resource "aws_iam_policy" "api" {


### PR DESCRIPTION
# Summary
Allow the Lambda API to retrieve environment variables from the parameter store.

# Related
* cds-snc/notification-planning#421