### PR TITLE
feat: VPC, WAF and LB logs to Cloud Based Sensor

### DIFF
--- a/aws/common/athena.tf
+++ b/aws/common/athena.tf
@@ -40,6 +40,6 @@ resource "aws_athena_named_query" "create_table_alb_logs" {
     {
       database_name   = aws_athena_database.notification_athena.name
       table_name      = "alb_logs"
-      bucket_location = "s3://${aws_s3_bucket.alb_log_bucket.bucket}/AWSLogs/${var.account_id}/elasticloadbalancing/${var.region}"
+      bucket_location = "s3://${var.cbs_satellite_bucket_name}/lb_logs/AWSLogs/${var.account_id}/elasticloadbalancing/${var.region}"
   })
 }

--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -30,10 +30,6 @@ output "asset_bucket_regional_domain_name" {
   value = aws_s3_bucket.asset_bucket.bucket_regional_domain_name
 }
 
-output "alb_log_bucket" {
-  value = aws_s3_bucket.alb_log_bucket.bucket
-}
-
 output "kms_arn" {
   value = aws_kms_key.notification-canada-ca.arn
 }

--- a/aws/common/vpc.tf
+++ b/aws/common/vpc.tf
@@ -201,3 +201,16 @@ resource "aws_default_network_acl" "notification-canada-ca" {
     CostCenter = "notification-canada-ca-${var.env}"
   }
 }
+
+resource "aws_flow_log" "cloud-based-sensor" {
+  log_destination      = "arn:aws:s3:::${var.cbs_satellite_bucket_name}/vpc_flow_logs/"
+  log_destination_type = "s3"
+  traffic_type         = "ALL"
+  vpc_id               = aws_vpc.notification-canada-ca.id
+  log_format           = "$${vpc-id} $${version} $${account-id} $${interface-id} $${srcaddr} $${dstaddr} $${srcport} $${dstport} $${protocol} $${packets} $${bytes} $${start} $${end} $${action} $${log-status} $${subnet-id} $${instance-id}"
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+    Terraform  = true
+  }
+}

--- a/aws/eks/alb.tf
+++ b/aws/eks/alb.tf
@@ -13,7 +13,8 @@ resource "aws_alb" "notification-canada-ca" {
   subnets = var.vpc_public_subnets
 
   access_logs {
-    bucket  = var.alb_log_bucket
+    bucket  = var.cbs_satellite_bucket_name
+    prefix  = "lb_logs"
     enabled = true
   }
 

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -50,10 +50,6 @@ variable "cloudfront_assets_arn" {
   type = string
 }
 
-variable "alb_log_bucket" {
-  type = string
-}
-
 variable "eks_cluster_name" {
   type = string
 }

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -54,6 +54,10 @@ variable "eks_cluster_name" {
   type = string
 }
 
+variable "firehose_waf_logs_iam_role_arn" {
+  type = string
+}
+
 locals {
   eks_application_log_group = "/aws/containerinsights/${var.eks_cluster_name}/application"
 }

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -357,3 +357,13 @@ data "aws_iam_policy_document" "firehose-waf-logs" {
     ]
   }
 }
+
+resource "aws_wafv2_web_acl_logging_configuration" "firehose-waf-logs" {
+  log_destination_configs = [aws_kinesis_firehose_delivery_stream.firehose-waf-logs.arn]
+  resource_arn            = aws_wafv2_web_acl.notification-canada-ca.arn
+  redacted_fields {
+    single_header {
+      name = "authorization"
+    }
+  }
+}

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -292,6 +292,10 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose-waf-logs" {
     prefix             = local.cbs_satellite_bucket_prefix
     bucket_arn         = local.cbs_satellite_bucket_arn
     compression_format = "GZIP"
+
+    # Buffer incoming data size (MB), before delivering to S3 bucket
+    # Should be greater than amount of data ingested in a 10 second period
+    buffer_size = 5
   }
 
   tags = {

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -270,3 +270,86 @@ resource "aws_wafv2_web_acl_logging_configuration" "cloudwatch-waf-logs" {
     }
   }
 }
