### PR TITLE
chore: remove unnecessary newrelic envs

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -31,7 +31,6 @@ env:
   TF_VAR_sqlalchemy_database_reader_uri: ${{ secrets.PRODUCTION_SQLALCHEMY_DATABASE_READER_URI }}
   TF_VAR_sqlalchemy_database_uri: ${{ secrets.PRODUCTION_SQLALCHEMY_DATABASE_URI }}
   TF_VAR_document_download_api_host: ${{ secrets.PRODUCTION_DOCUMENT_DOWNLOAD_API_HOST }}
-  TF_VAR_new_relic_license_key: ${{ secrets.PRODUCTION_NEW_RELIC_LICENSE_KEY }}
   # Prevents repeated creation of the Slack lambdas if already existing.
   # See: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/84
   TF_RECREATE_MISSING_LAMBDA_PACKAGE: false

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -34,7 +34,6 @@ env:
   TF_VAR_sqlalchemy_database_reader_uri: ${{ secrets.STAGING_SQLALCHEMY_DATABASE_READER_URI }}
   TF_VAR_sqlalchemy_database_uri: ${{ secrets.STAGING_SQLALCHEMY_DATABASE_URI }}
   TF_VAR_document_download_api_host: ${{ secrets.STAGING_DOCUMENT_DOWNLOAD_API_HOST }}
-  TF_VAR_new_relic_license_key: ${{ secrets.STAGING_NEW_RELIC_LICENSE_KEY }}
   TF_VAR_perf_test_phone_number: ${{ secrets.PERF_TEST_PHONE_NUMBER }}
   TF_VAR_perf_test_email: ${{ secrets.PERF_TEST_EMAIL }}
   TF_VAR_perf_test_domain: ${{ secrets.PERF_TEST_DOMAIN }}

--- a/.github/workflows/terragrunt_plan_production.yml
+++ b/.github/workflows/terragrunt_plan_production.yml
@@ -26,7 +26,6 @@ env:
   TF_VAR_document_download_api_host: ${{ secrets.PRODUCTION_DOCUMENT_DOWNLOAD_API_HOST }}
   TF_VAR_sqlalchemy_database_reader_uri: ${{ secrets.PRODUCTION_SQLALCHEMY_DATABASE_READER_URI }}
   TF_VAR_sqlalchemy_database_uri: ${{ secrets.PRODUCTION_SQLALCHEMY_DATABASE_URI }}
-  TF_VAR_new_relic_license_key: ${{ secrets.PRODUCTION_NEW_RELIC_LICENSE_KEY }}
   # Prevents repeated creation of the Slack lambdas if already existing.
   # See: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/84
   TF_RECREATE_MISSING_LAMBDA_PACKAGE: false

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -30,7 +30,6 @@ env:
   TF_VAR_document_download_api_host: ${{ secrets.STAGING_DOCUMENT_DOWNLOAD_API_HOST }}
   TF_VAR_sqlalchemy_database_reader_uri: ${{ secrets.STAGING_SQLALCHEMY_DATABASE_READER_URI }}
   TF_VAR_sqlalchemy_database_uri: ${{ secrets.STAGING_SQLALCHEMY_DATABASE_URI }}
-  TF_VAR_new_relic_license_key: ${{ secrets.STAGING_NEW_RELIC_LICENSE_KEY }}
   # Prevents repeated creation of the Slack lambdas if already existing.
   # See: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/84
   TF_RECREATE_MISSING_LAMBDA_PACKAGE: false

