### PR TITLE
feat: create Firehose WAF logging IAM role

### DIFF
--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -53,3 +53,7 @@ output "s3_bucket_asset_bucket_arn" {
 output "s3_bucket_csv_upload_bucket_arn" {
   value = aws_s3_bucket.csv_bucket.arn
 }
+
+output "firehose_waf_logs_iam_role_arn" {
+  value = aws_iam_role.firehose_waf_logs.arn
+}

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -260,3 +260,13 @@ resource "aws_cloudwatch_log_group" "notification-canada-ca-waf-logs" {
     CostCenter = "notification-canada-ca-${var.env}"
   }
 }
+
+resource "aws_wafv2_web_acl_logging_configuration" "cloudwatch-waf-logs" {
+  log_destination_configs = [aws_cloudwatch_log_group.notification-canada-ca-waf-logs.arn]
+  resource_arn            = aws_wafv2_web_acl.api_lambda.arn
+  redacted_fields {
+    single_header {
+      name = "authorization"
+    }
+  }
+}

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -263,7 +263,7 @@ resource "aws_cloudwatch_log_group" "notification-canada-ca-waf-logs" {
 
 resource "aws_wafv2_web_acl_logging_configuration" "cloudwatch-waf-logs" {
   log_destination_configs = [aws_cloudwatch_log_group.notification-canada-ca-waf-logs.arn]
-  resource_arn            = aws_wafv2_web_acl.api_lambda.arn
+  resource_arn            = aws_wafv2_web_acl.notification-canada-ca.arn
   redacted_fields {
     single_header {
       name = "authorization"

--- a/aws/lambda-api/waf.tf
+++ b/aws/lambda-api/waf.tf
@@ -167,3 +167,13 @@ resource "aws_cloudwatch_log_group" "notification-canada-ca-api-lambda-waf-logs"
     CostCenter = "notification-canada-ca-${var.env}"
   }
 }
+
+resource "aws_wafv2_web_acl_logging_configuration" "cloudwatch-api-lambda-waf-logs" {
+  log_destination_configs = [aws_cloudwatch_log_group.notification-canada-ca-api-lambda-waf-logs.arn]
+  resource_arn            = aws_wafv2_web_acl.api_lambda.arn
+  redacted_fields {
+    single_header {
+      name = "authorization"
+    }
+  }
+}

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -12,7 +12,8 @@ inputs = {
   elb_account_ids = {
     "ca-central-1" = "985666609251"
   }
-  new_relic_account_id = "2691974"
+  new_relic_account_id      = "2691974"
+  cbs_satellite_bucket_name = "cbs-satellite-${local.vars.inputs.account_id}"
 }
 
 generate "provider" {
@@ -80,6 +81,11 @@ variable "region" {
 variable "elb_account_ids" {
   description = "AWS account IDs used by load balancers"
   type        = map(string)
+}
+
+variable "cbs_satellite_bucket_name" {
+  description = "Name of the Cloud Based Sensor S3 satellite bucket"
+  type        = string
 }
 EOF
 }


### PR DESCRIPTION
# Summary
This role will be used by a Kinesis Firehose to send WAF ACL
logs to the Cloud Based Sensor satellite bucket.

It is being created first so that its ARN can be used as an
output by the EKS and Lambda API Terraform modules.

# Related
*  #429 
* cds-snc/notification-planning#525