### PR TITLE
fix: add missing Lambda API vars and remove unused

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -28,17 +28,9 @@ env:
   TF_VAR_slack_channel_critical_topic: "notification-ops"
   TF_VAR_slack_channel_general_topic: "notification-ops"
   TF_VAR_cloudwatch_opsgenie_alarm_webhook: ${{ secrets.PRODUCTION_CLOUDWATCH_OPSGENIE_ALARM_WEBHOOK }}
-  TF_VAR_admin_client_secret: ${{ secrets.PRODUCTION_ADMIN_CLIENT_SECRET }}
-  TF_VAR_auth_tokens: ${{ secrets.PRODUCTION_AUTH_TOKENS }}
-  TF_VAR_dangerous_salt: ${{ secrets.PRODUCTION_DANGEROUS_SALT }}
-  TF_VAR_mlwr_host: False
-  TF_VAR_redis_url: ${{ secrets.PRODUCTION_REDIS_URL }}
-  TF_VAR_secret_key: ${{ secrets.PRODUCTION_SECRET_KEY }}
   TF_VAR_sqlalchemy_database_reader_uri: ${{ secrets.PRODUCTION_SQLALCHEMY_DATABASE_READER_URI }}
   TF_VAR_sqlalchemy_database_uri: ${{ secrets.PRODUCTION_SQLALCHEMY_DATABASE_URI }}
   TF_VAR_document_download_api_host: ${{ secrets.PRODUCTION_DOCUMENT_DOWNLOAD_API_HOST }}
-  TF_VAR_api_domain_name: ${{ secrets.PRODUCTION_API_DOMAIN_NAME }}
-  TF_VAR_api_lambda_domain_name: ${{ secrets.PRODUCTION_API_LAMBDA_DOMAIN_NAME }}
   TF_VAR_new_relic_license_key: ${{ secrets.PRODUCTION_NEW_RELIC_LICENSE_KEY }}
   # Prevents repeated creation of the Slack lambdas if already existing.
   # See: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/84

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -31,17 +31,9 @@ env:
   TF_VAR_slack_channel_critical_topic: "notification-staging-ops"
   TF_VAR_slack_channel_general_topic: "notification-staging-ops"
   TF_VAR_cloudwatch_opsgenie_alarm_webhook: ""
-  TF_VAR_admin_client_secret: ${{ secrets.STAGING_ADMIN_CLIENT_SECRET }}
-  TF_VAR_auth_tokens: ${{ secrets.STAGING_AUTH_TOKENS }}
-  TF_VAR_dangerous_salt: ${{ secrets.STAGING_DANGEROUS_SALT }}
-  TF_VAR_mlwr_host: False
-  TF_VAR_redis_url: ${{ secrets.STAGING_REDIS_URL }}
-  TF_VAR_secret_key: ${{ secrets.STAGING_SECRET_KEY }}
   TF_VAR_sqlalchemy_database_reader_uri: ${{ secrets.STAGING_SQLALCHEMY_DATABASE_READER_URI }}
   TF_VAR_sqlalchemy_database_uri: ${{ secrets.STAGING_SQLALCHEMY_DATABASE_URI }}
   TF_VAR_document_download_api_host: ${{ secrets.STAGING_DOCUMENT_DOWNLOAD_API_HOST }}
-  TF_VAR_api_domain_name: ${{ secrets.STAGING_API_DOMAIN_NAME }}
-  TF_VAR_api_lambda_domain_name: ${{ secrets.STAGING_API_LAMBDA_DOMAIN_NAME }}
   TF_VAR_new_relic_license_key: ${{ secrets.STAGING_NEW_RELIC_LICENSE_KEY }}
   TF_VAR_perf_test_phone_number: ${{ secrets.PERF_TEST_PHONE_NUMBER }}
   TF_VAR_perf_test_email: ${{ secrets.PERF_TEST_EMAIL }}

--- a/.github/workflows/terragrunt_plan_production.yml
+++ b/.github/workflows/terragrunt_plan_production.yml
@@ -23,19 +23,9 @@ env:
   TF_VAR_slack_channel_warning_topic: notification-ops
   TF_VAR_slack_channel_critical_topic: notification-ops
   TF_VAR_slack_channel_general_topic: notification-ops
