### PR TITLE
Revert addition of api sub-domain 

### DIFF
--- a/aws/dns/acm.tf
+++ b/aws/dns/acm.tf
@@ -2,13 +2,15 @@ resource "aws_acm_certificate" "notification-canada-ca" {
   domain_name = var.domain
   subject_alternative_names = [
     "*.${var.domain}",
-    "*.api.${var.domain}",
     "*.document.${var.domain}"
   ]
   validation_method = "DNS"
 
   lifecycle {
     create_before_destroy = true
+    # TF bug on AWS 2.0: prevents certificates from being destroyed/recreated
+    # https://github.com/hashicorp/terraform-provider-aws/issues/8531
+    ignore_changes = [subject_alternative_names]
   }
 
   tags = {
@@ -22,13 +24,15 @@ resource "aws_acm_certificate" "notification-canada-ca-alt" {
   domain_name = var.alt_domain
   subject_alternative_names = [
     "*.${var.alt_domain}",
-    "*.api.${var.alt_domain}",
     "*.document.${var.alt_domain}"
   ]
   validation_method = "DNS"
 
   lifecycle {
     create_before_destroy = true
+    # TF bug on AWS 2.0: prevents certificates from being destroyed/recreated
+    # https://github.com/hashicorp/terraform-provider-aws/issues/8531
+    ignore_changes = [subject_alternative_names]
   }
 
   tags = {


### PR DESCRIPTION
# Summary | Résumé

Because the addition of a new domain in the alternative names in our certificates proved more difficult than initially anticipated, I am reverting previously merged change around _addition of api sub-domain in the list of alt names in certificates_ to unblock the TF release pipeline.

The old certificates can't be properly destroyed at the moment as they kept being attached to the load balancer listener. We might have to recreate the load balancer in a way that won't affect downtime in production.

# Test instructions | Instructions pour tester la modification

Setup should be as before without plan and TF apply failures.