### PR TITLE
Expire linked files after 7 days

### DIFF
--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -215,7 +215,15 @@ resource "aws_s3_bucket" "document_bucket" {
       }
     }
   }
+  
+  # expire linked files after 7 days
+  lifecycle_rule {
+    enabled = true
 
+    expiration {
+      days = 7
+    }
+  }
   # Expire files attached directly to emails after a few days.
   # Those are stored in a `tmp/` folder.
   # See https://github.com/cds-snc/notification-document-download-api

--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -229,7 +229,7 @@ resource "aws_s3_bucket" "document_bucket" {
   # Those are stored in a `tmp/` folder.
   # See https://github.com/cds-snc/notification-document-download-api
   lifecycle_rule {
-    id      = "tf-s3-lifecycle-20210324115309091500000001"
+    id      = "tf-s3-lifecycle-attached-files"
     enabled = true
     prefix  = "tmp/"
 

--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -215,9 +215,10 @@ resource "aws_s3_bucket" "document_bucket" {
       }
     }
   }
-  
+
   # expire linked files after 7 days
   lifecycle_rule {
+    id      = "tf-s3-lifecycle-linked-files"
     enabled = true
 
     expiration {
@@ -228,6 +229,7 @@ resource "aws_s3_bucket" "document_bucket" {
   # Those are stored in a `tmp/` folder.
   # See https://github.com/cds-snc/notification-document-download-api
   lifecycle_rule {
+    id      = "tf-s3-lifecycle-20210324115309091500000001"
     enabled = true
     prefix  = "tmp/"
 

--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -225,6 +225,7 @@ resource "aws_s3_bucket" "document_bucket" {
       days = 7
     }
   }
+
   # Expire files attached directly to emails after a few days.
   # Those are stored in a `tmp/` folder.
   # See https://github.com/cds-snc/notification-document-download-api


### PR DESCRIPTION
# Summary | Résumé

If the sending method is not "attach" then it is "link" and the document is stored in the root of our `notification-canada-ca-${var.env}-document-download` bucket: https://github.com/cds-snc/notification-document-download-api/blob/main/app/utils/store.py#L67

We already have a lifecycle policy that expires files in the `tmp` folder after 3 days. 

So we just need to add another policy that will apply to the other docs outside of the `tmp` folder.

In order to have multiple lifecycle rules on the same bucket, we need to assign them unique `id`s so Terraform doesn't get confused.

Will the 2 lifecycle rules produce the desired behaviour? i.e. files in `/tmp` expire in 3 days, other files in the root folder expire after 7. [According to the AWS docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-configuration-examples.html#lifecycle-config-conceptual-ex5) it should work.
