### PR TITLE
Add new GCA routes to WAF rules

### DIFF
--- a/aws/eks/admin_waf_regex_patterns.tf
+++ b/aws/eks/admin_waf_regex_patterns.tf
@@ -44,7 +44,7 @@ resource "aws_wafv2_regex_pattern_set" "re_admin" {
 
   # GCA routes
   regular_expression {
-    regex_string = "/other-services|/autres-services"
+    regex_string = "/other-services|/autres-services|/service-level-agreement|/accord-niveaux-de-service|/service-level-objectives|/objectifs-niveau-de-service"
   }
 
   tags = {


### PR DESCRIPTION
This PR adds the following new GCA routes to allow https://github.com/cds-snc/notification-admin/pull/1380 to be merged:
- /service-level-agreement
- /accord-niveaux-de-service
- /service-level-objectives
- /objectifs-niveau-de-service