### PR TITLE
feat: database tools ECR

### DIFF
--- a/aws/database-tools/blazer.tf
+++ b/aws/database-tools/blazer.tf
@@ -37,7 +37,7 @@ resource "aws_ecs_task_definition" "blazer" {
       "name" : "blazer",
       "cpu" : 0,
       "essential" : true,
-      "image" : "ankane/blazer:v2.6.5",
+      "image" : "${aws_ecr_repository.blazer.repository_url}:v2.6.5",
       "logConfiguration" : {
         "logDriver" : "awslogs",
         "options" : {
@@ -54,10 +54,10 @@ resource "aws_ecs_task_definition" "blazer" {
         }
       ],
       "secrets" : [{
-        "name" : "DATABASE_URL",
+        "name" : "BLAZER_DATABASE_URL",
         "valueFrom" : "${aws_ssm_parameter.sqlalchemy_database_reader_uri.arn}"
         }, {
-        "name" : "BLAZER_DATABASE_URL",
+        "name" : "DATABASE_URL",
         "valueFrom" : "${aws_ssm_parameter.db_tools_environment_variables.arn}"
       }]
     }

--- a/aws/database-tools/ecr.tf
+++ b/aws/database-tools/ecr.tf
@@ -1,0 +1,12 @@
+resource "aws_ecr_repository" "blazer" {
+  name                 = "database-tools/blazer"
+  image_tag_mutability = "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}

--- a/aws/eks/securitygroups.tf
+++ b/aws/eks/securitygroups.tf
@@ -58,15 +58,6 @@ resource "aws_security_group" "blazer" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  ingress {
-    description = "Access to internal service"
-    from_port   = 8080
-    to_port     = 8080
-    protocol    = "tcp"
-    self        = true
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
   egress {
     description     = "Access to RDS DB through the EKS Security Group"
     from_port       = 5432


### PR DESCRIPTION
# Summary
Add an ECR to hold the database tools images and remove the ingress
on port 8080 as this is handled automatically by the SSM Session
Manager.

The PR also swaps the ECS task env vars, which is a change that has
already been made in the AWS console.

# Related
- #572
- cds-snc/platform-core-services#137