### PR TITLE
feat: k8s v1.21 upgrade and EKS addons

### DIFF
--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -93,3 +93,28 @@ resource "aws_eks_fargate_profile" "notification-canada-ca-fargate-profile" {
     }
   }
 }
+
+###
+# AWS EKS addons
+###
+
+resource "aws_eks_addon" "coredns" {
+  cluster_name      = aws_eks_cluster.notification-canada-ca-eks-cluster.name
+  addon_name        = "coredns"
+  addon_version     = var.eks_addon_coredns_version
+  resolve_conflicts = "OVERWRITE"
+}
+
+resource "aws_eks_addon" "kube_proxy" {
+  cluster_name      = aws_eks_cluster.notification-canada-ca-eks-cluster.name
+  addon_name        = "kube-proxy"
+  addon_version     = var.eks_addon_kube_proxy_version
+  resolve_conflicts = "OVERWRITE"
+}
+
+resource "aws_eks_addon" "vpc_cni" {
+  cluster_name      = aws_eks_cluster.notification-canada-ca-eks-cluster.name
+  addon_name        = "vpc-cni"
+  addon_version     = var.eks_addon_vpc_cni_version
+  resolve_conflicts = "OVERWRITE"
+}

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -59,6 +59,21 @@ variable "eks_cluster_version" {
   type        = string
 }
 
+variable "eks_addon_coredns_version" {
+  description = "CoreDNS EKS addon version"
+  type        = string
+}
+
+variable "eks_addon_kube_proxy_version" {
+  description = "kube-proxy EKS addon version"
+  type        = string
+}
+
+variable "eks_addon_vpc_cni_version" {
+  description = "VPC-CNI EKS addon version"
+  type        = string
+}
+
 variable "firehose_waf_logs_iam_role_arn" {
   type = string
 }

--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -39,5 +39,8 @@ inputs = {
   cloudfront_assets_arn                  = dependency.cloudfront.outputs.cloudfront_assets_arn
   eks_cluster_name                       = "notification-canada-ca-production-eks-cluster"
   eks_cluster_version                    = "1.20"
+  eks_addon_coredns_version              = "v1.8.3-eksbuild.1"
+  eks_addon_kube_proxy_version           = "v1.20.4-eksbuild.2"
+  eks_addon_vpc_cni_version              = "v1.11.0-eksbuild.1"  
   eks_node_ami_version                   = "1.20.11-20220406"
 }

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -68,8 +68,11 @@ inputs = {
   firehose_waf_logs_iam_role_arn         = dependency.common.outputs.firehose_waf_logs_iam_role_arn
   cloudfront_assets_arn                  = dependency.cloudfront.outputs.cloudfront_assets_arn
   eks_cluster_name                       = "notification-canada-ca-staging-eks-cluster"
-  eks_cluster_version                    = "1.20"
-  eks_node_ami_version                   = "1.20.11-20220406"  
+  eks_cluster_version                    = "1.21"
+  eks_addon_coredns_version              = "v1.8.3-eksbuild.1"
+  eks_addon_kube_proxy_version           = "v1.20.4-eksbuild.2"
+  eks_addon_vpc_cni_version              = "v1.11.0-eksbuild.1"
+  eks_node_ami_version                   = "1.21.5-20220420"
 }
 
 terraform {


### PR DESCRIPTION
# Summary
Upgrade the Kubernetes cluster to v1.21 and bump node
worker AMI release versions.

Also adds Terraform resources to manage EKS CoreDNS,
kube-proxy and vpc-cni addon versions.

# Related
* cds-snc/notification-planning#555