### PR TITLE
fix: remove CloudWatch WAF ACL log destination

### DIFF
--- a/aws/common/athena.tf
+++ b/aws/common/athena.tf
@@ -52,6 +52,6 @@ resource "aws_athena_named_query" "create_table_waf_logs" {
     {
       database_name   = aws_athena_database.notification_athena.name
       table_name      = "waf_logs"
-      bucket_location = "s3://${var.cbs_satellite_bucket_name}/waf_acl_logs/AWSLogs/${var.account_id}/lb/${var.region}/"
+      bucket_location = "s3://${var.cbs_satellite_bucket_name}/waf_acl_logs/AWSLogs/${var.account_id}/lb/"
   })
 }

--- a/aws/common/athena.tf
+++ b/aws/common/athena.tf
@@ -43,3 +43,15 @@ resource "aws_athena_named_query" "create_table_alb_logs" {
       bucket_location = "s3://${var.cbs_satellite_bucket_name}/lb_logs/AWSLogs/${var.account_id}/elasticloadbalancing/${var.region}/"
   })
 }
+
+resource "aws_athena_named_query" "create_table_waf_logs" {
+  name      = "create_table_waf_logs"
+  workgroup = aws_athena_workgroup.primary.name
+  database  = aws_athena_database.notification_athena.name
+  query = templatefile("${path.module}/sql/waf_log_create_table.sql.tmpl",
+    {
+      database_name   = aws_athena_database.notification_athena.name
+      table_name      = "waf_logs"
+      bucket_location = "s3://${var.cbs_satellite_bucket_name}/waf_acl_logs/AWSLogs/${var.account_id}/lb/${var.region}/"
+  })
+}

--- a/aws/common/athena.tf
+++ b/aws/common/athena.tf
@@ -40,6 +40,6 @@ resource "aws_athena_named_query" "create_table_alb_logs" {
     {
       database_name   = aws_athena_database.notification_athena.name
       table_name      = "alb_logs"
-      bucket_location = "s3://${var.cbs_satellite_bucket_name}/lb_logs/AWSLogs/${var.account_id}/elasticloadbalancing/${var.region}"
+      bucket_location = "s3://${var.cbs_satellite_bucket_name}/lb_logs/AWSLogs/${var.account_id}/elasticloadbalancing/${var.region}/"
   })
 }

--- a/aws/common/sql/alb_log_create_table.sql.tmpl
+++ b/aws/common/sql/alb_log_create_table.sql.tmpl
@@ -1,7 +1,7 @@
 -- Inspired from the following links:
 -- https://docs.aws.amazon.com/athena/latest/ug/application-load-balancer-logs.html
 -- https://github.com/yutachaos/terraform-aws-athena-alb-logs
