### PR TITLE
Blocks invalid URIs sent to API and Admin

### DIFF
--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -316,7 +316,11 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 11
 
     action {
-      count {}
+      block {
+        custom_response {
+          response_code = 204
+        }
+      }
     }
 
     statement {

--- a/aws/lambda-api/waf.tf
+++ b/aws/lambda-api/waf.tf
@@ -211,7 +211,11 @@ resource "aws_wafv2_web_acl" "api_lambda" {
     priority = 11
 
     action {
-      count {}
+      block {
+        custom_response {
+          response_code = 204
+        }
+      }
     }
 
     statement {


### PR DESCRIPTION
# Summary | Résumé

This is part of our WAF rules strengthening, the [grand plan documented here](https://docs.google.com/document/d/1HFvkt7Hkt1sjiOa1n8GIcmv5Ck3Y1DU1lbM0n7s-C2Y/edit#).

* Enable block for requests containing invalid URIs to API and Admin components.

# Test instructions | Instructions pour tester la modification

* Hit the API on a URI that does not exist.
* Hit the admin on a URI that does not exist.