--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -35,8 +35,6 @@ resource "aws_lambda_function" "api" {
       NEW_RELIC_ACCOUNT_ID                  = var.new_relic_account_id
       NEW_RELIC_APP_NAME                    = var.new_relic_app_name
       NEW_RELIC_DISTRIBUTED_TRACING_ENABLED = var.new_relic_distribution_tracing_enabled
-      NEW_RELIC_LICENSE_KEY                 = var.new_relic_license_key
-      NEW_RELIC_MONITOR_MODE                = var.new_relic_monitor_mode
       NEW_RELIC_EXTENSION_LOGS_ENABLED      = true
       NEW_RELIC_LAMBDA_EXTENSION_ENABLED    = true
       FF_CLOUDWATCH_METRICS_ENABLED         = var.ff_cloudwatch_metrics_enabled

--- a/aws/lambda-api/variables.tf
+++ b/aws/lambda-api/variables.tf
@@ -22,15 +22,6 @@ variable "new_relic_distribution_tracing_enabled" {
   type = string
 }
 
-variable "new_relic_license_key" {
-  type      = string
-  sensitive = true
-}
-
-variable "new_relic_monitor_mode" {
-  type = string
-}
-
 variable "notification_queue_prefix" {
   type = string
 }

--- a/env/production/lambda-api/terragrunt.hcl
+++ b/env/production/lambda-api/terragrunt.hcl
@@ -22,10 +22,10 @@ dependency "common" {
       "",
       "",
     ]
-    sns_alert_general_arn            = ""
-    sns_alert_warning_arn            = ""
-    sns_alert_critical_arn           = ""
-    s3_bucket_csv_upload_bucket_arn  = ""
+    sns_alert_general_arn           = ""
+    sns_alert_warning_arn           = ""
+    sns_alert_critical_arn          = ""
+    s3_bucket_csv_upload_bucket_arn = ""
   }
 }
 
@@ -59,7 +59,7 @@ inputs = {
   env                                    = "production"
   admin_base_url                         = "https://notification.canada.ca"
   api_domain_name                        = "api.notification.canada.ca"
-  api_lambda_domain_name                 = "api-lambda.notification.canada.ca"  
+  api_lambda_domain_name                 = "api-lambda.notification.canada.ca"
   api_image_tag                          = "release"
   eks_cluster_securitygroup              = dependency.eks.outputs.eks-cluster-securitygroup
   vpc_private_subnets                    = dependency.common.outputs.vpc_private_subnets

--- a/env/production/lambda-api/terragrunt.hcl
+++ b/env/production/lambda-api/terragrunt.hcl
@@ -71,7 +71,6 @@ inputs = {
   csv_upload_bucket_arn                  = dependency.common.outputs.s3_bucket_csv_upload_bucket_arn
   new_relic_app_name                     = "notification-lambda-api-production"
   new_relic_distribution_tracing_enabled = "true"
-  new_relic_monitor_mode                 = "true"
   notification_queue_prefix              = "eks-notification-canada-ca"
   redis_enabled                          = 1
   certificate_arn                        = dependency.dns.outputs.aws_acm_notification_canada_ca_arn

--- a/env/staging/lambda-api/terragrunt.hcl
+++ b/env/staging/lambda-api/terragrunt.hcl
@@ -65,7 +65,6 @@ inputs = {
   csv_upload_bucket_arn                  = dependency.common.outputs.s3_bucket_csv_upload_bucket_arn
   new_relic_app_name                     = "notification-lambda-api-staging"
   new_relic_distribution_tracing_enabled = "true"
-  new_relic_monitor_mode                 = "true"
   notification_queue_prefix              = "eks-notification-canada-ca"
   redis_enabled                          = 1
   certificate_arn                        = dependency.dns.outputs.aws_acm_notification_canada_ca_arn

--- a/env/staging/lambda-api/terragrunt.hcl
+++ b/env/staging/lambda-api/terragrunt.hcl
@@ -16,10 +16,10 @@ dependency "common" {
       "",
       "",
     ]
-    sns_alert_general_arn            = ""
-    sns_alert_warning_arn            = ""
-    sns_alert_critical_arn           = ""
-    s3_bucket_csv_upload_bucket_arn  = ""
+    sns_alert_general_arn           = ""
+    sns_alert_warning_arn           = ""
+    sns_alert_critical_arn          = ""
+    s3_bucket_csv_upload_bucket_arn = ""
   }
 }
 


### PR DESCRIPTION
These two environment variables are handled by the common parameter store env sync and are incorrectly overriding. Removing them will make the lambda fallback to the common variable retrieved from the parameter store.