### PR TITLE
feat: pin the EC2 node AMI release version

### DIFF
--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -47,7 +47,8 @@ resource "aws_eks_node_group" "notification-canada-ca-eks-node-group" {
   node_role_arn   = aws_iam_role.eks-worker-role.arn
   subnet_ids      = var.vpc_private_subnets
 
-  instance_types = var.primary_worker_instance_types
+  release_version = var.eks_node_ami_version
+  instance_types  = var.primary_worker_instance_types
 
   scaling_config {
     desired_size = var.primary_worker_desired_size

--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -57,7 +57,7 @@ resource "aws_eks_node_group" "notification-canada-ca-eks-node-group" {
   }
 
   update_config {
-    max_unavailable_percentage = 25
+    max_unavailable = 1
   }
 
   # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.

--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -56,6 +56,10 @@ resource "aws_eks_node_group" "notification-canada-ca-eks-node-group" {
     min_size     = var.primary_worker_min_size
   }
 
+  update_config {
+    max_unavailable_percentage = 25
+  }
+
   # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.
   # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
   depends_on = [

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -58,6 +58,11 @@ variable "firehose_waf_logs_iam_role_arn" {
   type = string
 }
 
+variable "eks_node_ami_version" {
+  description = "The Amazon Machine Image version used by the EKS EC2 nodes" # https://docs.aws.amazon.com/eks/latest/userguide/eks-linux-ami-versions.html
+  type        = string
+}
+
 locals {
   eks_application_log_group = "/aws/containerinsights/${var.eks_cluster_name}/application"
 }

--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -38,4 +38,5 @@ inputs = {
   firehose_waf_logs_iam_role_arn         = dependency.common.outputs.firehose_waf_logs_iam_role_arn
   cloudfront_assets_arn                  = dependency.cloudfront.outputs.cloudfront_assets_arn
   eks_cluster_name                       = "notification-canada-ca-production-eks-cluster"
+  eks_node_ami_version                   = "1.19.15-20220309"
 }

--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -38,5 +38,5 @@ inputs = {
   firehose_waf_logs_iam_role_arn         = dependency.common.outputs.firehose_waf_logs_iam_role_arn
   cloudfront_assets_arn                  = dependency.cloudfront.outputs.cloudfront_assets_arn
   eks_cluster_name                       = "notification-canada-ca-production-eks-cluster"
-  eks_node_ami_version                   = "1.19.15-20220309"
+  eks_node_ami_version                   = "1.19.15-20220317"
 }

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -68,7 +68,7 @@ inputs = {
   firehose_waf_logs_iam_role_arn         = dependency.common.outputs.firehose_waf_logs_iam_role_arn
   cloudfront_assets_arn                  = dependency.cloudfront.outputs.cloudfront_assets_arn
   eks_cluster_name                       = "notification-canada-ca-staging-eks-cluster"
-  eks_node_ami_version                   = "1.19.15-20220309"  
+  eks_node_ami_version                   = "1.19.15-20220317"  
 }
 
 terraform {

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -68,6 +68,7 @@ inputs = {
   firehose_waf_logs_iam_role_arn         = dependency.common.outputs.firehose_waf_logs_iam_role_arn
   cloudfront_assets_arn                  = dependency.cloudfront.outputs.cloudfront_assets_arn
   eks_cluster_name                       = "notification-canada-ca-staging-eks-cluster"
+  eks_node_ami_version                   = "1.19.15-20220309"  
 }
 
 terraform {


### PR DESCRIPTION
# Summary
Update the EKS node group to pin the AMI version being used
by the nodes.  Without this, it always defaults to `latest`.

# Related
* cds-snc/notification-planning#535