### PR TITLE
Re-allowing GenericRFI_Body after checking WAF blocked traffic

### DIFF
--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -59,6 +59,10 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
         excluded_rule {
           name = "GenericLFI_Body"
         }
+
+        excluded_rule {
+          name = "GenericRFI_Body"
+        }
       }
     }
 

--- a/aws/lambda-api/waf.tf
+++ b/aws/lambda-api/waf.tf
@@ -59,6 +59,10 @@ resource "aws_wafv2_web_acl" "api_lambda" {
         excluded_rule {
           name = "GenericLFI_Body"
         }
+
+        excluded_rule {
+          name = "GenericRFI_Body"
+        }
       }
     }
 


### PR DESCRIPTION
# Summary | Résumé

We were not sure about the `GenericRFI_Body` rule [when initially evaluating](https://github.com/cds-snc/notification-terraform/pull/498), blocking or not. We might have blocked what appears as a few requests today. Hence this PR disables the `GenericRFI_Body` from the common ruleset for the time being.

# Test instructions | Instructions pour tester la modification

Deploy and inspect the WAF dashboard in the AWS console.
