### PR TITLE
Terraform apply failure: provider undefined fix

### DIFF
--- a/aws/ses_receiving_emails/lambda.tf
+++ b/aws/ses_receiving_emails/lambda.tf
@@ -15,9 +15,7 @@ module "ses_receiving_emails" {
     GC_NOTIFY_SERVICE_EMAIL = var.gc_notify_service_email
   }
 
-  providers = {
-    aws = aws.us-east-1
-  }
+  provider = aws.us-east-1
 }
 
 resource "aws_lambda_function_event_invoke_config" "ses_receiving_emails_invoke_config" {


### PR DESCRIPTION
# Summary | Résumé

Terraform apply failed with the following error:

```
│ Warning: Provider aws is undefined
│ 
│   on lambda.tf line 19, in module "ses_receiving_emails":
│   19:     aws = aws.us-east-1
│ 
│ Module module.ses_receiving_emails does not declare a provider named aws.
│ If you wish to specify a provider configuration for the module, add an
│ entry for aws in the required_providers block within the module.
╵
Releasing state lock. This may take a few moments...
time=2023-01-09T17:06:51Z level=error msg=1 error occurred:
	* exit status 1
	```