### PR TITLE
Lowering data retention period for CSV uploads

### DIFF
--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -18,7 +18,7 @@ resource "aws_s3_bucket" "csv_bucket" {
     enabled = true
 
     expiration {
-      days = 30
+      days = 7
     }
   }
 


### PR DESCRIPTION
# Summary | Résumé

After a team talk, we realized that our data retention for CSV uploads does not match our advertised policy.

This change would not match our policy for provinces and territories set at 3 days but would at least improve the situation for now in a quick manner.

# Test instructions | Instructions pour tester la modification

* Check the S3 bucket once this comes in effect to see if there are documents still in the bucket that are older than  7 days.
