### PR TITLE
Expire linked files after 7 days (#532)

### DIFF
--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -216,10 +216,21 @@ resource "aws_s3_bucket" "document_bucket" {
     }
   }
 
+  # expire linked files after 7 days
+  lifecycle_rule {
+    id      = "tf-s3-lifecycle-linked-files"
+    enabled = true
+
+    expiration {
+      days = 7
+    }
+  }
+
   # Expire files attached directly to emails after a few days.
   # Those are stored in a `tmp/` folder.
   # See https://github.com/cds-snc/notification-document-download-api
   lifecycle_rule {
+    id      = "tf-s3-lifecycle-attached-files"
     enabled = true
     prefix  = "tmp/"
 


### PR DESCRIPTION
# Summary | Résumé

This is re-applying code from previous PR [Expire linked files after 7 days](https://github.com/cds-snc/notification-terraform/pull/532).

If the sending method is not "attach" then it is "link" and the document is stored in the root of our `notification-canada-ca-${var.env}-document-download` bucket: https://github.com/cds-snc/notification-document-download-api/blob/main/app/utils/store.py#L67

We already have a lifecycle policy that expires files in the `tmp` folder after 3 days. 

So we just need to add another policy that will apply to the other docs outside of the `tmp` folder.

In order to have multiple lifecycle rules on the same bucket, we need to assign them unique `id`s so Terraform doesn't get confused.

Will the 2 lifecycle rules produce the desired behaviour? i.e. files in `/tmp` expire in 3 days, other files in the root folder expire after 7. [According to the AWS docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-configuration-examples.html#lifecycle-config-conceptual-ex5) it should work.
