### PR TITLE
[feat] waf: rate limit apis

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -32,6 +32,7 @@ env:
   TF_VAR_sqlalchemy_database_uri: ${{ secrets.PRODUCTION_SQLALCHEMY_DATABASE_URI }}
   TF_VAR_document_download_api_host: ${{ secrets.PRODUCTION_DOCUMENT_DOWNLOAD_API_HOST }}
   TF_VAR_new_relic_license_key: ${{ secrets.PRODUCTION_NEW_RELIC_LICENSE_KEY }}
+  TF_VAR_waf_secret: ${{secrets.PRODUCTION_WAF_SECRET}}
   # Prevents repeated creation of the Slack lambdas if already existing.
   # See: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/84
   TF_RECREATE_MISSING_LAMBDA_PACKAGE: false

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -39,6 +39,7 @@ env:
   TF_VAR_perf_test_email: ${{ secrets.PERF_TEST_EMAIL }}
   TF_VAR_perf_test_domain: ${{ secrets.PERF_TEST_DOMAIN }}
   TF_VAR_perf_test_auth_header: ${{ secrets.PERF_TEST_AUTH_HEADER }}
+  TF_VAR_waf_secret: ${{secrets.STAGING_WAF_SECRET}}
   # Prevents repeated creation of the Slack lambdas if already existing.
   # See: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/84
   TF_RECREATE_MISSING_LAMBDA_PACKAGE: false

--- a/.github/workflows/terragrunt_plan_production.yml
+++ b/.github/workflows/terragrunt_plan_production.yml
@@ -27,6 +27,7 @@ env:
   TF_VAR_sqlalchemy_database_reader_uri: ${{ secrets.PRODUCTION_SQLALCHEMY_DATABASE_READER_URI }}
   TF_VAR_sqlalchemy_database_uri: ${{ secrets.PRODUCTION_SQLALCHEMY_DATABASE_URI }}
   TF_VAR_new_relic_license_key: ${{ secrets.PRODUCTION_NEW_RELIC_LICENSE_KEY }}
+  TF_VAR_waf_secret: ${{secrets.PRODUCTION_WAF_SECRET}}
   # Prevents repeated creation of the Slack lambdas if already existing.
   # See: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/84
   TF_RECREATE_MISSING_LAMBDA_PACKAGE: false

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -31,6 +31,7 @@ env:
   TF_VAR_sqlalchemy_database_reader_uri: ${{ secrets.STAGING_SQLALCHEMY_DATABASE_READER_URI }}
   TF_VAR_sqlalchemy_database_uri: ${{ secrets.STAGING_SQLALCHEMY_DATABASE_URI }}
   TF_VAR_new_relic_license_key: ${{ secrets.STAGING_NEW_RELIC_LICENSE_KEY }}
+  TF_VAR_waf_secret: ${{secrets.STAGING_WAF_SECRET}}
   # Prevents repeated creation of the Slack lambdas if already existing.
   # See: https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/84
   TF_RECREATE_MISSING_LAMBDA_PACKAGE: false

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -382,6 +382,65 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     }
   }
 
+  rule {
+    name     = "ApiRateLimit"
+    priority = 210
+
+    action {
+      count {}
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "ApiRateLimit"
+      sampled_requests_enabled   = true
+    }
+    statement {
+      rate_based_statement {
+        limit              = var.api_waf_rate_limit
+        aggregate_key_type = "IP"
+        scope_down_statement {
+          and_statement {
+            statement {
+              byte_match_statement {
+                positional_constraint = "STARTS_WITH"
+                field_to_match {
+                  single_header {
+                    name = "host"
+                  }
+                }
+                search_string = "api."
+                text_transformation {
+                  priority = 1
+                  type     = "COMPRESS_WHITE_SPACE"
+                }
+                text_transformation {
+                  priority = 2
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+            statement {
+              not_statement {
+                statement {
+                  byte_match_statement {
+                    positional_constraint = "EXACTLY"
+                    field_to_match {
+                      single_header {
+                        name = "WAF-secret"
+                      }
+                    }
+                    search_string = var.waf_secret
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
   }

--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -44,5 +44,6 @@ inputs = {
   eks_addon_vpc_cni_version              = "v1.11.0-eksbuild.1"  
   eks_node_ami_version                   = "1.22.9-20220725"
   fall_back_non_api_waf_rate_limit       = 500
+  api_waf_rate_limit                     = 30000
   sign_in_waf_rate_limit                 = 100
 }

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -74,6 +74,7 @@ inputs = {
   eks_addon_vpc_cni_version              = "v1.11.0-eksbuild.1"
   eks_node_ami_version                   = "1.22.9-20220725"
   fall_back_non_api_waf_rate_limit       = 500
+  api_waf_rate_limit                     = 5000
   sign_in_waf_rate_limit                 = 100
 }
 


### PR DESCRIPTION
# Summary | Résumé

Rate limit api and document-download-api.

Before merging this need:
- [ ] To [add the waf_secret to the header of admin's api requests](https://github.com/cds-snc/notification-admin/pull/1313).

- [ ] To add `STAGING_WAF_SECRET` and `PRODUCTION_WAF_SECRET` to this repo's secrets.

