### PR TITLE
tweak Cloudwatch Insights query

### DIFF
--- a/aws/lambda-api/cloudwatch_queries.tf
+++ b/aws/lambda-api/cloudwatch_queries.tf
@@ -7,7 +7,7 @@ resource "aws_cloudwatch_query_definition" "api-lambda-errors" {
 
   query_string = <<QUERY
 fields @timestamp, @message, @logStream
-| filter levelname like /ERROR/
+| filter @message like /rror/
 | sort @timestamp desc
 | limit 20
 QUERY


### PR DESCRIPTION
# Summary | Résumé

We have Notify errors that don't have levelname ERROR, such as
```
{"name": "api", "levelname": "INFO", "message": "{'result': 'error', 'message': 'Template not found'}",
```
 
# Test instructions | Instructions pour tester la modification

Run and compare both versions of the query.
