### PR TITLE
feat: add Kubernetes cluster version

### DIFF
--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -5,6 +5,7 @@
 resource "aws_eks_cluster" "notification-canada-ca-eks-cluster" {
   name     = var.eks_cluster_name
   role_arn = aws_iam_role.eks-cluster-role.arn
+  version  = var.eks_cluster_version
 
   enabled_cluster_log_types = ["api", "audit", "controllerManager", "scheduler", "authenticator"]
 

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -54,6 +54,11 @@ variable "eks_cluster_name" {
   type = string
 }
 
+variable "eks_cluster_version" {
+  description = "Kubernetes version of the cluster"
+  type        = string
+}
+
 variable "firehose_waf_logs_iam_role_arn" {
   type = string
 }

--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -38,5 +38,6 @@ inputs = {
   firehose_waf_logs_iam_role_arn         = dependency.common.outputs.firehose_waf_logs_iam_role_arn
   cloudfront_assets_arn                  = dependency.cloudfront.outputs.cloudfront_assets_arn
   eks_cluster_name                       = "notification-canada-ca-production-eks-cluster"
+  eks_cluster_version                    = "1.19"
   eks_node_ami_version                   = "1.19.15-20220406"
 }

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -68,7 +68,8 @@ inputs = {
   firehose_waf_logs_iam_role_arn         = dependency.common.outputs.firehose_waf_logs_iam_role_arn
   cloudfront_assets_arn                  = dependency.cloudfront.outputs.cloudfront_assets_arn
   eks_cluster_name                       = "notification-canada-ca-staging-eks-cluster"
-  eks_node_ami_version                   = "1.19.15-20220406"  
+  eks_cluster_version                    = "1.20"
+  eks_node_ami_version                   = "1.20.11-20220406"  
 }
 
 terraform {


### PR DESCRIPTION
# Summary
Set the Kubernetes cluster version in the Terraform which
will allow for cluster upgrades through PRs.

The full cluster upgrade will be tested in Staging before
making the same version bump for Production.

# Related
* cds-snc/notification-planning#555