### PR TITLE
Added api sub-domain in the list of alt names in certificates

### DIFF
--- a/aws/dns/acm.tf
+++ b/aws/dns/acm.tf
@@ -22,7 +22,7 @@ resource "aws_acm_certificate" "notification-canada-ca-alt" {
   domain_name = var.alt_domain
   subject_alternative_names = [
     "*.${var.alt_domain}",
-    "*.api.${var.domain}",
+    "*.api.${var.alt_domain}",
     "*.document.${var.alt_domain}"
   ]
   validation_method = "DNS"

--- a/aws/dns/acm.tf
+++ b/aws/dns/acm.tf
@@ -9,9 +9,6 @@ resource "aws_acm_certificate" "notification-canada-ca" {
 
   lifecycle {
     create_before_destroy = true
-    # TF bug on AWS 2.0: prevents certificates from being destroyed/recreated
-    # https://github.com/hashicorp/terraform-provider-aws/issues/8531
-    ignore_changes = [subject_alternative_names]
   }
 
   tags = {
@@ -32,9 +29,6 @@ resource "aws_acm_certificate" "notification-canada-ca-alt" {
 
   lifecycle {
     create_before_destroy = true
-    # TF bug on AWS 2.0: prevents certificates from being destroyed/recreated
-    # https://github.com/hashicorp/terraform-provider-aws/issues/8531
-    ignore_changes = [subject_alternative_names]
   }
 
   tags = {

--- a/aws/dns/acm.tf
+++ b/aws/dns/acm.tf
@@ -2,6 +2,7 @@ resource "aws_acm_certificate" "notification-canada-ca" {
   domain_name = var.domain
   subject_alternative_names = [
     "*.${var.domain}",
+    "*.api.${var.domain}",
     "*.document.${var.domain}"
   ]
   validation_method = "DNS"
@@ -24,6 +25,7 @@ resource "aws_acm_certificate" "notification-canada-ca-alt" {
   domain_name = var.alt_domain
   subject_alternative_names = [
     "*.${var.alt_domain}",
+    "*.api.${var.domain}",
     "*.document.${var.alt_domain}"
   ]
   validation_method = "DNS"


### PR DESCRIPTION
# Summary | Résumé

Trying out to add a subdomain for `*.api.notification.canada.ca` as an alt name for our certificates, helping our friends using WebLogic as an app container, as indicated by [this Freshdesk ticket](https://cds-snc.freshdesk.com/a/tickets/9116).

Also removed an `ignore_changes` statement on a bug previously identified but that should not take place anymore with hashicorp/aws/3.0.0. Let's see how that works out.

# Test instructions | Instructions pour tester la modification

1. Head to staging or production environment with the new deployed certificate (e.g. `api.notification.canada.ca`).
2. Get the certificate details.
3. Check the Subject Alternative Name field and check if there is an entry for the new `*.api.notification.canada.ca` entry.

Here is a screenshot of the current certificate details without the new entry for the API sub-domain:

![image](https://user-images.githubusercontent.com/805567/179624522-de8c3ccf-fcea-4a7e-905a-bfba100a55b4.png)
