### PR TITLE
chore: update EKS addon versions

### DIFF
--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -39,8 +39,8 @@ inputs = {
   cloudfront_assets_arn                  = dependency.cloudfront.outputs.cloudfront_assets_arn
   eks_cluster_name                       = "notification-canada-ca-production-eks-cluster"
   eks_cluster_version                    = "1.22"
-  eks_addon_coredns_version              = "v1.8.4-eksbuild.1"
-  eks_addon_kube_proxy_version           = "v1.21.2-eksbuild.2"
+  eks_addon_coredns_version              = "v1.8.7-eksbuild.1"
+  eks_addon_kube_proxy_version           = "v1.22.6-eksbuild.1"
   eks_addon_vpc_cni_version              = "v1.11.0-eksbuild.1"  
   eks_node_ami_version                   = "1.22.6-20220429"
 }


### PR DESCRIPTION
# Summary 
Updates the Prod CoreDNS and kube-proxy add-ons to the recommended
versions for Kubernetes v1.22.

Recommend versions are listed here:
* [CoreDNS](https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html)
* [kube-proxy](https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html)

# ⚠️  Note
This will have no Terraform plan and will only be applied after
it is tagged and released in a subsequent PR.

# Related
* #474 
* cds-snc/notification-planning#555