+
+#
+# WAF logging to Cloud Based Sensor satellite bucket
+#
+locals {
+  cbs_satellite_bucket_arn    = "arn:aws:s3:::${var.cbs_satellite_bucket_name}"
+  cbs_satellite_bucket_prefix = "waf_acl_logs/AWSLogs/${var.account_id}/"
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "firehose-waf-logs" {
+  name        = "aws-waf-logs-notification-canada-ca-waf"
+  destination = "extended_s3"
+
+  server_side_encryption {
+    enabled = true
+  }
+
+  extended_s3_configuration {
+    role_arn           = aws_iam_role.firehose-waf-logs.arn
+    prefix             = local.cbs_satellite_bucket_prefix
+    bucket_arn         = local.cbs_satellite_bucket_arn
+    compression_format = "GZIP"
+  }
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+    Terraform  = true
+  }
+}
+
+resource "aws_iam_role" "firehose-waf-logs" {
+  name               = "FirehoseWafLogs"
+  assume_role_policy = data.aws_iam_policy_document.firehose-assume.json
+}
+
+resource "aws_iam_policy" "firehose-waf-logs" {
+  name   = "FirehoseWafLogsPolicy"
+  path   = "/"
+  policy = data.aws_iam_policy_document.firehose-waf-logs.json
+}
+
+resource "aws_iam_role_policy_attachment" "firehose-waf-logs" {
+  role       = aws_iam_role.firehose-waf-logs.name
+  policy_arn = aws_iam_policy.firehose-waf-logs.arn
+}
+
+data "aws_iam_policy_document" "firehose-assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["firehose.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "firehose-waf-logs" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:PutObject"
+    ]
+    resources = [
+      local.cbs_satellite_bucket_arn,
+      "${local.cbs_satellite_bucket_arn}/*"
+    ]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:CreateServiceLinkedRole"
+    ]
+    resources = [
+      "arn:aws:iam::*:role/aws-service-role/wafv2.amazonaws.com/AWSServiceRoleForWAFV2Logging"
+    ]
+  }
+}

--- a/aws/lambda-api/variables.tf
+++ b/aws/lambda-api/variables.tf
@@ -53,6 +53,10 @@ variable "eks_cluster_securitygroup" {
   type = string
 }
 
+variable "firehose_waf_logs_iam_role_arn" {
+  type = string
+}
+
 variable "document_download_api_host" {
   type = string
 }

--- a/aws/lambda-api/waf.tf
+++ b/aws/lambda-api/waf.tf
@@ -177,3 +177,41 @@ resource "aws_wafv2_web_acl_logging_configuration" "cloudwatch-api-lambda-waf-lo
     }
   }
 }
+
+#
+# WAF logging to Cloud Based Sensor satellite bucket
+#
+resource "aws_kinesis_firehose_delivery_stream" "firehose-api-lambda-waf-logs" {
+  name        = "aws-waf-logs-notification-canada-ca-api-lambda-waf"
+  destination = "extended_s3"
+
+  server_side_encryption {
+    enabled = true
+  }
+
+  extended_s3_configuration {
+    role_arn           = var.firehose_waf_logs_iam_role_arn
+    prefix             = "waf_acl_logs/AWSLogs/${var.account_id}/lambda/"
+    bucket_arn         = "arn:aws:s3:::${var.cbs_satellite_bucket_name}"
+    compression_format = "GZIP"
+
+    # Buffer incoming data size (MB), before delivering to S3 bucket
+    # Should be greater than amount of data ingested in a 10 second period
+    buffer_size = 5
+  }
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+    Terraform  = true
+  }
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "firehose-api-lambda-waf-logs" {
+  log_destination_configs = [aws_kinesis_firehose_delivery_stream.firehose-api-lambda-waf-logs.arn]
+  resource_arn            = aws_wafv2_web_acl.api_lambda.arn
+  redacted_fields {
+    single_header {
+      name = "authorization"
+    }
+  }
+}

--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -35,6 +35,7 @@ inputs = {
   sns_alert_warning_arn                  = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                 = dependency.common.outputs.sns_alert_critical_arn
   sns_alert_general_arn                  = dependency.common.outputs.sns_alert_general_arn
+  firehose_waf_logs_iam_role_arn         = dependency.common.outputs.firehose_waf_logs_iam_role_arn
   cloudfront_assets_arn                  = dependency.cloudfront.outputs.cloudfront_assets_arn
   eks_cluster_name                       = "notification-canada-ca-production-eks-cluster"
 }

