### PR TITLE
fix: update ECR user IAM policy

### DIFF
--- a/aws/lambda-api/ecr_user.tf
+++ b/aws/lambda-api/ecr_user.tf
@@ -61,6 +61,13 @@ data "aws_iam_policy_document" "ecr" {
     sid    = "PermissionsToUpdateFunction"
     effect = "Allow"
     actions = [
+      "lambda:GetAlias",
+      "lambda:GetFunction",
+      "lambda:GetFunctionConfiguration",
+      "lambda:ListAliases",
+      "lambda:ListVersionsByFunction",
+      "lambda:PublishVersion",
+      "lambda:UpdateAlias",
       "lambda:UpdateFunctionCode"
     ]
     resources = [local.api-lambda-function-arn]


### PR DESCRIPTION
# Summary
Allow the ECR user to also update the Lambda function's
version and alias.  This is being done so that the provisioned
concurrency for the Lambda function stays in sync with
the latest published function changes.