### PR TITLE
Re-include code for turn on rate_limit_all_except_api (#521)

### DIFF
--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -462,7 +462,15 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 200
 
     action {
-      count {}
+      block {
+        custom_response {
+          response_code = 429
+          response_header {
+            name  = "waf-block"
+            value = "RateLimitRestriction"
+          }
+        }
+      }
     }
 
     visibility_config {


### PR DESCRIPTION
# Summary | Résumé

Previously removed #521 to perform a production release. We can re-include these changes for next release rounds.

> Turn the rate limit for admin and documentation to block

> See [analysis](https://docs.google.com/spreadsheets/d/1nVNiFJ1w2gVHbJHYE_3Ntx0k4XUUsAW3LpU_QzVB4Fg).