-  TF_VAR_admin_client_secret: ${{ secrets.PRODUCTION_ADMIN_CLIENT_SECRET }}
-  TF_VAR_api_host_name: ${{ secrets.PRODUCTION_API_HOST_NAME }}
-  TF_VAR_auth_tokens: ${{ secrets.PRODUCTION_AUTH_TOKENS }}
-  TF_VAR_base_domain: ${{ secrets.PRODUCTION_BASE_DOMAIN }}
-  TF_VAR_dangerous_salt: ${{ secrets.PRODUCTION_DANGEROUS_SALT }}
   TF_VAR_document_download_api_host: ${{ secrets.PRODUCTION_DOCUMENT_DOWNLOAD_API_HOST }}
-  TF_VAR_mlwr_host: "false"
-  TF_VAR_redis_url: ${{ secrets.PRODUCTION_REDIS_URL }}
-  TF_VAR_secret_key: ${{ secrets.PRODUCTION_SECRET_KEY }}
   TF_VAR_sqlalchemy_database_reader_uri: ${{ secrets.PRODUCTION_SQLALCHEMY_DATABASE_READER_URI }}
   TF_VAR_sqlalchemy_database_uri: ${{ secrets.PRODUCTION_SQLALCHEMY_DATABASE_URI }}
-  TF_VAR_api_domain_name: ${{ secrets.PRODUCTION_API_DOMAIN_NAME }}
-  TF_VAR_api_lambda_domain_name: ${{ secrets.PRODUCTION_API_LAMBDA_DOMAIN_NAME }}
   TF_VAR_new_relic_license_key: ${{ secrets.PRODUCTION_NEW_RELIC_LICENSE_KEY }}
   # Prevents repeated creation of the Slack lambdas if already existing.
   # See: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/84

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -27,19 +27,9 @@ env:
   TF_VAR_slack_channel_warning_topic: "notification-staging-ops"
   TF_VAR_slack_channel_critical_topic: "notification-staging-ops"
   TF_VAR_slack_channel_general_topic: "notification-staging-ops"
-  TF_VAR_admin_client_secret: ${{ secrets.STAGING_ADMIN_CLIENT_SECRET }}
-  TF_VAR_api_host_name: ${{ secrets.STAGING_API_HOST_NAME }}
-  TF_VAR_auth_tokens: ${{ secrets.STAGING_AUTH_TOKENS }}
-  TF_VAR_base_domain: ${{ secrets.STAGING_BASE_DOMAIN }}
-  TF_VAR_dangerous_salt: ${{ secrets.STAGING_DANGEROUS_SALT }}
   TF_VAR_document_download_api_host: ${{ secrets.STAGING_DOCUMENT_DOWNLOAD_API_HOST }}
-  TF_VAR_mlwr_host: "false"
-  TF_VAR_redis_url: ${{ secrets.STAGING_REDIS_URL }}
-  TF_VAR_secret_key: ${{ secrets.STAGING_SECRET_KEY }}
   TF_VAR_sqlalchemy_database_reader_uri: ${{ secrets.STAGING_SQLALCHEMY_DATABASE_READER_URI }}
   TF_VAR_sqlalchemy_database_uri: ${{ secrets.STAGING_SQLALCHEMY_DATABASE_URI }}
-  TF_VAR_api_domain_name: ${{ secrets.STAGING_API_DOMAIN_NAME }}
-  TF_VAR_api_lambda_domain_name: ${{ secrets.STAGING_API_LAMBDA_DOMAIN_NAME }}
   TF_VAR_new_relic_license_key: ${{ secrets.STAGING_NEW_RELIC_LICENSE_KEY }}
   # Prevents repeated creation of the Slack lambdas if already existing.
   # See: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/84

