### PR TITLE
fix: set alt_domain on staging

### DIFF
--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -350,7 +350,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
                     name = "host"
                   }
                 }
-                search_string = var.alt_domain
+                search_string = var.alt_domain != "" ? var.alt_domain : var.domain
                 text_transformation {
                   priority = 1
                   type     = "COMPRESS_WHITE_SPACE"

--- a/env/staging/env_vars.hcl
+++ b/env/staging/env_vars.hcl
@@ -1,6 +1,6 @@
 inputs = {
   account_id = "239043911459"
   domain     = "staging.notification.cdssandbox.xyz"
-  alt_domain = ""
+  alt_domain = "staging.notification.cdssandbox.xyz"
   env        = "staging"
 }

--- a/env/staging/env_vars.hcl
+++ b/env/staging/env_vars.hcl
@@ -1,6 +1,6 @@
 inputs = {
   account_id = "239043911459"
   domain     = "staging.notification.cdssandbox.xyz"
-  alt_domain = "staging.notification.cdssandbox.xyz"
+  alt_domain = ""
   env        = "staging"
 }


### PR DESCRIPTION
# Summary | Résumé

An empty `alt_domain` was causing the `terragrunt apply` to fail on staging
https://github.com/cds-snc/notification-terraform/runs/8160963993?check_suite_focus=true

# Test instructions | Instructions pour tester la modification

cross your fingers and merge!