### PR TITLE
Run scan-files on the document-download s3 bucket

### DIFF
--- a/aws/common/file_scanning.tf
+++ b/aws/common/file_scanning.tf
@@ -1,10 +1,8 @@
 module "s3_scan_objects" {
   source = "github.com/cds-snc/terraform-modules?ref=v3.0.9//S3_scan_object"
 
-  product_name = "gc-notify"
-  # just apply this to staging first to test it out
-  # after we QA, change to "notification-canada-ca-${var.env}-document-download"
-  s3_upload_bucket_name = "notification-canada-ca-staging-document-download"
+  product_name          = "gc-notify"
+  s3_upload_bucket_name = "notification-canada-ca-${var.env}-document-download"
 
   billing_tag_value = var.billing_tag_value
 }

--- a/aws/common/file_scanning.tf
+++ b/aws/common/file_scanning.tf
@@ -1,0 +1,10 @@
+module "s3_scan_objects" {
+  source = "github.com/cds-snc/terraform-modules?ref=v3.0.9//S3_scan_object"
+
+  product_name          = "gc-notify"
+  # just apply this to staging first to test it out
+  # after we QA, change to "notification-canada-ca-${var.env}-document-download"
+  s3_upload_bucket_name = "notification-canada-ca-staging-document-download"
+
+  billing_tag_value = var.billing_tag_value
+}

--- a/aws/common/file_scanning.tf
+++ b/aws/common/file_scanning.tf
@@ -1,7 +1,7 @@
 module "s3_scan_objects" {
   source = "github.com/cds-snc/terraform-modules?ref=v3.0.9//S3_scan_object"
 
-  product_name          = "gc-notify"
+  product_name = "gc-notify"
   # just apply this to staging first to test it out
   # after we QA, change to "notification-canada-ca-${var.env}-document-download"
   s3_upload_bucket_name = "notification-canada-ca-staging-document-download"

--- a/aws/common/variables.tf
+++ b/aws/common/variables.tf
@@ -1,3 +1,8 @@
+variable "billing_tag_value" {
+  type        = string
+  description = "Identifies the billing code."
+}
+
 variable "cloudwatch_opsgenie_alarm_webhook" {
   description = "OpsGenie webhook used to trigger a page when there is a critical alarm."
   type        = string

--- a/aws/performance-test/security_group.tf
+++ b/aws/performance-test/security_group.tf
@@ -2,15 +2,16 @@ resource "aws_security_group" "perf_test" {
   name        = "perf_test"
   description = "Performance Test Security Group"
   vpc_id      = var.vpc_id
+}
 
-  egress {
-    from_port = 443
-    to_port   = 443
-    protocol  = "tcp"
-    # We need to connect to the staging api server (not managed in terraform)
-    # tfsec:ignore:AWS009
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+resource "aws_security_group_rule" "perftest-egress-internet" {
+  description       = "Egress to the internet from perftest"
+  type              = "egress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.perf_test.id
 }
 
 # Connect perf test to the vpc private endpoint security group

--- a/env/production/common/terragrunt.hcl
+++ b/env/production/common/terragrunt.hcl
@@ -32,6 +32,7 @@ inputs = {
   alarm_critical_expired_sms_created_threshold                       = 200
   alarm_warning_expired_email_created_threshold                      = 100
   alarm_critical_expired_email_created_threshold                     = 200
+  billing_tag_value                                                  = "notification-canada-ca-production"
   sqs_priority_db_tasks_queue_name                                   = "priority-database-tasks.fifo"
   sqs_normal_db_tasks_queue_name                                     = "normal-database-tasks"
   sqs_bulk_db_tasks_queue_name                                       = "bulk-database-tasks"

--- a/env/staging/common/terragrunt.hcl
+++ b/env/staging/common/terragrunt.hcl
@@ -30,6 +30,7 @@ inputs = {
   alarm_critical_expired_sms_created_threshold                       = 200
   alarm_warning_expired_email_created_threshold                      = 100
   alarm_critical_expired_email_created_threshold                     = 200
+  billing_tag_value                                                  = "notification-canada-ca-staging"
   sqs_priority_db_tasks_queue_name                                   = "priority-database-tasks.fifo"
   sqs_normal_db_tasks_queue_name                                     = "normal-database-tasks"
   sqs_bulk_db_tasks_queue_name                                       = "bulk-database-tasks"


### PR DESCRIPTION
# Summary | Résumé

At @maxneuvians suggestion, I took a look at how `scan-files` was integrated in [share-files-securely](https://github.com/cds-snc/share-files-securely). I am copying some of the [terraform from that project]( https://github.com/cds-snc/share-files-securely/blob/main/terraform/file_scanning.tf#L1-L8) in this PR.

As I understand it, this will tell `scan-files` to start scanning the files uploaded by users that will be attached to emails. `scan-files` will then add some metadata to files in the s3 bucket, and we can implement something in `notification-api` to read that metadata and reject any files flagged as malicious. 

I will first deploy this to staging to test it out, and later make the change in production if everything is working as expected.

# Test instructions | Instructions pour tester la modification

Check that the terragrunt plan is as expected.