### PR TITLE
feat: give lambda access to retrieve new relic license key secret

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -31,6 +31,7 @@ env:
   TF_VAR_sqlalchemy_database_reader_uri: ${{ secrets.PRODUCTION_SQLALCHEMY_DATABASE_READER_URI }}
   TF_VAR_sqlalchemy_database_uri: ${{ secrets.PRODUCTION_SQLALCHEMY_DATABASE_URI }}
   TF_VAR_document_download_api_host: ${{ secrets.PRODUCTION_DOCUMENT_DOWNLOAD_API_HOST }}
+  TF_VAR_new_relic_license_key: ${{ secrets.PRODUCTION_NEW_RELIC_LICENSE_KEY }}
   # Prevents repeated creation of the Slack lambdas if already existing.
   # See: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/84
   TF_RECREATE_MISSING_LAMBDA_PACKAGE: false

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -34,6 +34,7 @@ env:
   TF_VAR_sqlalchemy_database_reader_uri: ${{ secrets.STAGING_SQLALCHEMY_DATABASE_READER_URI }}
   TF_VAR_sqlalchemy_database_uri: ${{ secrets.STAGING_SQLALCHEMY_DATABASE_URI }}
   TF_VAR_document_download_api_host: ${{ secrets.STAGING_DOCUMENT_DOWNLOAD_API_HOST }}
+  TF_VAR_new_relic_license_key: ${{ secrets.STAGING_NEW_RELIC_LICENSE_KEY }}
   TF_VAR_perf_test_phone_number: ${{ secrets.PERF_TEST_PHONE_NUMBER }}
   TF_VAR_perf_test_email: ${{ secrets.PERF_TEST_EMAIL }}
   TF_VAR_perf_test_domain: ${{ secrets.PERF_TEST_DOMAIN }}

--- a/.github/workflows/terragrunt_plan_production.yml
+++ b/.github/workflows/terragrunt_plan_production.yml
@@ -26,6 +26,7 @@ env:
   TF_VAR_document_download_api_host: ${{ secrets.PRODUCTION_DOCUMENT_DOWNLOAD_API_HOST }}
   TF_VAR_sqlalchemy_database_reader_uri: ${{ secrets.PRODUCTION_SQLALCHEMY_DATABASE_READER_URI }}
   TF_VAR_sqlalchemy_database_uri: ${{ secrets.PRODUCTION_SQLALCHEMY_DATABASE_URI }}
+  TF_VAR_new_relic_license_key: ${{ secrets.PRODUCTION_NEW_RELIC_LICENSE_KEY }}
   # Prevents repeated creation of the Slack lambdas if already existing.
   # See: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/84
   TF_RECREATE_MISSING_LAMBDA_PACKAGE: false

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -30,6 +30,7 @@ env:
   TF_VAR_document_download_api_host: ${{ secrets.STAGING_DOCUMENT_DOWNLOAD_API_HOST }}
   TF_VAR_sqlalchemy_database_reader_uri: ${{ secrets.STAGING_SQLALCHEMY_DATABASE_READER_URI }}
   TF_VAR_sqlalchemy_database_uri: ${{ secrets.STAGING_SQLALCHEMY_DATABASE_URI }}
+  TF_VAR_new_relic_license_key: ${{ secrets.STAGING_NEW_RELIC_LICENSE_KEY }}
   # Prevents repeated creation of the Slack lambdas if already existing.
   # See: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/84
   TF_RECREATE_MISSING_LAMBDA_PACKAGE: false

--- a/aws/lambda-api/iam.tf
+++ b/aws/lambda-api/iam.tf
@@ -86,7 +86,7 @@ data "aws_iam_policy_document" "api_policies" {
       "secretsmanager:GetSecretValue",
     ]
     resources = [
-      data.aws_secretsmanager_secret_version.new-relic-license-key.arn
+      aws_secretsmanager_secret_version.new-relic-license-key.arn
     ]
   }
 }

