### PR TITLE
feat: BLOCK api calls outside CA and US

### DIFF
--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -295,7 +295,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 20
 
     action {
-      count {}
+      block {}
     }
     statement {
       and_statement {

--- a/aws/lambda-api/waf.tf
+++ b/aws/lambda-api/waf.tf
@@ -145,7 +145,7 @@ resource "aws_wafv2_web_acl" "api_lambda" {
     priority = 20
 
     action {
-      count {}
+      block {}
     }
     statement {
       not_statement {


### PR DESCRIPTION
# Summary | Résumé

WAF now restricted to CA and US as analyzed in [CanadaUSOnlyGeoRestriction Analysis](https://docs.google.com/spreadsheets/d/1aIB8QlbyRR5Ex96I0qgEdnXqbYQ9hlxYoXQKaTN-cVk/edit#gid=0).

Ready to be turned from COUNT to BLOCK.

# Test instructions | Instructions pour tester la modification

As described in  [CanadaUSOnlyGeoRestriction Analysis](https://docs.google.com/spreadsheets/d/1aIB8QlbyRR5Ex96I0qgEdnXqbYQ9hlxYoXQKaTN-cVk/edit#gid=0):
- curl to api from servers in CA, US, EU
- CA, US should be let through, EU blocked
