### PR TITLE
dashboards for inflights

### DIFF
--- a/aws/common/dashboard_inflights.tf
+++ b/aws/common/dashboard_inflights.tf
@@ -126,6 +126,9 @@ resource "aws_cloudwatch_dashboard" "inflights_dashboard" {
     ]
 }
 EOF
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
 }
 
 

--- a/aws/common/dashboard_inflights.tf
+++ b/aws/common/dashboard_inflights.tf
@@ -1,0 +1,133 @@
+resource "aws_cloudwatch_dashboard" "inflights_dashboard" {
+  dashboard_name = "Inflights"
+  dashboard_body = <<EOF
+{
+    "widgets": [
+        {
+            "height": 6,
+            "width": 6,
+            "y": 0,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "NotificationCanadaCa", "batch_saving_inflight", "notification_type", "email", "created", "True", "priority", "priority", { "label": "created" } ],
+                    [ "...", "acknowledged", ".", ".", ".", { "label": "acknowledged" } ],
+                    [ "...", "expired", ".", ".", ".", { "label": "expired" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ca-central-1",
+                "stat": "Sum",
+                "period": 300,
+                "title": "Priority email inflights"
+            }
+        },
+        {
+            "height": 6,
+            "width": 6,
+            "y": 0,
+            "x": 6,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "NotificationCanadaCa", "batch_saving_inflight", "notification_type", "email", "created", "True", "priority", "normal", { "label": "created" } ],
+                    [ "...", "acknowledged", ".", ".", ".", { "label": "acknowledged" } ],
+                    [ "...", "expired", ".", ".", ".", { "label": "expired" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ca-central-1",
+                "stat": "Sum",
+                "period": 300,
+                "title": "Normal email inflights"
+            }
+        },
+        {
+            "height": 6,
+            "width": 6,
+            "y": 0,
+            "x": 12,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "NotificationCanadaCa", "batch_saving_inflight", "notification_type", "email", "created", "True", "priority", "bulk", { "label": "created" } ],
+                    [ "...", "acknowledged", ".", ".", ".", { "label": "acknowledged" } ],
+                    [ "...", "expired", ".", ".", ".", { "label": "expired" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ca-central-1",
+                "stat": "Sum",
+                "period": 300,
+                "title": "Bulk email inflights"
+            }
+        },
+        {
+            "height": 6,
+            "width": 6,
+            "y": 6,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "NotificationCanadaCa", "batch_saving_inflight", "notification_type", "sms", "created", "True", "priority", "priority", { "label": "created" } ],
+                    [ "...", "acknowledged", ".", ".", ".", { "label": "acknowledged" } ],
+                    [ "...", "expired", ".", ".", ".", { "label": "expired" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ca-central-1",
+                "stat": "Sum",
+                "period": 300,
+                "title": "Priority sms inflights"
+            }
+        },
+        {
+            "height": 6,
+            "width": 6,
+            "y": 6,
+            "x": 6,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "NotificationCanadaCa", "batch_saving_inflight", "notification_type", "sms", "created", "True", "priority", "normal", { "label": "created" } ],
+                    [ "...", "acknowledged", ".", ".", ".", { "label": "acknowledged" } ],
+                    [ "...", "expired", ".", ".", ".", { "label": "expired" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ca-central-1",
+                "stat": "Sum",
+                "period": 300,
+                "title": "Normal sms inflights"
+            }
+        },
+        {
+            "height": 6,
+            "width": 6,
+            "y": 6,
+            "x": 12,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "NotificationCanadaCa", "batch_saving_inflight", "notification_type", "sms", "created", "True", "priority", "bulk", { "label": "created" } ],
+                    [ "...", "acknowledged", ".", ".", ".", { "label": "acknowledged" } ],
+                    [ "...", "expired", ".", ".", ".", { "label": "expired" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ca-central-1",
+                "stat": "Sum",
+                "period": 300,
+                "title": "Bulk sms inflights"
+            }
+        }
+    ]
+}
+EOF
+}
+
+
+
+

