### PR TITLE
fix: redeploy API gateway when config changes

### DIFF
--- a/aws/lambda-api/api_gateway.tf
+++ b/aws/lambda-api/api_gateway.tf
@@ -89,9 +89,14 @@ resource "aws_api_gateway_integration_response" "integration_response" {
 resource "aws_api_gateway_deployment" "api" {
   rest_api_id = aws_api_gateway_rest_api.api.id
 
+  triggers = {
+    redeployment = sha1(file("${path.module}/api_gateway.tf"))
+  }
+
   depends_on = [
     aws_api_gateway_integration.integration
   ]
+
   lifecycle {
     create_before_destroy = true
   }

--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -62,6 +62,7 @@ resource "aws_lambda_permission" "api_1" {
   statement_id  = "AllowAPIGatewayInvoke1"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.api.function_name
+  qualifier     = aws_lambda_alias.api_latest.name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_api_gateway_rest_api.api.execution_arn}/*/*"
 }


### PR DESCRIPTION
# Summary
This fix will cause the API gateway to be redeployed when there
are any configuration changes made.

Also updates the Lambda permissions to allow the API gateway
to execute the `latest` Lambda alias.