### PR TITLE
feat: log Blazer audit to CloudWatch

### DIFF
--- a/aws/database-tools/blazer.tf
+++ b/aws/database-tools/blazer.tf
@@ -37,7 +37,7 @@ resource "aws_ecs_task_definition" "blazer" {
       "name" : "blazer",
       "cpu" : 0,
       "essential" : true,
-      "image" : "${aws_ecr_repository.blazer.repository_url}:v2.6.5-google-auth",
+      "image" : "${aws_ecr_repository.blazer.repository_url}:${var.blazer_image_tag}",
       "logConfiguration" : {
         "logDriver" : "awslogs",
         "options" : {
@@ -53,6 +53,10 @@ resource "aws_ecs_task_definition" "blazer" {
           "Protocol" : "tcp"
         }
       ],
+      "environment" : [{
+        "name" : "LOG_LEVEL",
+        "value" : "info"
+      }],
       "secrets" : [{
         "name" : "BLAZER_DATABASE_URL",
         "valueFrom" : "${aws_ssm_parameter.sqlalchemy_database_reader_uri.arn}"

--- a/aws/database-tools/variables.tf
+++ b/aws/database-tools/variables.tf
@@ -18,6 +18,11 @@ variable "billing_tag_key" {
   description = "Identifies the billing key"
 }
 
+variable "blazer_image_tag" {
+  type        = string
+  description = "The Blazer Docker image tag to deploy"
+}
+
 variable "notify_o11y_google_oauth_client_id" {
   type        = string
   sensitive   = true

--- a/env/production/database-tools/terragrunt.hcl
+++ b/env/production/database-tools/terragrunt.hcl
@@ -45,6 +45,7 @@ inputs = {
   vpc_id                          = dependency.common.outputs.vpc_id
   billing_tag_key                 = "CostCenter"
   billing_tag_value               = "notification-canada-ca-staging"
+  blazer_image_tag                = "3a4bcb999df711dfee89025bbcff18cf42b50126"
   database-tools-securitygroup    = dependency.eks.outputs.database-tools-securitygroup
   database-tools-db-securitygroup = dependency.eks.outputs.database-tools-db-securitygroup
 }

--- a/env/staging/database-tools/terragrunt.hcl
+++ b/env/staging/database-tools/terragrunt.hcl
@@ -41,6 +41,7 @@ inputs = {
   vpc_id                          = dependency.common.outputs.vpc_id
   billing_tag_key                 = "CostCenter"
   billing_tag_value               = "notification-canada-ca-staging"
+  blazer_image_tag                = "latest"
   database-tools-securitygroup    = dependency.eks.outputs.database-tools-securitygroup
   database-tools-db-securitygroup = dependency.eks.outputs.database-tools-db-securitygroup
 }


### PR DESCRIPTION
# Summary
Update the Blazer ECS image to log all Blazer audit info to CloudWatch.  This will make it easier to bring these logs into Sentinel.

Also updates the Blazer ECS task to allow the deploy of environment specific Docker images and to increase the log level from `warn` to `info`.

# Related
- cds-snc/platform-core-services#179