### PR TITLE
Re-enabling NewRelic config file

### DIFF
--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -31,6 +31,7 @@ resource "aws_lambda_function" "api" {
       NOTIFY_EMAIL_DOMAIN                   = var.domain
       NOTIFY_ENVIRONMENT                    = var.env
       REDIS_ENABLED                         = var.redis_enabled
+      NEW_RELIC_CONFIG_FILE                 = "/app/newrelic.ini"
       NEW_RELIC_ENVIRONMENT                 = var.env
       NEW_RELIC_LAMBDA_HANDLER              = "application.handler"
       NEW_RELIC_ACCOUNT_ID                  = var.new_relic_account_id


### PR DESCRIPTION
# Summary | Résumé

After temporarily disabling NewRelic config file for release purposes, we are now re-enabling NewRelic config file!

# Test instructions | Instructions pour tester la modification

This previously worked in staging environment... but things to watch out for:

* CloudWatch logs to makes sure NewRelic does not make the lambda-api crash.