--- a/aws/lambda-api/iam.tf
+++ b/aws/lambda-api/iam.tf
@@ -86,7 +86,7 @@ data "aws_iam_policy_document" "api_policies" {
       "secretsmanager:GetSecretValue",
     ]
     resources = [
-      data.new-relic-license-key.arn
+      data.aws_secretsmanager_secret_version.new-relic-license-key.arn
     ]
   }
 }

--- a/aws/lambda-api/iam.tf
+++ b/aws/lambda-api/iam.tf
@@ -79,6 +79,16 @@ data "aws_iam_policy_document" "api_policies" {
       "arn:aws:ssm:${var.region}:${var.account_id}:parameter/ENVIRONMENT_VARIABLES"
     ]
   }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+    resources = [
+      data.new-relic-license-key.arn
+    ]
+  }
 }
 
 resource "aws_iam_policy" "api" {

--- a/aws/lambda-api/secrets_manager.tf
+++ b/aws/lambda-api/secrets_manager.tf
@@ -13,5 +13,5 @@ data "aws_secretsmanager_secret" "new-relic-license-key-secret" {
 }
 
 data "aws_secretsmanager_secret_version" "new-relic-license-key" {
-  secret_id = data.aws_secretsmanager_secret.new-relic-license-key.id
+  secret_id = data.aws_secretsmanager_secret.new-relic-license-key-secret.id
 }

--- a/aws/lambda-api/secrets_manager.tf
+++ b/aws/lambda-api/secrets_manager.tf
@@ -7,11 +7,12 @@ resource "aws_secretsmanager_secret_version" "ecr-user-access-key" {
   secret_string = aws_iam_access_key.ecr-user.secret
 }
 
-# Created outside terraform when New Relic was integrated
-data "aws_secretsmanager_secret" "new-relic-license-key-secret" {
-  name = "NEW_RELIC_LICENSE_KEY"
+resource "aws_secretsmanager_secret" "new-relic-license-key" {
+  name        = "NEW_RELIC_LICENSE_KEY"
+  description = "The New Relic license key, for sending telemetry"
 }
 
-data "aws_secretsmanager_secret_version" "new-relic-license-key" {
-  secret_id = data.aws_secretsmanager_secret.new-relic-license-key-secret.id
+resource "aws_secretsmanager_secret_version" "new-relic-license-key" {
+  secret_id     = aws_secretsmanager_secret.new-relic-license-key.id
+  secret_string = var.new_relic_license_key
 }

--- a/aws/lambda-api/secrets_manager.tf
+++ b/aws/lambda-api/secrets_manager.tf
@@ -6,3 +6,12 @@ resource "aws_secretsmanager_secret_version" "ecr-user-access-key" {
   secret_id     = aws_secretsmanager_secret.ecr-user-access-key.id
   secret_string = aws_iam_access_key.ecr-user.secret
 }
+
+# Created outside terraform when New Relic was integrated
+data "aws_secretsmanager_secret" "new-relic-license-key-secret" {
+  name = "NEW_RELIC_LICENSE_KEY"
+}
+
+data "aws_secretsmanager_secret_version" "new-relic-license-key" {
+  secret_id = data.aws_secretsmanager_secret.new-relic-license-key.id
+}

--- a/aws/lambda-api/variables.tf
+++ b/aws/lambda-api/variables.tf
@@ -22,6 +22,11 @@ variable "new_relic_distribution_tracing_enabled" {
   type = string
 }
 
+variable "new_relic_license_key" {
+  type      = string
+  sensitive = true
+}
+
 variable "notification_queue_prefix" {
   type = string
 }


### PR DESCRIPTION
The new relic agent is failing to startup since it's missing permissions to retrieve the license file secret.

```
[NR_EXT] Failed to retrieve New Relic license key AccessDeniedException: User: arn:aws:sts::239043911459:assumed-role/notify-api/api-lambda is not authorized to perform: secretsmanager:GetSecretValue on resource: NEW_RELIC_LICENSE_KEY because no identity-based policy allows the secretsmanager:GetSecretValue action
```