### PR TITLE
Add a new retention period to the celery log group

### DIFF
--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -7,6 +7,11 @@ resource "aws_cloudwatch_log_group" "notification-canada-ca-eks-cluster-logs" {
   retention_in_days = 14
 }
 
+resource "aws_cloudwatch_log_group" "notification-canada-ca-eks-application-logs" {
+  name              = local.eks_application_log_group
+  retention_in_days = 30
+}
+
 ###
 # AWS EKS Cloudwatch log metric filters
 ###

--- a/env/staging/eks/.terraform.lock.hcl
+++ b/env/staging/eks/.terraform.lock.hcl
@@ -1,9 +1,27 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.2.0"
+  hashes = [
+    "h1:CIWi5G6ob7p2wWoThRQbOB8AbmFlCzp7Ka81hR3cVp0=",
+    "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
+    "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
+    "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
+    "zh:55c0d7ddddbd0a46d57c51fcfa9b91f14eed081a45101dbfc7fd9d2278aa1403",
+    "zh:73a5dd68379119167934c48afa1101b09abad2deb436cd5c446733e705869d6b",
+    "zh:841fc4ac6dc3479981330974d44ad2341deada8a5ff9e3b1b4510702dfbdbed9",
+    "zh:91be62c9b41edb137f7f835491183628d484e9d6efa82fcb75cfa538c92791c5",
+    "zh:acd5f442bd88d67eb948b18dc2ed421c6c3faee62d3a12200e442bfff0aa7d8b",
+    "zh:ad5720da5524641ad718a565694821be5f61f68f1c3c5d2cfa24426b8e774bef",
+    "zh:e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65",
+    "zh:f6542918faa115df46474a36aabb4c3899650bea036b5f8a5e296be6f8f25767",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "3.74.2"
-  constraints = "~> 3.0"
+  constraints = "~> 3.0, >= 3.46.0"
   hashes = [
     "h1:TryIinyNf2gFkYA/d4hD0a76mPSvyl9rMUHePqs6cgs=",
     "zh:2b1df436ec034ae9416b23b95efd192b2fe271a7c8595493329dcde8e452c036",


### PR DESCRIPTION
# Summary | Résumé

I am attempting to change the retention period of our celery logs from "indefinite" to 30 days. The purpose of this is to delete PII that was logged by sqlalchemy in the log group `/aws/containerinsights/notification-canada-ca-production-eks-cluster/application`. 

Pat has advised me that this log group was probably auto created, and does not exist in terraform yet. So I will need to:
> do a Terraform state import so that Terraform doesn’t try to create the log group, but instead only updates the retention period 

[Terraform state import for log group docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#import)