### PR TITLE
chore: trigger re-create of WAF ACL logging config

### DIFF
--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -275,6 +275,7 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose-waf-logs" {
 resource "aws_wafv2_web_acl_logging_configuration" "firehose-waf-logs" {
   log_destination_configs = [aws_kinesis_firehose_delivery_stream.firehose-waf-logs.arn]
   resource_arn            = aws_wafv2_web_acl.notification-canada-ca.arn
+
   redacted_fields {
     single_header {
       name = "authorization"

--- a/aws/lambda-api/waf.tf
+++ b/aws/lambda-api/waf.tf
@@ -182,6 +182,7 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose-api-lambda-waf-logs" {
 resource "aws_wafv2_web_acl_logging_configuration" "firehose-api-lambda-waf-logs" {
   log_destination_configs = [aws_kinesis_firehose_delivery_stream.firehose-api-lambda-waf-logs.arn]
   resource_arn            = aws_wafv2_web_acl.api_lambda.arn
+
   redacted_fields {
     single_header {
       name = "authorization"


### PR DESCRIPTION
# Summary
During the apply of #438, the WAF ACL logging config was removed
and not recreated.  This formatting change will cause the logging config 
for Firehose to be recreated.

The reason this happened is because there was a misconfiguration
where two logging destinations had been set for a WAF ACL and
only one is supported.

# Related
* #438