### PR TITLE
Added a non-wildcard version of the API SAN

### DIFF
--- a/.github/workflows/terraform_static_analysis.yml
+++ b/.github/workflows/terraform_static_analysis.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Terraform security scan
         uses: triat/terraform-security-scan@v2.2.1
         with:
-          tfsec_version: 'v1.26.3'
+          tfsec_version: 'v0.39.26'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/terraform_static_analysis.yml
+++ b/.github/workflows/terraform_static_analysis.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Terraform security scan
         uses: triat/terraform-security-scan@v2.2.1
         with:
-          tfsec_version: 'v0.39.26'
+          tfsec_version: 'v1.26.3'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/terraform_static_analysis.yml
+++ b/.github/workflows/terraform_static_analysis.yml
@@ -16,8 +16,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Terraform security scan
-        uses: triat/terraform-security-scan@v2.2.1
+        uses: aquasecurity/tfsec-action@v1.0.0
         with:
-          tfsec_version: 'v0.39.26'
+          version: 'v0.39.26'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/aws/dns/acm.tf
+++ b/aws/dns/acm.tf
@@ -3,6 +3,7 @@ resource "aws_acm_certificate" "notification-canada-ca" {
   subject_alternative_names = [
     "*.${var.domain}",
     "*.api.${var.domain}",
+    "api.${var.domain}",
     "*.document.${var.domain}"
   ]
   validation_method = "DNS"
@@ -23,6 +24,7 @@ resource "aws_acm_certificate" "notification-canada-ca-alt" {
   subject_alternative_names = [
     "*.${var.alt_domain}",
     "*.api.${var.alt_domain}",
+    "api.${var.alt_domain}",
     "*.document.${var.alt_domain}"
   ]
   validation_method = "DNS"


### PR DESCRIPTION
# Summary | Résumé

Trying out a non-wildcard of the API SAN in addition to a wildcard version. This is to help out the SSC users that are using WebLogic, which can't accept wildcard for the SANs.

# Test instructions | Instructions pour tester la modification

Look out for the non-wildcard API entry in the certificate subject alternative names when deployed.
