### PR TITLE
fix description error

### DIFF
--- a/aws/eks/securitygroups.tf
+++ b/aws/eks/securitygroups.tf
@@ -78,7 +78,7 @@ resource "aws_security_group" "blazer" {
 
 resource "aws_security_group" "database-tools-db-securitygroup" {
   name        = "Database tools Database Security Group"
-  description = "Security group for database in database-tools. Needs access to notify's main DB and blazer task"
+  description = "Security group for database in database-tools"
   vpc_id      = var.vpc_id
 }
 


### PR DESCRIPTION
# Summary | Résumé

Apply failed:
```
╷
│ Error: error creating Security Group (Database tools Database Security Group): InvalidParameterValue: Invalid security group description. Valid descriptions are strings less than 256 characters from the following set:  a-zA-Z0-9. _-:/()#,@[]+=&;{}!$*
│ 	status code: 400, request id: ffc132a6-f693-422e-b9ae-2c87ee5305eb
│ 
│   with aws_security_group.database-tools-db-securitygroup,
│   on securitygroups.tf line 79, in resource "aws_security_group" "database-tools-db-securitygroup":
│   79: resource "aws_security_group" "database-tools-db-securitygroup" {
│ 
╵
Releasing state lock. This may take a few moments...
time=2022-10-20T19:50:47Z level=error msg=1 error occurred:
	* exit status 1

```