### PR TITLE
fix: remove Lambda API_HOST_NAME variable

### DIFF
--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -23,7 +23,6 @@ resource "aws_lambda_function" "api" {
   environment {
     variables = {
       ADMIN_BASE_URL                        = var.admin_base_url
-      API_HOST_NAME                         = "https://${var.api_domain_name}"
       DOCUMENT_DOWNLOAD_API_HOST            = var.document_download_api_host
       SQLALCHEMY_DATABASE_URI               = var.sqlalchemy_database_uri
       SQLALCHEMY_DATABASE_READER_URI        = var.sqlalchemy_database_reader_uri


### PR DESCRIPTION
# Summary
The `API_HOST_NAME` is no longer needed as it is being provided by the 
Kubernetes `.env` files (added in cds-snc/notification-manifests#1053).

# ⚠️  Note
This also includes the updated New Relic license key being deployed to Staging.