### PR TITLE
chore: upgrade worker node AMI versions

### DIFF
--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -38,5 +38,5 @@ inputs = {
   firehose_waf_logs_iam_role_arn         = dependency.common.outputs.firehose_waf_logs_iam_role_arn
   cloudfront_assets_arn                  = dependency.cloudfront.outputs.cloudfront_assets_arn
   eks_cluster_name                       = "notification-canada-ca-production-eks-cluster"
-  eks_node_ami_version                   = "1.19.15-20220317"
+  eks_node_ami_version                   = "1.19.15-20220406"
 }

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -68,7 +68,7 @@ inputs = {
   firehose_waf_logs_iam_role_arn         = dependency.common.outputs.firehose_waf_logs_iam_role_arn
   cloudfront_assets_arn                  = dependency.cloudfront.outputs.cloudfront_assets_arn
   eks_cluster_name                       = "notification-canada-ca-staging-eks-cluster"
-  eks_node_ami_version                   = "1.19.15-20220317"  
+  eks_node_ami_version                   = "1.19.15-20220406"  
 }
 
 terraform {


### PR DESCRIPTION
# Summary
Bump release version of EKS worker nodes to latest.

# Related
* cds-snc/notification-planning#535