### PR TITLE
fix: Don't geoblock US for api lambda waf too

### DIFF
--- a/aws/lambda-api/waf.tf
+++ b/aws/lambda-api/waf.tf
@@ -151,7 +151,7 @@ resource "aws_wafv2_web_acl" "api_lambda" {
       not_statement {
         statement {
           geo_match_statement {
-            country_codes = ["CA"]
+            country_codes = ["CA", "US"]
           }
         }
       }

--- a/aws/lambda-api/waf.tf
+++ b/aws/lambda-api/waf.tf
@@ -141,7 +141,7 @@ resource "aws_wafv2_web_acl" "api_lambda" {
   }
 
   rule {
-    name     = "CanadaOnlyGeoRestriction"
+    name     = "CanadaUSOnlyGeoRestriction"
     priority = 20
 
     action {
@@ -159,7 +159,7 @@ resource "aws_wafv2_web_acl" "api_lambda" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "CanadaOnlyGeoRestriction"
+      metric_name                = "CanadaUSOnlyGeoRestriction"
       sampled_requests_enabled   = true
     }
   }


### PR DESCRIPTION
# Summary | Résumé

Forgot to change the api lambda's WAF in #516

# Test instructions | Instructions pour tester la modification

- After merging to staging
- Do a GET to https://api.staging.notification.cdssandbox.xyz  from servers in CA, US, and EU.
- Then in Athena run
```
with data as (
    select 
        from_unixtime(timestamp / 1000e0) as time, action, nonterminatingmatchingrule,
        httprequest.clientip, httprequest.country, httprequest.httpmethod, hostheader.value as host, httprequest.uri
    from waf_logs
    cross join UNNEST(httprequest.headers) AS t(hostheader)
    cross join UNNEST(nonterminatingmatchingrules) AS t(nonterminatingmatchingrule)
    where hostheader.name = 'Host'
)
select * from data
where clientip = '...'
order by time desc
```
should have the `CanadaUSOnlyGeoRestriction` counted for EU but not CA or US.