### PR TITLE
chore: upgrade Staging Kubernetes to 1.22

### DIFF
--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -68,11 +68,11 @@ inputs = {
   firehose_waf_logs_iam_role_arn         = dependency.common.outputs.firehose_waf_logs_iam_role_arn
   cloudfront_assets_arn                  = dependency.cloudfront.outputs.cloudfront_assets_arn
   eks_cluster_name                       = "notification-canada-ca-staging-eks-cluster"
-  eks_cluster_version                    = "1.21"
+  eks_cluster_version                    = "1.22"
   eks_addon_coredns_version              = "v1.8.4-eksbuild.1"
   eks_addon_kube_proxy_version           = "v1.21.2-eksbuild.2"
   eks_addon_vpc_cni_version              = "v1.11.0-eksbuild.1"
-  eks_node_ami_version                   = "1.21.5-20220420"
+  eks_node_ami_version                   = "1.22.6-20220421"
 }
 
 terraform {

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -72,7 +72,7 @@ inputs = {
   eks_addon_coredns_version              = "v1.8.4-eksbuild.1"
   eks_addon_kube_proxy_version           = "v1.21.2-eksbuild.2"
   eks_addon_vpc_cni_version              = "v1.11.0-eksbuild.1"
-  eks_node_ami_version                   = "1.22.6-20220421"
+  eks_node_ami_version                   = "1.22.6-20220429"
 }
 
 terraform {


### PR DESCRIPTION
# Summary
Upgrade Staging Kubernetes cluster to `v1.22` and
bump the node group AMI release version.

# Related
* cds-snc/notification-planning#555