### PR TITLE
chore: remove S3 scan file module

### DIFF
--- a/aws/common/file_scanning.tf
+++ b/aws/common/file_scanning.tf
@@ -1,8 +1,0 @@
-module "s3_scan_objects" {
-  source = "github.com/cds-snc/terraform-modules?ref=v3.0.9//S3_scan_object"
-
-  product_name          = "gc-notify"
-  s3_upload_bucket_name = "notification-canada-ca-${var.env}-document-download"
-
-  billing_tag_value = var.billing_tag_value
-}

--- a/aws/common/variables.tf
+++ b/aws/common/variables.tf
@@ -1,8 +1,3 @@
-variable "billing_tag_value" {
-  type        = string
-  description = "Identifies the billing code."
-}
-
 variable "cloudwatch_opsgenie_alarm_webhook" {
   description = "OpsGenie webhook used to trigger a page when there is a critical alarm."
   type        = string

--- a/env/production/common/terragrunt.hcl
+++ b/env/production/common/terragrunt.hcl
@@ -32,7 +32,6 @@ inputs = {
   alarm_critical_expired_sms_created_threshold                       = 200
   alarm_warning_expired_email_created_threshold                      = 100
   alarm_critical_expired_email_created_threshold                     = 200
-  billing_tag_value                                                  = "notification-canada-ca-production"
   sqs_priority_db_tasks_queue_name                                   = "priority-database-tasks.fifo"
   sqs_normal_db_tasks_queue_name                                     = "normal-database-tasks"
   sqs_bulk_db_tasks_queue_name                                       = "bulk-database-tasks"

--- a/env/staging/common/terragrunt.hcl
+++ b/env/staging/common/terragrunt.hcl
@@ -30,7 +30,6 @@ inputs = {
   alarm_critical_expired_sms_created_threshold                       = 200
   alarm_warning_expired_email_created_threshold                      = 100
   alarm_critical_expired_email_created_threshold                     = 200
-  billing_tag_value                                                  = "notification-canada-ca-staging"
   sqs_priority_db_tasks_queue_name                                   = "priority-database-tasks.fifo"
   sqs_normal_db_tasks_queue_name                                     = "normal-database-tasks"
   sqs_bulk_db_tasks_queue_name                                       = "bulk-database-tasks"


### PR DESCRIPTION
# Summary
Remove the S3 scan file module as it is not currently setup to work with scanning files using custom key encryption.

@smcmurtry is investigating calling the API directly to perform the file scanning from the document download API.

# Related
- #600 