### PR TITLE
General waf rate limit

### DIFF
--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -162,7 +162,6 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
       sampled_requests_enabled   = true
     }
 
-
     statement {
       rate_based_statement {
         limit              = 500
@@ -193,10 +192,6 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
       }
     }
   }
-
-
-
-
 
   rule {
     name     = "document_download_invalid_path"

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -141,6 +141,64 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
   }
 
   rule {
+    name     = "rate_limit_all_except_api"
+    priority = 11
+
+    action {
+      block {
+        custom_response {
+          response_code = 403
+          response_header {
+            name  = "waf-block"
+            value = "RateLimitRestriction"
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "GeneralRateLimit"
+      sampled_requests_enabled   = true
+    }
+
+
+    statement {
+      rate_based_statement {
+        limit              = 500
+        aggregate_key_type = "IP"
+        scope_down_statement {
+          statement {
+            not_statement {
+              byte_match_statement {
+                positional_constraint = "STARTS_WITH"
+                field_to_match {
+                  single_header {
+                    name = "host"
+                  }
+                }
+                search_string = "api."
+                text_transformation {
+                  priority = 1
+                  type     = "COMPRESS_WHITE_SPACE"
+                }
+                text_transformation {
+                  priority = 2
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+
+
+
+
+  rule {
     name     = "document_download_invalid_path"
     priority = 10
 


### PR DESCRIPTION
# Summary | Résumé

Add a general rate limit for everything except api and dd-api.

# Test instructions | Instructions pour tester la modification

hit admin many times until you're blocked.