--- a/aws/common/dashboard_inflights.tf
+++ b/aws/common/dashboard_inflights.tf
@@ -1,12 +1,52 @@
 resource "aws_cloudwatch_dashboard" "inflights_dashboard" {
-  dashboard_name = "Inflights"
+  dashboard_name = "Redis batching"
   dashboard_body = <<EOF
 {
     "widgets": [
+          {
+            "height": 6,
+            "width": 9,
+            "y": 0,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "NotificationCanadaCa", "batch_saving_published", "list_name", "inbox:email:priority" ],
+                    [ "...", "inbox:email:normal" ],
+                    [ "...", "inbox:email:bulk" ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ca-central-1",
+                "stat": "Sum",
+                "period": 300,
+                "title": "Added to email inboxes"
+            }
+        },
+        {
+            "height": 6,
+            "width": 9,
+            "y": 0,
+            "x": 9,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "NotificationCanadaCa", "batch_saving_published", "list_name", "inbox:sms:priority" ],
+                    [ "...", "inbox:sms:normal" ],
+                    [ "...", "inbox:sms:bulk" ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ca-central-1",
+                "stat": "Sum",
+                "period": 300,
+                "title": "Added to sms inboxes"
+            }
+        },
         {
             "height": 6,
             "width": 6,
-            "y": 0,
+            "y": 6,
             "x": 0,
             "type": "metric",
             "properties": {
@@ -26,7 +66,7 @@ resource "aws_cloudwatch_dashboard" "inflights_dashboard" {
         {
             "height": 6,
             "width": 6,
-            "y": 0,
+            "y": 6,
             "x": 6,
             "type": "metric",
             "properties": {
@@ -46,7 +86,7 @@ resource "aws_cloudwatch_dashboard" "inflights_dashboard" {
         {
             "height": 6,
             "width": 6,
-            "y": 0,
+            "y": 6,
             "x": 12,
             "type": "metric",
             "properties": {
@@ -66,7 +106,7 @@ resource "aws_cloudwatch_dashboard" "inflights_dashboard" {
         {
             "height": 6,
             "width": 6,
-            "y": 6,
+            "y": 12,
             "x": 0,
             "type": "metric",
             "properties": {
@@ -86,7 +126,7 @@ resource "aws_cloudwatch_dashboard" "inflights_dashboard" {
         {
             "height": 6,
             "width": 6,
-            "y": 6,
+            "y": 12,
             "x": 6,
             "type": "metric",
             "properties": {
@@ -106,7 +146,7 @@ resource "aws_cloudwatch_dashboard" "inflights_dashboard" {
         {
             "height": 6,
             "width": 6,
-            "y": 6,
+            "y": 12,
             "x": 12,
             "type": "metric",
             "properties": {

--- a/aws/common/dashboard_inflights.tf
+++ b/aws/common/dashboard_inflights.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_dashboard" "inflights_dashboard" {
-  dashboard_name = "Redis batching"
+  dashboard_name = "Redis-batching"
   dashboard_body = <<EOF
 {
     "widgets": [

--- a/aws/common/dashboard_inflights.tf
+++ b/aws/common/dashboard_inflights.tf
@@ -1,5 +1,5 @@
-resource "aws_cloudwatch_dashboard" "inflights_dashboard" {
-  dashboard_name = "Redis-batching"
+resource "aws_cloudwatch_dashboard" "redis_batch_saving" {
+  dashboard_name = "Redis-batch-saving"
   dashboard_body = <<EOF
 {
     "widgets": [

--- a/aws/common/dashboard_inflights.tf
+++ b/aws/common/dashboard_inflights.tf
@@ -126,11 +126,4 @@ resource "aws_cloudwatch_dashboard" "inflights_dashboard" {
     ]
 }
 EOF
-  tags = {
-    CostCenter = "notification-canada-ca-${var.env}"
-  }
 }
-
-
-
-


### PR DESCRIPTION
# Summary | Résumé

Add dashboard for redis inboxes and inflights


![image](https://user-images.githubusercontent.com/8228248/171186821-3ce2cbcc-06bc-4f82-84b1-99db0f32bd33.png)


# Test instructions | Instructions pour tester la modification

On staging I copied the source to:
https://ca-central-1.console.aws.amazon.com/cloudwatch/home?region=ca-central-1#dashboards:name=temp-dashboard-pr

View the past week of data to see some things show up.