### PR TITLE
Added base path mapping for api lambda from alt domain name

### DIFF
--- a/aws/lambda-api/api_gateway.tf
+++ b/aws/lambda-api/api_gateway.tf
@@ -149,6 +149,12 @@ resource "aws_api_gateway_base_path_mapping" "api_lambda" {
   domain_name = aws_api_gateway_domain_name.api_lambda.domain_name
 }
 
+resource "aws_api_gateway_base_path_mapping" "api_lambda_alt" {
+  api_id      = aws_api_gateway_rest_api.api.id
+  stage_name  = aws_api_gateway_stage.api.stage_name
+  domain_name = aws_api_gateway_domain_name.alt_api_lambda.domain_name
+}
+
 resource "aws_api_gateway_base_path_mapping" "api" {
   api_id      = aws_api_gateway_rest_api.api.id
   stage_name  = aws_api_gateway_stage.api.stage_name


### PR DESCRIPTION
# Summary | Résumé

* Added base path mapping for api lambda from alt domain name

# Test instructions | Instructions pour tester la modification

Try the domain api.staging.notification.alpha.cdssandbox.xyz !