-CREATE EXTERNAL TABLE IF NOT EXISTS `${database_name}.${table_name}`(
+CREATE EXTERNAL TABLE IF NOT EXISTS `${database_name}.${table_name}` (
                type string,
                time string,
                elb string,
@@ -12,7 +12,7 @@ CREATE EXTERNAL TABLE IF NOT EXISTS `${database_name}.${table_name}`(
                request_processing_time double,
                target_processing_time double,
                response_processing_time double,
-               elb_status_code string,
+               elb_status_code int,
                target_status_code string,
                received_bytes bigint,
                sent_bytes bigint,
@@ -36,12 +36,9 @@ CREATE EXTERNAL TABLE IF NOT EXISTS `${database_name}.${table_name}`(
                classification string,
                classification_reason string
             )
-            PARTITIONED BY (
-               year string, month string, day string
-            )
             ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.RegexSerDe'
             WITH SERDEPROPERTIES (
                'serialization.format' = '1',
-               'input.regex' =
-               '([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*):([0-9]*) ([^ ]*)[:-]([0-9]*) ([-.0-9]*) ([-.0-9]*) ([-.0-9]*) (|[-0-9]*) (-|[-0-9]*) ([-0-9]*) ([-0-9]*) \"([^ ]*) ([^ ]*) (- |[^ ]*)\" \"([^\"]*)\" ([A-Z0-9-]+) ([A-Za-z0-9.-]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^\"]*)\" ([-.0-9]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^ ]*)\" \"([^\s]+?)\" \"([^\s]+)\" \"([^ ]*)\" \"([^ ]*)\"')
-            LOCATION '${bucket_location}'
+               'input.regex' = 
+               '([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*):([0-9]*) ([^ ]*)[:-]([0-9]*) ([-.0-9]*) ([-.0-9]*) ([-.0-9]*) (|[-0-9]*) (-|[-0-9]*) ([-0-9]*) ([-0-9]*) \"([^ ]*) (.*) (- |[^ ]*)\" \"([^\"]*)\" ([A-Z0-9-_]+) ([A-Za-z0-9.-]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^\"]*)\" ([-.0-9]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^ ]*)\" \"([^\s]+?)\" \"([^\s]+)\" \"([^ ]*)\" \"([^ ]*)\"')
+            LOCATION '${bucket_location}';

--- a/aws/common/sql/waf_log_create_table.sql.tmpl
+++ b/aws/common/sql/waf_log_create_table.sql.tmpl
@@ -1,0 +1,107 @@
+-- Inspired from the following links:
+-- https://docs.aws.amazon.com/athena/latest/ug/waf-logs.html#create-waf-table
+CREATE EXTERNAL TABLE `${database_name}.${table_name}` (
+  `timestamp` bigint,
+  `formatversion` int,
+  `webaclid` string,
+  `terminatingruleid` string,
+  `terminatingruletype` string,
+  `action` string,
+  `terminatingrulematchdetails` array<
+                                  struct<
+                                    conditiontype:string,
+                                    location:string,
+                                    matcheddata:array<string>
+                                        >
+                                     >,
+  `httpsourcename` string,
+  `httpsourceid` string,
+  `rulegrouplist` array<
+                     struct<
+                        rulegroupid:string,
+                        terminatingrule:struct<
+                           ruleid:string,
+                           action:string,
+                           rulematchdetails:string
+                                               >,
+                        nonterminatingmatchingrules:array<
+                                                       struct<
+                                                          ruleid:string,
+                                                          action:string,
+                                                          rulematchdetails:array<
+                                                               struct<
+                                                                  conditiontype:string,
+                                                                  location:string,
+                                                                  matcheddata:array<string>
+                                                                     >
+                                                                  >
+                                                               >
+                                                            >,
+                        excludedrules:array<
+                                         struct<
+                                            ruleid:string,
+                                            exclusiontype:string
+                                               >
+                                            >
+                           >
+                       >,
+  `ratebasedrulelist` array<
+                        struct<
+                          ratebasedruleid:string,
+                          ratebasedrulename:string,
+                          limitkey:string,
+                          limitvalue:string,
+                          maxrateallowed:int
+                              >
+                           >,
+  `nonterminatingmatchingrules` array<
+                                  struct<
+                                    ruleid:string,
+                                    action:string,
+                                    rulematchdetails:array<
+                                        struct<
+                                            conditiontype:string,
+                                            location:string,
+                                            matcheddata:array<string>
+                                              >
+                                            >,
+                                    captcharesponse:struct<
+                                                    responsecode:string,
+                                                    solvetimestamp:bigint
+                                                          >
+                                        >
+                                     >,
+  `requestheadersinserted` string,
+  `responsecodesent` string,
+  `httprequest` struct<
+                      clientip:string,
+                      country:string,
+                      headers:array<
+                                struct<
+                                  name:string,
+                                  value:string
+                                      >
+                                   >,
+                      uri:string,
+                      args:string,
+                      httpversion:string,
+                      httpmethod:string,
+                      requestid:string
+                      >,
+  `labels` array<
+             struct<
+               name:string
+                   >
+                  >,
+  `captcharesponse` struct<
+                        responsecode:string,
+                        solvetimestamp:bigint,
+                        failurereason:string
+                    >
+)
+ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
+WITH SERDEPROPERTIES (
+ 'paths'='action,formatVersion,httpRequest,httpSourceId,httpSourceName,labels,nonTerminatingMatchingRules,rateBasedRuleList,requestHeadersInserted,responseCodeSent,ruleGroupList,terminatingRuleId,terminatingRuleMatchDetails,terminatingRuleType,timestamp,webaclId,captchaResponse')
+STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'
+OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
+LOCATION '${bucket_location}';

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -245,33 +245,6 @@ resource "aws_wafv2_regex_pattern_set" "re_document_download" {
 }
 
 #
-# WAF logging to CloudWatch log group
-#
-resource "aws_wafv2_web_acl_logging_configuration" "notification-canada-ca-waf-logs" {
-  log_destination_configs = [aws_cloudwatch_log_group.notification-canada-ca-waf-logs.arn]
-  resource_arn            = aws_wafv2_web_acl.notification-canada-ca.arn
-}
-
-resource "aws_cloudwatch_log_group" "notification-canada-ca-waf-logs" {
-  name              = "aws-waf-logs-notification-canada-ca-waf"
-  retention_in_days = 7
-
-  tags = {
-    CostCenter = "notification-canada-ca-${var.env}"
-  }
-}
-
-resource "aws_wafv2_web_acl_logging_configuration" "cloudwatch-waf-logs" {
-  log_destination_configs = [aws_cloudwatch_log_group.notification-canada-ca-waf-logs.arn]
-  resource_arn            = aws_wafv2_web_acl.notification-canada-ca.arn
-  redacted_fields {
-    single_header {
-      name = "authorization"
-    }
-  }
-}
-
-#
 # WAF logging to Cloud Based Sensor satellite bucket
 #
 resource "aws_kinesis_firehose_delivery_stream" "firehose-waf-logs" {

--- a/aws/lambda-api/waf.tf
+++ b/aws/lambda-api/waf.tf
@@ -152,33 +152,6 @@ resource "aws_wafv2_web_acl" "api_lambda" {
 }
 
 #
-# WAF logging to CloudWatch log group
-#
-resource "aws_wafv2_web_acl_logging_configuration" "notification-canada-ca-api-lambda-waf-logs" {
-  log_destination_configs = [aws_cloudwatch_log_group.notification-canada-ca-api-lambda-waf-logs.arn]
-  resource_arn            = aws_wafv2_web_acl.api_lambda.arn
-}
-
-resource "aws_cloudwatch_log_group" "notification-canada-ca-api-lambda-waf-logs" {
-  name              = "aws-waf-logs-notification-canada-ca-api-lambda-waf"
-  retention_in_days = 7
-
-  tags = {
-    CostCenter = "notification-canada-ca-${var.env}"
-  }
-}
-
-resource "aws_wafv2_web_acl_logging_configuration" "cloudwatch-api-lambda-waf-logs" {
-  log_destination_configs = [aws_cloudwatch_log_group.notification-canada-ca-api-lambda-waf-logs.arn]
-  resource_arn            = aws_wafv2_web_acl.api_lambda.arn
-  redacted_fields {
-    single_header {
-      name = "authorization"
-    }
-  }
-}
-
-#
 # WAF logging to Cloud Based Sensor satellite bucket
 #
 resource "aws_kinesis_firehose_delivery_stream" "firehose-api-lambda-waf-logs" {


### PR DESCRIPTION
# Summary
Delete the CloudWatch WAF ACL logging destination as the S3
bucket + Firehose is required by Cloud Based Sensor. An Athena
query has been added to create a table from the WAF logs.

Also fixes the Athena query that create's a table from the load balancer
S3 access logs bucket. The previous query was running successfully, 
but failing to pull any data into the new table.