### PR TITLE
chore: remove envs provided upstream in the manifest

### DIFF
--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -25,6 +25,7 @@ resource "aws_lambda_function" "api" {
       ADMIN_CLIENT_SECRET                   = var.admin_client_secret
       DOCUMENT_DOWNLOAD_API_HOST            = var.document_download_api_host
       SQLALCHEMY_DATABASE_URI               = var.sqlalchemy_database_uri
+      SQLALCHEMY_DATABASE_READER_URI        = var.sqlalchemy_database_reader_uri
       NOTIFICATION_QUEUE_PREFIX             = var.notification_queue_prefix
       NOTIFY_EMAIL_DOMAIN                   = var.domain
       NOTIFY_ENVIRONMENT                    = var.env

--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -44,6 +44,7 @@ resource "aws_lambda_function" "api" {
   lifecycle {
     ignore_changes = [
       image_uri,
+      description, # Will be updated outside TF to force cold start existing lambdas. Primarily when common envs are updated
     ]
   }
 }

--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -22,7 +22,6 @@ resource "aws_lambda_function" "api" {
   }
   environment {
     variables = {
-      ADMIN_CLIENT_SECRET                   = var.admin_client_secret
       DOCUMENT_DOWNLOAD_API_HOST            = var.document_download_api_host
       SQLALCHEMY_DATABASE_URI               = var.sqlalchemy_database_uri
       SQLALCHEMY_DATABASE_READER_URI        = var.sqlalchemy_database_reader_uri

--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -23,16 +23,12 @@ resource "aws_lambda_function" "api" {
   environment {
     variables = {
       ADMIN_CLIENT_SECRET                   = var.admin_client_secret
-      ADMIN_CLIENT_USER_NAME                = var.admin_client_user_name
-      ASSET_DOMAIN                          = var.asset_domain
-      ASSET_UPLOAD_BUCKET_NAME              = var.asset_upload_bucket_name
-      AUTH_TOKENS                           = var.auth_tokens
-      AWS_PINPOINT_REGION                   = var.aws_pinpoint_region
-      CSV_UPLOAD_BUCKET_NAME                = var.csv_upload_bucket_name
-      DANGEROUS_SALT                        = var.dangerous_salt
-      DOCUMENTS_BUCKET                      = var.documents_bucket
-      ENVIRONMENT                           = var.env
-      MLWR_HOST                             = var.mlwr_host
+      DOCUMENT_DOWNLOAD_API_HOST            = var.document_download_api_host
+      SQLALCHEMY_DATABASE_URI               = var.sqlalchemy_database_uri
+      NOTIFICATION_QUEUE_PREFIX             = var.notification_queue_prefix
+      NOTIFY_EMAIL_DOMAIN                   = var.domain
+      NOTIFY_ENVIRONMENT                    = var.env
+      REDIS_ENABLED                         = var.redis_enabled
       NEW_RELIC_LAMBDA_HANDLER              = "application.handler"
       NEW_RELIC_ACCOUNT_ID                  = var.new_relic_account_id
       NEW_RELIC_APP_NAME                    = var.new_relic_app_name
@@ -41,20 +37,7 @@ resource "aws_lambda_function" "api" {
       NEW_RELIC_MONITOR_MODE                = var.new_relic_monitor_mode
       NEW_RELIC_EXTENSION_LOGS_ENABLED      = true
       NEW_RELIC_LAMBDA_EXTENSION_ENABLED    = true
-      NOTIFICATION_QUEUE_PREFIX             = var.notification_queue_prefix
-      NOTIFY_EMAIL_DOMAIN                   = var.domain
-      NOTIFY_ENVIRONMENT                    = var.env
-      REDIS_ENABLED                         = var.redis_enabled
-      REDIS_URL                             = var.redis_url
-      SECRET_KEY                            = var.secret_key
-      SQLALCHEMY_DATABASE_READER_URI        = var.sqlalchemy_database_reader_uri
-      SQLALCHEMY_DATABASE_URI               = var.sqlalchemy_database_uri
-      SQLALCHEMY_POOL_SIZE                  = var.sqlalchemy_pool_size
-      DOCUMENT_DOWNLOAD_API_HOST            = var.document_download_api_host
-      FF_BATCH_INSERTION                    = var.ff_batch_insertion
-      FF_REDIS_BATCH_SAVING                 = var.ff_redis_batch_saving
       FF_CLOUDWATCH_METRICS_ENABLED         = var.ff_cloudwatch_metrics_enabled
-      FF_NOTIFICATION_CELERY_PERSISTENCE    = var.ff_notification_celery_persistence
     }
   }
 


### PR DESCRIPTION
Lambda envs that are common with the manifest repo are no longer necessary since the api will automatically retrieve the common envs from aws system manager parameter store.