### PR TITLE
chore: upgrade CoreDNS and kube-proxy addons

### DIFF
--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -69,8 +69,8 @@ inputs = {
   cloudfront_assets_arn                  = dependency.cloudfront.outputs.cloudfront_assets_arn
   eks_cluster_name                       = "notification-canada-ca-staging-eks-cluster"
   eks_cluster_version                    = "1.22"
-  eks_addon_coredns_version              = "v1.8.4-eksbuild.1"
-  eks_addon_kube_proxy_version           = "v1.21.2-eksbuild.2"
+  eks_addon_coredns_version              = "v1.8.7-eksbuild.1"
+  eks_addon_kube_proxy_version           = "v1.22.6-eksbuild.1"
   eks_addon_vpc_cni_version              = "v1.11.0-eksbuild.1"
   eks_node_ami_version                   = "1.22.6-20220429"
 }


### PR DESCRIPTION
# Summary
Update the add-ons to the recommended version for Kubernetes v1.22.

Recommend versions are listed here:
* [CoreDNS](https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html)
* [kube-proxy](https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html)

# Related
* cds-snc/notification-planning#555