### PR TITLE
add ip blocklist to terraform

### DIFF
--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -54,6 +54,6 @@ output "firehose_waf_logs_iam_role_arn" {
   value = aws_iam_role.firehose_waf_logs.arn
 }
 
-output "ip_blocklist" {
+output "ip_blocklist_arn" {
   value = aws_wafv2_ip_set.ip_blocklist.arn
 }

--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -53,3 +53,7 @@ output "s3_bucket_csv_upload_bucket_arn" {
 output "firehose_waf_logs_iam_role_arn" {
   value = aws_iam_role.firehose_waf_logs.arn
 }
+
+output "ip_blocklist" {
+  value = aws_wafv2_ip_set.ip_blocklist.arn
+}

--- a/aws/common/waf.tf
+++ b/aws/common/waf.tf
@@ -1,0 +1,10 @@
+resource "aws_wafv2_ip_set" "ip_blocklist" {
+  name               = "ip_blocklist"
+  scope              = "REGIONAL"
+  ip_address_version = "IPV4"
+  addresses          = ["40.50.60.70/32"]
+
+  lifecycle {
+    ignore_changes = all
+  }
+}

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -98,5 +98,6 @@ locals {
 }
 
 variable "ip_blocklist_arn" {
-  type = string
+  description = "Block all the IPs on this list from accessing admin and api"
+  type        = string
 }

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -98,5 +98,5 @@ locals {
 }
 
 variable "ip_blocklist_arn" {
-  type = list(any)
+  type = string
 }

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -96,3 +96,7 @@ variable "sign_in_waf_rate_limit" {
 locals {
   eks_application_log_group = "/aws/containerinsights/${var.eks_cluster_name}/application"
 }
+
+variable "ip_blocklist" {
+  type = list(any)
+}

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -97,6 +97,6 @@ locals {
   eks_application_log_group = "/aws/containerinsights/${var.eks_cluster_name}/application"
 }
 
-variable "ip_blocklist" {
+variable "ip_blocklist_arn" {
   type = list(any)
 }

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -382,6 +382,27 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     }
   }
 
+  rule {
+    name     = "ip_blocklist"
+    priority = 1
+
+    action {
+      block {}
+    }
+
+    statement {
+      ip_set_reference_statement {
+        arn = aws_wafv2_ip_set.ip_blocklist.arn
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "BlockedIP"
+      sampled_requests_enabled   = true
+    }
+  }
+
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
   }
@@ -463,5 +484,16 @@ resource "aws_wafv2_web_acl_logging_configuration" "firehose-waf-logs" {
     single_header {
       name = "authorization"
     }
+  }
+}
+
+resource "aws_wafv2_ip_set" "ip_blocklist" {
+  name               = "ip_blocklist"
+  scope              = "REGIONAL"
+  ip_address_version = "IPV4"
+  addresses          = ["40.50.60.70/32"]
+
+  lifecycle {
+    ignore_changes = all
   }
 }

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -384,7 +384,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
 
   rule {
     name     = "ip_blocklist"
-    priority = 1
+    priority = 8
 
     action {
       block {}

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -392,7 +392,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
 
     statement {
       ip_set_reference_statement {
-        arn = aws_wafv2_ip_set.ip_blocklist.arn
+        arn = var.ip_blocklist
       }
     }
 
@@ -484,16 +484,5 @@ resource "aws_wafv2_web_acl_logging_configuration" "firehose-waf-logs" {
     single_header {
       name = "authorization"
     }
-  }
-}
-
-resource "aws_wafv2_ip_set" "ip_blocklist" {
-  name               = "ip_blocklist"
-  scope              = "REGIONAL"
-  ip_address_version = "IPV4"
-  addresses          = ["40.50.60.70/32"]
-
-  lifecycle {
-    ignore_changes = all
   }
 }

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -392,7 +392,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
 
     statement {
       ip_set_reference_statement {
-        arn = var.ip_blocklist
+        arn = var.ip_blocklist_arn
       }
     }
 

--- a/aws/lambda-api/variables.tf
+++ b/aws/lambda-api/variables.tf
@@ -106,5 +106,6 @@ variable "ff_cloudwatch_metrics_enabled" {
 }
 
 variable "ip_blocklist_arn" {
-  type = string
+  description = "Block all the IPs on this list from accessing admin and api"
+  type        = string
 }

--- a/aws/lambda-api/variables.tf
+++ b/aws/lambda-api/variables.tf
@@ -104,3 +104,7 @@ variable "new_relic_account_id" {
 variable "ff_cloudwatch_metrics_enabled" {
   type = bool
 }
+
+variable "ip_blocklist_arn" {
+  type = string
+}

--- a/aws/lambda-api/waf.tf
+++ b/aws/lambda-api/waf.tf
@@ -166,7 +166,7 @@ resource "aws_wafv2_web_acl" "api_lambda" {
 
   rule {
     name     = "ip_blocklist"
-    priority = 1
+    priority = 8
 
     action {
       block {}

--- a/aws/lambda-api/waf.tf
+++ b/aws/lambda-api/waf.tf
@@ -164,6 +164,27 @@ resource "aws_wafv2_web_acl" "api_lambda" {
     }
   }
 
+  rule {
+    name     = "ip_blocklist"
+    priority = 1
+
+    action {
+      block {}
+    }
+
+    statement {
+      ip_set_reference_statement {
+        arn = aws_wafv2_ip_set.ip_blocklist.arn
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "BlockedIP"
+      sampled_requests_enabled   = true
+    }
+  }
+
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
   }
@@ -211,5 +232,16 @@ resource "aws_wafv2_web_acl_logging_configuration" "firehose-api-lambda-waf-logs
     single_header {
       name = "authorization"
     }
+  }
+}
+
+resource "aws_wafv2_ip_set" "ip_blocklist" {
+  name               = "ip_blocklist"
+  scope              = "REGIONAL"
+  ip_address_version = "IPV4"
+  addresses          = ["40.50.60.70/32"]
+
+  lifecycle {
+    ignore_changes = all
   }
 }

--- a/aws/lambda-api/waf.tf
+++ b/aws/lambda-api/waf.tf
@@ -174,7 +174,7 @@ resource "aws_wafv2_web_acl" "api_lambda" {
 
     statement {
       ip_set_reference_statement {
-        arn = var.ip_blocklist
+        arn = var.ip_blocklist_arn
       }
     }
 

--- a/aws/lambda-api/waf.tf
+++ b/aws/lambda-api/waf.tf
@@ -174,7 +174,7 @@ resource "aws_wafv2_web_acl" "api_lambda" {
 
     statement {
       ip_set_reference_statement {
-        arn = aws_wafv2_ip_set.ip_blocklist.arn
+        arn = var.ip_blocklist
       }
     }
 
@@ -232,16 +232,5 @@ resource "aws_wafv2_web_acl_logging_configuration" "firehose-api-lambda-waf-logs
     single_header {
       name = "authorization"
     }
-  }
-}
-
-resource "aws_wafv2_ip_set" "ip_blocklist" {
-  name               = "ip_blocklist"
-  scope              = "REGIONAL"
-  ip_address_version = "IPV4"
-  addresses          = ["40.50.60.70/32"]
-
-  lifecycle {
-    ignore_changes = all
   }
 }

--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -45,4 +45,5 @@ inputs = {
   eks_node_ami_version                   = "1.22.9-20220725"
   fall_back_non_api_waf_rate_limit       = 500
   sign_in_waf_rate_limit                 = 100
+  ip_blocklist_arn                       = dependency.common.outputs.ip_blocklist_arn
 }

--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -8,6 +8,14 @@ dependencies {
 
 dependency "common" {
   config_path = "../common"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    ip_blocklist_arn               = ""
+  }
 }
 
 dependency "dns" {

--- a/env/production/lambda-api/terragrunt.hcl
+++ b/env/production/lambda-api/terragrunt.hcl
@@ -27,7 +27,7 @@ dependency "common" {
     sns_alert_critical_arn          = ""
     s3_bucket_csv_upload_bucket_arn = ""
     firehose_waf_logs_iam_role_arn  = ""
-    ip_blocklist_arn                = []
+    ip_blocklist_arn                = ""
   }
 }
 

--- a/env/production/lambda-api/terragrunt.hcl
+++ b/env/production/lambda-api/terragrunt.hcl
@@ -27,6 +27,7 @@ dependency "common" {
     sns_alert_critical_arn          = ""
     s3_bucket_csv_upload_bucket_arn = ""
     firehose_waf_logs_iam_role_arn  = ""
+    ip_blocklist_arn                = []
   }
 }
 
@@ -79,4 +80,5 @@ inputs = {
   sns_alert_warning_arn                  = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                 = dependency.common.outputs.sns_alert_critical_arn
   ff_cloudwatch_metrics_enabled          = "true"
+  ip_blocklist_arn                       = dependency.common.outputs.ip_blocklist_arn
 }

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -7,7 +7,7 @@ dependency "common" {
 
   # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
   # module hasn't been applied yet.
-  mock_outputs_allowed_terraform_commands = ["validate"]
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
     vpc_private_subnets = [

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -23,7 +23,7 @@ dependency "common" {
     sns_alert_critical_arn         = ""
     sns_alert_general_arn          = ""
     firehose_waf_logs_iam_role_arn = ""
-    ip_blocklist_arn               = []
+    ip_blocklist_arn               = ""
   }
 }
 

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -23,7 +23,7 @@ dependency "common" {
     sns_alert_critical_arn         = ""
     sns_alert_general_arn          = ""
     firehose_waf_logs_iam_role_arn = ""
-    ip_blocklist                   = []
+    ip_blocklist_arn               = []
   }
 }
 
@@ -76,6 +76,7 @@ inputs = {
   eks_node_ami_version                   = "1.22.9-20220725"
   fall_back_non_api_waf_rate_limit       = 500
   sign_in_waf_rate_limit                 = 100
+  ip_blocklist_arn                       = dependency.common.outputs.ip_blocklist_arn
 }
 
 terraform {

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -8,6 +8,7 @@ dependency "common" {
   # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
   # module hasn't been applied yet.
   mock_outputs_allowed_terraform_commands = ["validate"]
+  mock_outputs_merge_with_state           = true
   mock_outputs = {
     vpc_private_subnets = [
       "subnet-001e585d12cce4d1e",

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -23,6 +23,7 @@ dependency "common" {
     sns_alert_critical_arn         = ""
     sns_alert_general_arn          = ""
     firehose_waf_logs_iam_role_arn = ""
+    ip_blocklist                   = []
   }
 }
 

--- a/env/staging/lambda-api/terragrunt.hcl
+++ b/env/staging/lambda-api/terragrunt.hcl
@@ -21,6 +21,7 @@ dependency "common" {
     sns_alert_critical_arn          = ""
     s3_bucket_csv_upload_bucket_arn = ""
     firehose_waf_logs_iam_role_arn  = ""
+    ip_blocklist                    = []
   }
 }
 

--- a/env/staging/lambda-api/terragrunt.hcl
+++ b/env/staging/lambda-api/terragrunt.hcl
@@ -21,7 +21,7 @@ dependency "common" {
     sns_alert_critical_arn          = ""
     s3_bucket_csv_upload_bucket_arn = ""
     firehose_waf_logs_iam_role_arn  = ""
-    ip_blocklist_arn                = []
+    ip_blocklist_arn                = ""
   }
 }
 

--- a/env/staging/lambda-api/terragrunt.hcl
+++ b/env/staging/lambda-api/terragrunt.hcl
@@ -21,7 +21,7 @@ dependency "common" {
     sns_alert_critical_arn          = ""
     s3_bucket_csv_upload_bucket_arn = ""
     firehose_waf_logs_iam_role_arn  = ""
-    ip_blocklist                    = []
+    ip_blocklist_arn                = []
   }
 }
 
@@ -74,6 +74,7 @@ inputs = {
   sns_alert_warning_arn                  = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                 = dependency.common.outputs.sns_alert_critical_arn
   ff_cloudwatch_metrics_enabled          = "true"
+  ip_blocklist_arn                       = dependency.common.outputs.ip_blocklist_arn
 }
 
 terraform {


### PR DESCRIPTION
# Summary | Résumé

Adding the IP blocklist to our terraform repo, this way during an incident we only have to add IP's to the blocklist on console. 