### PR TITLE
test: update Blazer to use Google Authentication

### DIFF
--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
     paths:
-      - ".env"     
+      - ".env"
       - "aws/**"
       - "env/staging/**"
       - ".github/workflows/merge_to_main_staging.yml"
@@ -28,6 +28,8 @@ env:
   TF_VAR_cloudwatch_slack_webhook_warning_topic: ${{ secrets.STAGING_CLOUDWATCH_SLACK_WEBHOOK }}
   TF_VAR_cloudwatch_slack_webhook_critical_topic: ${{ secrets.STAGING_CLOUDWATCH_SLACK_WEBHOOK }}
   TF_VAR_cloudwatch_slack_webhook_general_topic: ${{ secrets.STAGING_CLOUDWATCH_SLACK_WEBHOOK }}
+  TF_VAR_notify_o11y_google_oauth_client_id: ${{ secrets.NOTIFY_O11Y_GOOGLE_OAUTH_CLIENT_ID }}
+  TF_VAR_notify_o11y_google_oauth_client_secret: ${{ secrets.NOTIFY_O11Y_GOOGLE_OAUTH_CLIENT_SECRET }}
   TF_VAR_slack_channel_warning_topic: "notification-staging-ops"
   TF_VAR_slack_channel_critical_topic: "notification-staging-ops"
   TF_VAR_slack_channel_general_topic: "notification-staging-ops"
@@ -102,7 +104,7 @@ jobs:
       - name: Apply aws/lambda-admin-pr
         run: |
           cd env/staging/lambda-admin-pr
-          terragrunt apply --terragrunt-non-interactive -auto-approve          
+          terragrunt apply --terragrunt-non-interactive -auto-approve
 
       - name: Apply aws/performance-test
         run: |
@@ -130,4 +132,4 @@ jobs:
         if: ${{ failure() }}
         run: |
           json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Terraform apply failed: <https://github.com/cds-snc/notification-terraform/actions/workflows/merge_to_main_staging.yml|Merge to main (Staging)>"}}]}'
-          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.NOTIFY_DEV_SLACK_WEBHOOK }}          
+          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.NOTIFY_DEV_SLACK_WEBHOOK }}

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -3,7 +3,7 @@ name: "Terragrunt plan STAGING"
 on:
   pull_request:
     paths:
-      - ".env"    
+      - ".env"
       - "aws/**"
       - "env/staging/**"
       - "env/terragrunt.hcl"
@@ -25,6 +25,8 @@ env:
   TF_VAR_cloudwatch_slack_webhook_warning_topic: ${{ secrets.STAGING_CLOUDWATCH_SLACK_WEBHOOK }}
   TF_VAR_cloudwatch_slack_webhook_critical_topic: ${{ secrets.STAGING_CLOUDWATCH_SLACK_WEBHOOK }}
   TF_VAR_cloudwatch_slack_webhook_general_topic: ${{ secrets.STAGING_CLOUDWATCH_SLACK_WEBHOOK }}
+  TF_VAR_notify_o11y_google_oauth_client_id: ${{ secrets.NOTIFY_O11Y_GOOGLE_OAUTH_CLIENT_ID }}
+  TF_VAR_notify_o11y_google_oauth_client_secret: ${{ secrets.NOTIFY_O11Y_GOOGLE_OAUTH_CLIENT_SECRET }}
   TF_VAR_slack_channel_warning_topic: "notification-staging-ops"
   TF_VAR_slack_channel_critical_topic: "notification-staging-ops"
   TF_VAR_slack_channel_general_topic: "notification-staging-ops"
@@ -45,7 +47,6 @@ jobs:
   terragrunt-plan-staging:
     runs-on: ubuntu-latest
     steps:
-
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -97,7 +98,7 @@ jobs:
             database-tools:
               - 'aws/database-tools/**'
               - 'env/staging/database-tools/**'
