### PR TITLE
feat: mark db items as sensitive

### DIFF
--- a/aws/lambda-api/variables.tf
+++ b/aws/lambda-api/variables.tf
@@ -44,7 +44,8 @@ variable "documents_bucket" {
 }
 
 variable "mlwr_host" {
-  type = string
+  type      = string
+  sensitive = true
 }
 
 variable "new_relic_app_name" {
@@ -82,11 +83,13 @@ variable "secret_key" {
 }
 
 variable "sqlalchemy_database_reader_uri" {
-  type = string
+  type      = string
+  sensitive = true
 }
 
 variable "sqlalchemy_database_uri" {
-  type = string
+  type      = string
+  sensitive = true
 }
 
 variable "sqlalchemy_pool_size" {


### PR DESCRIPTION
Mark as sensitive before their removal so that the plan output will not display the current values.