### PR TITLE
Bump k8 node group to 1.22.9-20220725

### DIFF
--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -42,5 +42,5 @@ inputs = {
   eks_addon_coredns_version              = "v1.8.7-eksbuild.1"
   eks_addon_kube_proxy_version           = "v1.22.6-eksbuild.1"
   eks_addon_vpc_cni_version              = "v1.11.0-eksbuild.1"  
-  eks_node_ami_version                   = "1.22.9-20220629"
+  eks_node_ami_version                   = "1.22.9-20220725"
 }

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -72,7 +72,7 @@ inputs = {
   eks_addon_coredns_version              = "v1.8.7-eksbuild.1"
   eks_addon_kube_proxy_version           = "v1.22.6-eksbuild.1"
   eks_addon_vpc_cni_version              = "v1.11.0-eksbuild.1"
-  eks_node_ami_version                   = "1.22.9-20220629"
+  eks_node_ami_version                   = "1.22.9-20220725"
 }
 
 terraform {


### PR DESCRIPTION
# Summary | Résumé

Upgrading the k8 worker node group to `1.22.9-20220725`.

# Test instructions | Instructions pour tester la modification

Deploy to staging and run smoke tests to see if everything works fine.