### PR TITLE
feat: grant permission to download newrelic lambda layers

### DIFF
--- a/aws/lambda-api/ecr_user.tf
+++ b/aws/lambda-api/ecr_user.tf
@@ -72,6 +72,6 @@ data "aws_iam_policy_document" "ecr" {
     actions = [
       "lambda:GetLayerVersion"
     ]
-    resources = ["arn:aws:lambda:ca-central-1:451483290750:layer:NewRelicPython*"]
+    resources = ["arn:aws:lambda:ca-central-1:451483290750:layer:NewRelicPython*:*"]
   }
 }

--- a/aws/lambda-api/ecr_user.tf
+++ b/aws/lambda-api/ecr_user.tf
@@ -65,4 +65,13 @@ data "aws_iam_policy_document" "ecr" {
     ]
     resources = [local.api-lambda-function-arn]
   }
+
+  statement {
+    sid    = "PermissionsToDownloadNewRelicLambdaLayers"
+    effect = "Allow"
+    actions = [
+      "lambda:GetLayerVersion"
+    ]
+    resources = ["arn:aws:lambda:ca-central-1:451483290750:layer:*"]
+  }
 }

--- a/aws/lambda-api/ecr_user.tf
+++ b/aws/lambda-api/ecr_user.tf
@@ -72,6 +72,6 @@ data "aws_iam_policy_document" "ecr" {
     actions = [
       "lambda:GetLayerVersion"
     ]
-    resources = ["arn:aws:lambda:ca-central-1:451483290750:layer:*"]
+    resources = ["arn:aws:lambda:ca-central-1:451483290750:layer:NewRelicPython*"]
   }
 }


### PR DESCRIPTION
Unable to retrieval the new relic layer due to missing permissions. This PR will modify the ecr-user permissions.

`An error occurred (AccessDeniedException) when calling the GetLayerVersionByArn operation: User: arn:aws:iam::***:user/ecr-user is not authorized to perform: lambda:GetLayerVersion on resource: arn:aws:lambda:ca-central-1:451483290750:layer:NewRelicPython39:12 because no identity-based policy allows the lambda:GetLayerVersion action`