### PR TITLE
chore: upgrade CoreDNS and kube-proxy versions

### DIFF
--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -39,8 +39,8 @@ inputs = {
   cloudfront_assets_arn                  = dependency.cloudfront.outputs.cloudfront_assets_arn
   eks_cluster_name                       = "notification-canada-ca-production-eks-cluster"
   eks_cluster_version                    = "1.21"
-  eks_addon_coredns_version              = "v1.8.3-eksbuild.1"
-  eks_addon_kube_proxy_version           = "v1.20.4-eksbuild.2"
+  eks_addon_coredns_version              = "v1.8.4-eksbuild.1"
+  eks_addon_kube_proxy_version           = "v1.21.2-eksbuild.2"
   eks_addon_vpc_cni_version              = "v1.11.0-eksbuild.1"  
   eks_node_ami_version                   = "1.21.5-20220420"
 }


### PR DESCRIPTION
# Summary
Upgrade the CoreDNS and kube-proxy addons to the recommended
version for Kubernetes v1.21.

# ⚠️  Note
This PR should have no changes.  The upgrade will happen in a 
subsequent PR when the `infrastructure_version.txt` version
is bumped.

# Related
* cds-snc/notification-planning#555