### PR TITLE
fix: autoscaling target reference function alias

### DIFF
--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -77,7 +77,7 @@ resource "aws_lambda_provisioned_concurrency_config" "api" {
 resource "aws_appautoscaling_target" "api" {
   min_capacity       = var.high_demand_min_concurrency
   max_capacity       = var.high_demand_max_concurrency
-  resource_id        = "function:${aws_lambda_function.api.function_name}:${aws_lambda_function.api.version}"
+  resource_id        = "function:${aws_lambda_function.api.function_name}:${aws_lambda_alias.api_latest.name}"
   scalable_dimension = "lambda:function:ProvisionedConcurrency"
   service_namespace  = "lambda"
   lifecycle {


### PR DESCRIPTION
# Summary
Update the Lambda API autoscaling target to reference the API alias
rather than its function version.

This is because we have switched to the `latest` function alias when
creating provisioned concurrency rather than using the function
version.