### PR TITLE
Revert "blazer execution role also needs ssm permissions"

### DIFF
--- a/aws/database-tools/container_execution_role.tf
+++ b/aws/database-tools/container_execution_role.tf
@@ -34,18 +34,4 @@ data "aws_iam_policy_document" "blazer_execution_role" {
       identifiers = ["ecs-tasks.amazonaws.com"]
     }
   }
-
-  statement {
-
-    effect = "Allow"
-
-    actions = [
-      "ssm:DescribeParameters",
-      "ssm:GetParameters",
-    ]
-    resources = [
-      aws_ssm_parameter.sqlalchemy_database_reader_uri.arn,
-      aws_ssm_parameter.db_tools_environment_variables.arn
-    ]
-  }
 }


### PR DESCRIPTION
Reverts cds-snc/notification-terraform#568

reverting cause its friday.