### PR TITLE
Removed fargate profile

### DIFF
--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -77,24 +77,6 @@ resource "aws_eks_node_group" "notification-canada-ca-eks-node-group" {
 }
 
 ###
-# AWS EKS Fragate profiles
-###
-
-resource "aws_eks_fargate_profile" "notification-canada-ca-fargate-profile" {
-  cluster_name           = aws_eks_cluster.notification-canada-ca-eks-cluster.name
-  fargate_profile_name   = "notification-canada-ca-fargate"
-  pod_execution_role_arn = aws_iam_role.eks-fargate-worker-role.arn
-  subnet_ids             = var.vpc_private_subnets
-
-  selector {
-    namespace = "notification-canada-ca"
-    labels = {
-      "profile" : "fargate"
-    }
-  }
-}
-
-###
 # AWS EKS addons
 ###
 


### PR DESCRIPTION
# Summary | Résumé

Fargate profile support has been dropped for a few AZ in ca-central-1. As we are not currently using it, dropping its creation will be simpler. We can revive it later if we decide to move our kubernetes out of EC2 and into fargate.

# Test instructions | Instructions pour tester la modification

Terraform plan and execution should now work (currently failing).
