### PR TITLE
fix permission for blazer execution role

### DIFF
--- a/aws/database-tools/container_execution_role.tf
+++ b/aws/database-tools/container_execution_role.tf
@@ -35,3 +35,43 @@ data "aws_iam_policy_document" "blazer_execution_role" {
     }
   }
 }
+
+resource "aws_iam_policy" "blazer_exection_role_parameter_policy" {
+  name   = "blazer_exection_role_parameter_policy"
+  path   = "/"
+  policy = data.aws_iam_policy_document.blazer_exection_role_parameter_policy_actions.json
+}
+
+resource "aws_iam_role_policy_attachment" "blazer_exection_role_parameter_policy_actions" {
+  role       = aws_iam_role.blazer_execution_role.name
+  policy_arn = aws_iam_policy.blazer_exection_role_parameter_policy.arn
+}
+
+data "aws_iam_policy_document" "blazer_exection_role_parameter_policy_actions" {
+  statement {
+
+    effect = "Allow"
+
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+
+    effect = "Allow"
+
+    actions = [
+      "ssm:DescribeParameters",
+      "ssm:GetParameters",
+    ]
+    resources = [
+      aws_ssm_parameter.sqlalchemy_database_reader_uri.arn,
+      aws_ssm_parameter.db_tools_environment_variables.arn
+    ]
+  }
+}


### PR DESCRIPTION
# Summary | Résumé

trying to fix this:![image](https://user-images.githubusercontent.com/8869623/197574122-fd42a63b-e89c-4a9e-9239-f69f43acc9e3.png)

this Pr failed: https://github.com/cds-snc/notification-terraform/pull/568
because we cant have both resources and principals attached the the same policy