### PR TITLE
blazer execution role also needs ssm permissions

### DIFF
--- a/aws/database-tools/container_execution_role.tf
+++ b/aws/database-tools/container_execution_role.tf
@@ -34,4 +34,18 @@ data "aws_iam_policy_document" "blazer_execution_role" {
       identifiers = ["ecs-tasks.amazonaws.com"]
     }
   }
+
+  statement {
+
+    effect = "Allow"
+
+    actions = [
+      "ssm:DescribeParameters",
+      "ssm:GetParameters",
+    ]
+    resources = [
+      aws_ssm_parameter.sqlalchemy_database_reader_uri.arn,
+      aws_ssm_parameter.db_tools_environment_variables.arn
+    ]
+  }
 }


### PR DESCRIPTION
# Summary | Résumé

We moved permissions to the task role/ but the execution role also needs to read the same parameters.

<img width="1513" alt="Screen Shot 2022-10-21 at 2 27 51 PM" src="https://user-images.githubusercontent.com/8869623/197264646-63b413eb-5307-4c2b-997c-d75dc7957d2c.png">
