### PR TITLE
match api-k8s and api-lambda in waf rules

### DIFF
--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -435,7 +435,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
                 name = "host"
               }
             }
-            search_string = "api."
+            search_string = "api"
             text_transformation {
               priority = 1
               type     = "COMPRESS_WHITE_SPACE"
@@ -501,7 +501,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
                     name = "host"
                   }
                 }
-                search_string = "api."
+                search_string = "api"
                 text_transformation {
                   priority = 1
                   type     = "COMPRESS_WHITE_SPACE"
@@ -544,7 +544,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
                     name = "host"
                   }
                 }
-                search_string = "api."
+                search_string = "api"
                 text_transformation {
                   priority = 1
                   type     = "COMPRESS_WHITE_SPACE"

--- a/aws/lambda-api/waf.tf
+++ b/aws/lambda-api/waf.tf
@@ -297,7 +297,7 @@ resource "aws_wafv2_web_acl" "api_lambda" {
                     name = "host"
                   }
                 }
-                search_string = "api."
+                search_string = "api"
                 text_transformation {
                   priority = 1
                   type     = "COMPRESS_WHITE_SPACE"


### PR DESCRIPTION
# Summary | Résumé

The WAF is matching on `api.*` to detect api usage. This misses `api-k8s.*` and `api-lambda.*`. The effect is that api-k8s is being rate limited at the same (lower) rate as admin, and so we cannot, for example, run performance tests on it.
This PR matches on `api*` instead of `api.*` so that the others cases will be captured.


# Test instructions | Instructions pour tester la modification

After merging we should be able to perf test api-k8s without being rate limited.