--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -35,7 +35,6 @@ inputs = {
   sns_alert_warning_arn                  = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                 = dependency.common.outputs.sns_alert_critical_arn
   sns_alert_general_arn                  = dependency.common.outputs.sns_alert_general_arn
-  alb_log_bucket                         = dependency.common.outputs.alb_log_bucket
   cloudfront_assets_arn                  = dependency.cloudfront.outputs.cloudfront_assets_arn
   eks_cluster_name                       = "notification-canada-ca-production-eks-cluster"
 }

--- a/env/production/lambda-api/terragrunt.hcl
+++ b/env/production/lambda-api/terragrunt.hcl
@@ -26,6 +26,7 @@ dependency "common" {
     sns_alert_warning_arn           = ""
     sns_alert_critical_arn          = ""
     s3_bucket_csv_upload_bucket_arn = ""
+    firehose_waf_logs_iam_role_arn  = ""
   }
 }
 
@@ -69,6 +70,7 @@ inputs = {
   high_demand_min_concurrency            = 1
   high_demand_max_concurrency            = 10
   csv_upload_bucket_arn                  = dependency.common.outputs.s3_bucket_csv_upload_bucket_arn
+  firehose_waf_logs_iam_role_arn         = dependency.common.outputs.firehose_waf_logs_iam_role_arn
   new_relic_app_name                     = "notification-lambda-api-production"
   new_relic_distribution_tracing_enabled = "true"
   notification_queue_prefix              = "eks-notification-canada-ca"

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -22,7 +22,6 @@ dependency "common" {
     sns_alert_warning_arn  = ""
     sns_alert_critical_arn = ""
     sns_alert_general_arn  = ""
-    alb_log_bucket         = ""
   }
 }
 
@@ -65,7 +64,6 @@ inputs = {
   sns_alert_warning_arn                  = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                 = dependency.common.outputs.sns_alert_critical_arn
   sns_alert_general_arn                  = dependency.common.outputs.sns_alert_general_arn
-  alb_log_bucket                         = dependency.common.outputs.alb_log_bucket
   cloudfront_assets_arn                  = dependency.cloudfront.outputs.cloudfront_assets_arn
   eks_cluster_name                       = "notification-canada-ca-staging-eks-cluster"
 }

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -19,9 +19,10 @@ dependency "common" {
       "subnet-0c7d18c0c51b28b61",
       "subnet-0c91f7c6b8211904b",
     ]
-    sns_alert_warning_arn  = ""
-    sns_alert_critical_arn = ""
-    sns_alert_general_arn  = ""
+    sns_alert_warning_arn          = ""
+    sns_alert_critical_arn         = ""
+    sns_alert_general_arn          = ""
+    firehose_waf_logs_iam_role_arn = ""
   }
 }
 
@@ -64,6 +65,7 @@ inputs = {
   sns_alert_warning_arn                  = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                 = dependency.common.outputs.sns_alert_critical_arn
   sns_alert_general_arn                  = dependency.common.outputs.sns_alert_general_arn
+  firehose_waf_logs_iam_role_arn         = dependency.common.outputs.firehose_waf_logs_iam_role_arn
   cloudfront_assets_arn                  = dependency.cloudfront.outputs.cloudfront_assets_arn
   eks_cluster_name                       = "notification-canada-ca-staging-eks-cluster"
 }

--- a/env/staging/lambda-api/terragrunt.hcl
+++ b/env/staging/lambda-api/terragrunt.hcl
@@ -20,6 +20,7 @@ dependency "common" {
     sns_alert_warning_arn           = ""
     sns_alert_critical_arn          = ""
     s3_bucket_csv_upload_bucket_arn = ""
+    firehose_waf_logs_iam_role_arn  = ""
   }
 }
 
@@ -63,6 +64,7 @@ inputs = {
   high_demand_min_concurrency            = 1
   high_demand_max_concurrency            = 10
   csv_upload_bucket_arn                  = dependency.common.outputs.s3_bucket_csv_upload_bucket_arn
+  firehose_waf_logs_iam_role_arn         = dependency.common.outputs.firehose_waf_logs_iam_role_arn
   new_relic_app_name                     = "notification-lambda-api-staging"
   new_relic_distribution_tracing_enabled = "true"
   notification_queue_prefix              = "eks-notification-canada-ca"


### PR DESCRIPTION
# Summary
Update the Notify infrastructure to send VPC flow logs, WAF ACL logs
and LB access logs to the Cloud Based Sensor satellite bucket.

# Related
* cds-snc/cloud-based-sensor#34
* cds-snc/notification-planning#525
* cds-snc/notification-planning#531