### PR TITLE
Rename parameter storevariables and update prod plans

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -17,6 +17,7 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: ca-central-1
+  TF_VAR_dbtools_password: ${{ secrets.PRODUCTION_DBTOOLS_PASSWORD }}
   TF_VAR_heartbeat_api_key: ${{ secrets.PRODUCTION_HEARTBEAT_API_KEY }}
   TF_VAR_heartbeat_base_url: ${{ secrets.PRODUCTION_HEARTBEAT_BASE_URL }}
   TF_VAR_heartbeat_template_id: ${{ secrets.PRODUCTION_HEARTBEAT_TEMPLATE_ID }}
@@ -103,6 +104,11 @@ jobs:
       - name: Apply aws/heartbeat
         run: |
           cd env/production/heartbeat
+          terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Apply aws/database-tools
+        run: |
+          cd env/staging/database-tools
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
       - name: Slack message on failure

--- a/.github/workflows/terragrunt_plan_production.yml
+++ b/.github/workflows/terragrunt_plan_production.yml
@@ -12,6 +12,7 @@ env:
   AWS_REGION: ca-central-1
   TERRAFORM_VERSION: 0.14.4
   TERRAGRUNT_VERSION: 0.35.13
+  TF_VAR_dbtools_password: ${{ secrets.PRODUCTION_DBTOOLS_PASSWORD }}
   TF_VAR_heartbeat_api_key: ${{ secrets.PRODUCTION_HEARTBEAT_API_KEY }}
   TF_VAR_heartbeat_base_url: ${{ secrets.PRODUCTION_HEARTBEAT_BASE_URL }}
   TF_VAR_heartbeat_template_id: ${{ secrets.PRODUCTION_HEARTBEAT_TEMPLATE_ID }}
@@ -122,5 +123,15 @@ jobs:
           directory: "env/production/heartbeat"
           comment-delete: "true"
           comment-title: "Production: heartbeat"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
+
+      - name: Terragrunt plan database-tools
+        if: ${{ steps.filter.outputs.database-tools == 'true' || steps.filter.outputs.common == 'true' }}
+        uses: cds-snc/terraform-plan@v1
+        with:
+          directory: "env/staging/database-tools"
+          comment-delete: "true"
+          comment-title: "Staging: database-tools"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"

--- a/aws/database-tools/blazer.tf
+++ b/aws/database-tools/blazer.tf
@@ -54,10 +54,10 @@ resource "aws_ecs_task_definition" "blazer" {
         }
       ],
       "secrets" : [{
-        "name" : "DATABASE_URL",
+        "name" : "BLAZER_DATABASE_URL",
         "valueFrom" : "${aws_ssm_parameter.sqlalchemy_database_reader_uri.arn}"
         }, {
-        "name" : "BLAZER_DATABASE_URL",
+        "name" : "DATABASE_URL",
         "valueFrom" : "${aws_ssm_parameter.db_tools_environment_variables.arn}"
       }]
     }

--- a/aws/database-tools/parameterstore.tf
+++ b/aws/database-tools/parameterstore.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 resource "aws_ssm_parameter" "db_tools_environment_variables" {
-  name  = "BLAZER_DATABASE_URL"
+  name  = "DATABASE_TOOLS_URL"
   type  = "SecureString"
   value = "postgres://postgres:${var.dbtools_password}@${aws_db_instance.database-tools.address}:5432"
 
@@ -14,7 +14,7 @@ resource "aws_ssm_parameter" "db_tools_environment_variables" {
 }
 
 resource "aws_ssm_parameter" "sqlalchemy_database_reader_uri" {
-  name  = "sqlalchemy_database_reader_uri"
+  name  = "NOTIFICATION_DB_READ_URL"
   type  = "SecureString"
   value = var.sqlalchemy_database_reader_uri
 


### PR DESCRIPTION
# Summary | Résumé

Originally:
BLAZER_DATABASE_URL -> Database we added for database tools
DATABASE_URL -> notification db

This was incorrect. We had to switch it. 
I clickopsed and tried it out and saw if this was the case (it was).

Now I renamed variables in parameter store

BLAZER_DATABASE -> DATABASE_TOOLS_URL (and then we call it DATABASE_URL) in the DB Cast
sqlalchemy_database_reader_uri -> NOTIFICATION_DB_READ_URL

