### PR TITLE
Revert "turn on rate_limit_all_except_api (#521)"

### DIFF
--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -363,15 +363,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 200
 
     action {
-      block {
-        custom_response {
-          response_code = 429
-          response_header {
-            name  = "waf-block"
-            value = "RateLimitRestriction"
-          }
-        }
-      }
+      count {}
     }
 
     visibility_config {


### PR DESCRIPTION
# Summary | Résumé

Because we need to slip in a quick release including most recent change that exclude the GenericRFI_Body WAF rule, this reverts #521 : feat: turn on rate_limit_all_except_api which might not be ready for prime time yet.