--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -53,7 +53,3 @@ output "s3_bucket_asset_bucket_arn" {
 output "s3_bucket_csv_upload_bucket_arn" {
   value = aws_s3_bucket.csv_bucket.arn
 }
-
-output "s3_bucket_csv_upload_bucket_name" {
-  value = aws_s3_bucket.csv_bucket.bucket
-}

--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -22,6 +22,8 @@ resource "aws_lambda_function" "api" {
   }
   environment {
     variables = {
+      ADMIN_BASE_URL                        = var.admin_base_url
+      API_HOST_NAME                         = "https://${var.api_domain_name}"
       DOCUMENT_DOWNLOAD_API_HOST            = var.document_download_api_host
       SQLALCHEMY_DATABASE_URI               = var.sqlalchemy_database_uri
       SQLALCHEMY_DATABASE_READER_URI        = var.sqlalchemy_database_reader_uri

--- a/aws/lambda-api/variables.tf
+++ b/aws/lambda-api/variables.tf
@@ -1,51 +1,17 @@
-variable "admin_client_secret" {
-  type      = string
-  sensitive = true
-}
-
-variable "admin_client_user_name" {
-  type      = string
-  sensitive = true
-}
-
-variable "asset_domain" {
+variable "admin_base_url" {
   type = string
 }
 
-variable "asset_upload_bucket_name" {
+variable "api_domain_name" {
   type = string
 }
 
-variable "auth_tokens" {
-  type      = string
-  sensitive = true
-}
-
-// check if this already exists
-variable "aws_pinpoint_region" {
-  type = string
-}
-
-variable "csv_upload_bucket_name" {
+variable "api_lambda_domain_name" {
   type = string
 }
 
 variable "csv_upload_bucket_arn" {
   type = string
-}
-
-variable "dangerous_salt" {
-  type      = string
-  sensitive = true
-}
-
-variable "documents_bucket" {
-  type = string
-}
-
-variable "mlwr_host" {
-  type      = string
-  sensitive = true
 }
 
 variable "new_relic_app_name" {
@@ -73,15 +39,6 @@ variable "redis_enabled" {
   type = string
 }
 
-variable "redis_url" {
-  type = string
-}
-
-variable "secret_key" {
-  type      = string
-  sensitive = true
-}
-
 variable "sqlalchemy_database_reader_uri" {
   type      = string
   sensitive = true
@@ -90,10 +47,6 @@ variable "sqlalchemy_database_reader_uri" {
 variable "sqlalchemy_database_uri" {
   type      = string
   sensitive = true
-}
-
-variable "sqlalchemy_pool_size" {
-  type = string
 }
 
 variable "vpc_private_subnets" {
@@ -128,14 +81,6 @@ variable "high_demand_max_concurrency" {
   type = number
 }
 
-variable "api_domain_name" {
-  type = string
-}
-
-variable "api_lambda_domain_name" {
-  type = string
-}
-
 variable "certificate_arn" {
   type = string
 }
@@ -156,18 +101,6 @@ variable "new_relic_account_id" {
   type = string
 }
 
-variable "ff_batch_insertion" {
-  type = bool
-}
-
-variable "ff_redis_batch_saving" {
-  type = bool
-}
-
 variable "ff_cloudwatch_metrics_enabled" {
-  type = bool
-}
-
-variable "ff_notification_celery_persistence" {
   type = bool
 }

--- a/env/production/lambda-api/terragrunt.hcl
+++ b/env/production/lambda-api/terragrunt.hcl
@@ -25,7 +25,6 @@ dependency "common" {
     sns_alert_general_arn            = ""
     sns_alert_warning_arn            = ""
     sns_alert_critical_arn           = ""
-    s3_bucket_csv_upload_bucket_name = ""
     s3_bucket_csv_upload_bucket_arn  = ""
   }
 }
@@ -58,22 +57,18 @@ include {
 
 inputs = {
   env                                    = "production"
+  admin_base_url                         = "https://notification.canada.ca"
+  api_domain_name                        = "api.notification.canada.ca"
+  api_lambda_domain_name                 = "api-lambda.notification.canada.ca"  
   api_image_tag                          = "release"
   eks_cluster_securitygroup              = dependency.eks.outputs.eks-cluster-securitygroup
   vpc_private_subnets                    = dependency.common.outputs.vpc_private_subnets
-  aws_pinpoint_region                    = "us-west-2"
   redis_enabled                          = "1"
-  sqlalchemy_pool_size                   = "256"
   low_demand_min_concurrency             = 1
   low_demand_max_concurrency             = 5
   high_demand_min_concurrency            = 1
   high_demand_max_concurrency            = 10
-  admin_client_user_name                 = "notify-admin"
-  asset_domain                           = "assets.notification.canada.ca"
-  asset_upload_bucket_name               = "notification-canada-ca-production-asset-upload"
-  csv_upload_bucket_name                 = dependency.common.outputs.s3_bucket_csv_upload_bucket_name
   csv_upload_bucket_arn                  = dependency.common.outputs.s3_bucket_csv_upload_bucket_arn
-  documents_bucket                       = "notification-alpha-canada-ca-document-download"
   new_relic_app_name                     = "notification-lambda-api-production"
   new_relic_distribution_tracing_enabled = "true"
   new_relic_monitor_mode                 = "true"
@@ -82,8 +77,5 @@ inputs = {
   certificate_arn                        = dependency.dns.outputs.aws_acm_notification_canada_ca_arn
   sns_alert_warning_arn                  = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                 = dependency.common.outputs.sns_alert_critical_arn
-  ff_batch_insertion                     = "true"
-  ff_redis_batch_saving                  = "true"
   ff_cloudwatch_metrics_enabled          = "true"
-  ff_notification_celery_persistence     = "true"
 }

--- a/env/staging/lambda-api/terragrunt.hcl
+++ b/env/staging/lambda-api/terragrunt.hcl
@@ -19,7 +19,6 @@ dependency "common" {
     sns_alert_general_arn            = ""
     sns_alert_warning_arn            = ""
     sns_alert_critical_arn           = ""
-    s3_bucket_csv_upload_bucket_name = ""
     s3_bucket_csv_upload_bucket_arn  = ""
   }
 }
@@ -52,22 +51,18 @@ include {
 
 inputs = {
   env                                    = "staging"
+  admin_base_url                         = "https://staging.notification.cdssandbox.xyz"
+  api_domain_name                        = "api.staging.notification.cdssandbox.xyz"
+  api_lambda_domain_name                 = "api-lambda.staging.notification.cdssandbox.xyz"
   api_image_tag                          = "latest"
   eks_cluster_securitygroup              = dependency.eks.outputs.eks-cluster-securitygroup
   vpc_private_subnets                    = dependency.common.outputs.vpc_private_subnets
-  aws_pinpoint_region                    = "us-west-2"
   redis_enabled                          = "1"
-  sqlalchemy_pool_size                   = "256"
   low_demand_min_concurrency             = 1
   low_demand_max_concurrency             = 5
   high_demand_min_concurrency            = 1
   high_demand_max_concurrency            = 10
-  admin_client_user_name                 = "notify-admin"
-  asset_domain                           = "assets.staging.notification.cdssandbox.xyz"
-  asset_upload_bucket_name               = "notification-canada-ca-staging-asset-upload"
-  csv_upload_bucket_name                 = dependency.common.outputs.s3_bucket_csv_upload_bucket_name
   csv_upload_bucket_arn                  = dependency.common.outputs.s3_bucket_csv_upload_bucket_arn
-  documents_bucket                       = "notification-canada-ca-staging-document-download"
   new_relic_app_name                     = "notification-lambda-api-staging"
   new_relic_distribution_tracing_enabled = "true"
   new_relic_monitor_mode                 = "true"
@@ -76,10 +71,7 @@ inputs = {
   certificate_arn                        = dependency.dns.outputs.aws_acm_notification_canada_ca_arn
   sns_alert_warning_arn                  = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                 = dependency.common.outputs.sns_alert_critical_arn
-  ff_batch_insertion                     = "true"
-  ff_redis_batch_saving                  = "true"
   ff_cloudwatch_metrics_enabled          = "true"
-  ff_notification_celery_persistence     = "true"
 }
 
 terraform {


### PR DESCRIPTION
# Summary
1. Add the `ADMIN_BASE_URL` and `API_HOST_NAME` to the Lambda API.
2. Move `api_domain_name` and `api_lambda_domain_name` out of secrets.
3. Remove unused variables from the Terraform, Terragrunt and workflows.

# Related
* cds-snc/notification-planning#421