### PR TITLE
fix: do not publish new Lambda versions

### DIFF
--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -1,7 +1,6 @@
 resource "aws_lambda_function" "api" {
   function_name = "api-lambda"
   role          = aws_iam_role.api.arn
-  publish       = true
 
   package_type = "Image"
   image_uri    = "${aws_ecr_repository.api-lambda.repository_url}:${var.api_image_tag}"


### PR DESCRIPTION
# Summary
By default, Terraform does not publish new Lambda versions
when a create/change operation is performed.

This is the behaviour we would like as it will allow our
provisioned concurrency to stay in sync with the Lambda
function updates performed by the AWS cli in our
release workflows.