### PR TITLE
add WAF rule for new dd-api endpoint

### DIFF
--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -234,6 +234,11 @@ resource "aws_wafv2_regex_pattern_set" "re_document_download" {
     regex_string = "/services/[\\w]{8}-[\\w]{4}-[\\w]{4}-[\\w]{4}-[\\w]{12}/documents/[\\w]{8}-[\\w]{4}-[\\w]{4}-[\\w]{4}-[\\w]{12}"
   }
 
+  # GET /d/<base64_uuid:service_id>/<base64_uuid:document_id>
+  regular_expression {
+    regex_string = "/d/[\\w]{22}/[\\w]{22}"
+  }
+
   # POST /services/<uuid:service_id>/documents
   regular_expression {
     regex_string = "/services/[\\w]{8}-[\\w]{4}-[\\w]{4}-[\\w]{4}-[\\w]{12}/documents"


### PR DESCRIPTION
# Summary | Résumé

Going to add a new endpoint to document-download api that is the same format as the current one for document download frontend. (in support of [this card](https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/cds-snc/notification-planning/240))

This requires adding a new rule to the WAF to let this endpoint through.

See also https://github.com/cds-snc/notification-document-download-api/pull/65
