### PR TITLE
chore: upgrade coredns/kube-proxy EKS addons

### DIFF
--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -69,8 +69,8 @@ inputs = {
   cloudfront_assets_arn                  = dependency.cloudfront.outputs.cloudfront_assets_arn
   eks_cluster_name                       = "notification-canada-ca-staging-eks-cluster"
   eks_cluster_version                    = "1.21"
-  eks_addon_coredns_version              = "v1.8.3-eksbuild.1"
-  eks_addon_kube_proxy_version           = "v1.20.4-eksbuild.2"
+  eks_addon_coredns_version              = "v1.8.4-eksbuild.1"
+  eks_addon_kube_proxy_version           = "v1.21.2-eksbuild.2"
   eks_addon_vpc_cni_version              = "v1.11.0-eksbuild.1"
   eks_node_ami_version                   = "1.21.5-20220420"
 }


### PR DESCRIPTION
# Summary
Upgrade the CoreDNS and kube-proxy EKS addons to the
recommended versions for Kubernetes 1.21.

# Related
* cds-snc/notification-planning#555