-      
+
       - name: Terragrunt plan common
         if: ${{ steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v2
@@ -176,7 +177,7 @@ jobs:
           comment-delete: "true"
           comment-title: "Staging: lambda-admin-pr"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          terragrunt: "true"          
+          terragrunt: "true"
 
       - name: Terragrunt plan performance-test
         if: ${{ steps.filter.outputs.performance-test == 'true' || steps.filter.outputs.common == 'true' }}

--- a/aws/database-tools/blazer.tf
+++ b/aws/database-tools/blazer.tf
@@ -37,7 +37,7 @@ resource "aws_ecs_task_definition" "blazer" {
       "name" : "blazer",
       "cpu" : 0,
       "essential" : true,
-      "image" : "${aws_ecr_repository.blazer.repository_url}:v2.6.5",
+      "image" : "${aws_ecr_repository.blazer.repository_url}:v2.6.5-google-auth",
       "logConfiguration" : {
         "logDriver" : "awslogs",
         "options" : {
@@ -59,6 +59,12 @@ resource "aws_ecs_task_definition" "blazer" {
         }, {
         "name" : "DATABASE_URL",
         "valueFrom" : "${aws_ssm_parameter.db_tools_environment_variables.arn}"
+        }, {
+        "name" : "GOOGLE_OAUTH_CLIENT_ID",
+        "valueFrom" : "${aws_ssm_parameter.notify_o11y_google_oauth_client_id.arn}"
+        }, {
+        "name" : "GOOGLE_OAUTH_CLIENT_SECRET",
+        "valueFrom" : "${aws_ssm_parameter.notify_o11y_google_oauth_client_secret.arn}"
       }]
     }
   ])

--- a/aws/database-tools/container_execution_role.tf
+++ b/aws/database-tools/container_execution_role.tf
@@ -71,7 +71,9 @@ data "aws_iam_policy_document" "blazer_exection_role_parameter_policy_actions" {
     ]
     resources = [
       aws_ssm_parameter.sqlalchemy_database_reader_uri.arn,
-      aws_ssm_parameter.db_tools_environment_variables.arn
+      aws_ssm_parameter.db_tools_environment_variables.arn,
+      aws_ssm_parameter.notify_o11y_google_oauth_client_id.arn,
+      aws_ssm_parameter.notify_o11y_google_oauth_client_secret.arn
     ]
   }
 }

--- a/aws/database-tools/parameterstore.tf
+++ b/aws/database-tools/parameterstore.tf
@@ -13,6 +13,28 @@ resource "aws_ssm_parameter" "db_tools_environment_variables" {
   }
 }
 
+resource "aws_ssm_parameter" "notify_o11y_google_oauth_client_id" {
+  name  = "notify_o11y_google_oauth_client_id"
+  type  = "SecureString"
+  value = var.notify_o11y_google_oauth_client_id
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}
+
+resource "aws_ssm_parameter" "notify_o11y_google_oauth_client_secret" {
+  name  = "notify_o11y_google_oauth_client_secret"
+  type  = "SecureString"
+  value = var.notify_o11y_google_oauth_client_secret
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}
+
 resource "aws_ssm_parameter" "sqlalchemy_database_reader_uri" {
   name  = "sqlalchemy_database_reader_uri"
   type  = "SecureString"

--- a/aws/database-tools/task_role.tf
+++ b/aws/database-tools/task_role.tf
@@ -56,7 +56,9 @@ data "aws_iam_policy_document" "blazer_task_role_actions" {
     ]
     resources = [
       aws_ssm_parameter.sqlalchemy_database_reader_uri.arn,
-      aws_ssm_parameter.db_tools_environment_variables.arn
+      aws_ssm_parameter.db_tools_environment_variables.arn,
+      aws_ssm_parameter.notify_o11y_google_oauth_client_id.arn,
+      aws_ssm_parameter.notify_o11y_google_oauth_client_secret.arn
     ]
   }
 }

--- a/aws/database-tools/variables.tf
+++ b/aws/database-tools/variables.tf
@@ -18,6 +18,18 @@ variable "billing_tag_key" {
   description = "Identifies the billing key"
 }
 
+variable "notify_o11y_google_oauth_client_id" {
+  type        = string
+  sensitive   = true
+  description = "Google OAuth client ID for Notify observability tools"
+}
+
+variable "notify_o11y_google_oauth_client_secret" {
+  type        = string
+  sensitive   = true
+  description = "Google OAuth client secret for Notify observability tools"
+}
+
 variable "sqlalchemy_database_reader_uri" {
   type        = string
   sensitive   = true


### PR DESCRIPTION
# Summary
Update the Blazer ECS task to use a Docker image that is setup to automatically authenticate users with their Google account when they connect.

This will give us an audit table that shows the queries run by users.

# :warning: Note
Once this is applied, we'll need to connect to the Blazer container and create the new `Users` database table with:
```sh
rails db:migrate
```

# Related
- cds-snc/platform-core-services#137