### PR TITLE
feat: add weekly workflow check for EKS AMI update

### DIFF
--- a/.github/workflows/check_eks_ami_update.yml
+++ b/.github/workflows/check_eks_ami_update.yml
@@ -1,0 +1,46 @@
+name: Check for EKS AMI updates
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 13 * * 1" # 1pm Monday UTC
+
+env:
+  AWS_DEFAULT_REGION: ca-central-1
+  EKS_AMI_PARAMETER_STORE: /aws/service/eks/optimized-ami/1.19/amazon-linux-2/recommended/release_version
+  EKS_CLUSTER_NAME: notification-canada-ca-staging-eks-cluster
+  EKS_CLUSTER_NODE_GROUP_NAME: notification-canada-ca-staging-eks-primary-node-group
+
+jobs:
+  check-eks-ami-update:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+    - name: Get latest AMI image release version
+      id: latest
+      run: |
+        LATEST_AMI="$(aws ssm get-parameter \
+          --name ${{ env.EKS_AMI_PARAMETER_STORE }} \
+          --query 'Parameter.Value' --output text)"
+        echo "::set-output name=ami::${LATEST_AMI}"
+
+    - name: Get Staging cluter node group AMI image release version
+      id: current
+      run: |
+        CURRENT_AMI="$(aws eks describe-nodegroup \
+          --cluster-name ${{ env.EKS_CLUSTER_NAME }} \
+          --nodegroup-name ${{ env.EKS_CLUSTER_NODE_GROUP_NAME }} \
+          --query 'nodegroup.releaseVersion' --output text)"
+        echo "::set-output name=ami::${CURRENT_AMI}"
+
+    - name: Post to slack
+      if: steps.latest.outputs.ami != steps.current.outputs.ami
+      run: |
+        json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":kubernetes: Kubernetes worker update available: <https://docs.aws.amazon.com/eks/latest/userguide/eks-linux-ami-versions.html|${{ steps.latest.outputs.ami }}>"}}]}'
+        curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.NOTIFY_DEV_SLACK_WEBHOOK }} 


### PR DESCRIPTION
# Summary
Add a GitHub workflow that checks once a week for updates
available for the EKS node AMI release version.

If there is an update, a message will be posted to Slack.

# Related
* cds-snc/notification-planning#535