### PR TITLE
Changes to add sns topics for us-east-1 and corresponding alerts

### DIFF
--- a/aws/common/kms.tf
+++ b/aws/common/kms.tf
@@ -108,3 +108,48 @@ EOF
     CostCenter = "notification-canada-ca-${var.env}"
   }
 }
+
+
+resource "aws_kms_key" "notification-canada-ca-us-east-1" {
+  provider = aws.us-east-1
+
+  description         = "notification-canada-ca ${var.env} encryption key in us-east-1"
+  enable_key_rotation = true
+
+  policy = <<EOF
+{
+   "Version":"2022-01-10",
+   "Id":"key-default-us-east-1",
+   "Statement":[
+      {
+         "Sid":"Enable IAM User Permissions",
+         "Effect":"Allow",
+         "Principal":{
+            "AWS":"arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+         },
+         "Action":"kms:*",
+         "Resource":"*"
+      },
+      {
+         "Sid":"Allow_CloudWatch_for_CMK",
+         "Effect":"Allow",
+         "Principal":{
+            "Service":[
+               "cloudwatch.amazonaws.com"
+            ]
+         },
+         "Action":[
+            "kms:Decrypt",
+            "kms:GenerateDataKey"
+         ],
+         "Resource":"*"
+      }
+   ]
+}
+EOF
+
+  tags = {
+    Name       = "notification-canada-ca"
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}

--- a/aws/common/lambda.tf
+++ b/aws/common/lambda.tf
@@ -155,16 +155,24 @@ resource "aws_lambda_permission" "ses_receiving_emails" {
 ##
 # SNS topics for CloudWatch alarms in us-east-1
 ##
+
+resource "aws_lambda_permission" "sns_ok_us_east_1_to_slack_lambda" {
+  action        = "lambda:InvokeFunction"
+  function_name = module.notify_slack_ok_us_east_1.notify_slack_lambda_function_arn
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.notification-canada-ca-alert-ok-us-east-1.arn
+}
+
 resource "aws_lambda_permission" "sns_warning_us_east_1_to_slack_lambda" {
   action        = "lambda:InvokeFunction"
-  function_name = module.notify_slack_warning.notify_slack_lambda_function_arn
+  function_name = module.notify_slack_warning_us_east_1.notify_slack_lambda_function_arn
   principal     = "sns.amazonaws.com"
   source_arn    = aws_sns_topic.notification-canada-ca-alert-warning-us-east-1.arn
 }
 
 resource "aws_lambda_permission" "sns_critical_us_east_1_to_slack_lambda" {
   action        = "lambda:InvokeFunction"
-  function_name = module.notify_slack_critical.notify_slack_lambda_function_arn
+  function_name = module.notify_slack_critical_us_east_1.notify_slack_lambda_function_arn
   principal     = "sns.amazonaws.com"
   source_arn    = aws_sns_topic.notification-canada-ca-alert-critical-us-east-1.arn
 }

--- a/aws/common/lambda.tf
+++ b/aws/common/lambda.tf
@@ -151,3 +151,20 @@ resource "aws_lambda_permission" "ses_receiving_emails" {
   # can ignore this because we specify `source_account` instead of `source_arn`
   source_account = var.account_id
 }
+
+##
+# SNS topics for CloudWatch alarms in us-east-1
+##
+resource "aws_lambda_permission" "sns_warning_us_east_1_to_slack_lambda" {
+  action        = "lambda:InvokeFunction"
+  function_name = module.notify_slack_warning.notify_slack_lambda_function_arn
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.notification-canada-ca-alert-warning-us-east-1.arn
+}
+
+resource "aws_lambda_permission" "sns_critical_us_east_1_to_slack_lambda" {
+  action        = "lambda:InvokeFunction"
+  function_name = module.notify_slack_critical.notify_slack_lambda_function_arn
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.notification-canada-ca-alert-critical-us-east-1.arn
+}

--- a/aws/common/lambda.tf
+++ b/aws/common/lambda.tf
@@ -151,28 +151,3 @@ resource "aws_lambda_permission" "ses_receiving_emails" {
   # can ignore this because we specify `source_account` instead of `source_arn`
   source_account = var.account_id
 }
-
-##
-# SNS topics for CloudWatch alarms in us-east-1
-##
-
-resource "aws_lambda_permission" "sns_ok_us_east_1_to_slack_lambda" {
-  action        = "lambda:InvokeFunction"
-  function_name = module.notify_slack_ok_us_east_1.notify_slack_lambda_function_arn
-  principal     = "sns.amazonaws.com"
-  source_arn    = aws_sns_topic.notification-canada-ca-alert-ok-us-east-1.arn
-}
-
-resource "aws_lambda_permission" "sns_warning_us_east_1_to_slack_lambda" {
-  action        = "lambda:InvokeFunction"
-  function_name = module.notify_slack_warning_us_east_1.notify_slack_lambda_function_arn
-  principal     = "sns.amazonaws.com"
-  source_arn    = aws_sns_topic.notification-canada-ca-alert-warning-us-east-1.arn
-}
-
-resource "aws_lambda_permission" "sns_critical_us_east_1_to_slack_lambda" {
-  action        = "lambda:InvokeFunction"
-  function_name = module.notify_slack_critical_us_east_1.notify_slack_lambda_function_arn
-  principal     = "sns.amazonaws.com"
-  source_arn    = aws_sns_topic.notification-canada-ca-alert-critical-us-east-1.arn
-}

--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -69,3 +69,11 @@ output "private-links-gateway-prefix-list-ids" {
   ]
   description = "The prefix list IDs for the gateway private links"
 }
+
+output "sns_alert_warning_arn_us_east_1" {
+  value = aws_sns_topic.notification-canada-ca-alert-warning-us-east-1.arn
+}
+
+output "sns_alert_critical_arn_us_east_1" {
+  value = aws_sns_topic.notification-canada-ca-alert-critical-us-east-1.arn
+}

--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -77,3 +77,7 @@ output "sns_alert_warning_arn_us_east_1" {
 output "sns_alert_critical_arn_us_east_1" {
   value = aws_sns_topic.notification-canada-ca-alert-critical-us-east-1.arn
 }
+
+output "sns_alert_ok_arn_us_east_1" {
+  value = aws_sns_topic.notification-canada-ca-alert-ok-us-east-1.arn
+}

--- a/aws/common/slack.tf
+++ b/aws/common/slack.tf
@@ -69,3 +69,58 @@ module "notify_slack_general" {
   lambda_function_name                   = "notify-slack-general"
   cloudwatch_log_group_retention_in_days = 90
 }
+
+# Setup slack notifications for us-east-1
+module "notify_slack_warning_us_east_1" {
+  source  = "terraform-aws-modules/notify-slack/aws"
+  version = "~> 4.24.0"
+
+  create_sns_topic = false
+  sns_topic_name   = aws_sns_topic.notification-canada-ca-alert-warning-us-east-1.name
+
+  slack_webhook_url = var.cloudwatch_slack_webhook_warning_topic
+  slack_channel     = var.slack_channel_warning_topic
+  slack_username    = "[WARNING] AWS Cloudwatch"
+  slack_emoji       = ":warning:"
+
+  lambda_function_name                   = "notify-slack-warning_us_east_1"
+  cloudwatch_log_group_retention_in_days = 90
+
+  depends_on = [aws_sns_topic.notification-canada-ca-alert-warning-us-east-1]
+}
+
+module "notify_slack_ok_us_east_1" {
+  source  = "terraform-aws-modules/notify-slack/aws"
+  version = "~> 4.24.0"
+
+  create_sns_topic = false
+  sns_topic_name   = aws_sns_topic.notification-canada-ca-alert-ok-us-east-1.name
+
+  slack_webhook_url = var.cloudwatch_slack_webhook_general_topic
+  slack_channel     = var.slack_channel_general_topic
+  slack_username    = "[OK] AWS Cloudwatch"
+  slack_emoji       = ":green:"
+
+  lambda_function_name                   = "notify-slack-ok_us_east_1"
+  cloudwatch_log_group_retention_in_days = 90
+
+  depends_on = [aws_sns_topic.notification-canada-ca-alert-ok-us-east-1]
+}
+
+module "notify_slack_critical_us_east_1" {
+  source  = "terraform-aws-modules/notify-slack/aws"
+  version = "~> 4.24.0"
+
+  create_sns_topic = false
+  sns_topic_name   = aws_sns_topic.notification-canada-ca-alert-critical-us-east-1.name
+
+  slack_webhook_url = var.cloudwatch_slack_webhook_critical_topic
+  slack_channel     = var.slack_channel_critical_topic
+  slack_username    = "[CRITICAL] AWS Cloudwatch"
+  slack_emoji       = ":rotating_light:"
+
+  lambda_function_name                   = "notify-slack-critical_us_east_1"
+  cloudwatch_log_group_retention_in_days = 90
+
+  depends_on = [aws_sns_topic.notification-canada-ca-alert-critical-us-east-1]
+}

--- a/aws/common/sns.tf
+++ b/aws/common/sns.tf
@@ -169,3 +169,88 @@ resource "aws_sns_topic_subscription" "alert_critical_us_west_2_to_opsgenie_ok" 
   raw_message_delivery   = false
   endpoint_auto_confirms = true
 }
+
+# SNS creation for us-east-1
+
+resource "aws_sns_topic" "notification-canada-ca-alert-ok-us-east-1" {
+  provider = aws.us-east-1
+
+  name              = "alert-ok-us-east-1"
+  kms_master_key_id = aws_kms_key.notification-canada-ca-us-east-1.arn
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}
+
+resource "aws_sns_topic" "notification-canada-ca-alert-warning-us-east-1" {
+  provider = aws.us-east-1
+
+  name              = "alert-warning-us-east-1"
+  kms_master_key_id = aws_kms_key.notification-canada-ca-us-east-1.arn
+
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}
+
+resource "aws_sns_topic" "notification-canada-ca-alert-critical-us-east-1" {
+  provider = aws.us-east-1
+
+  name              = "alert-critical-us-east-1"
+  kms_master_key_id = aws_kms_key.notification-canada-ca-us-east-1.arn
+
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}
+
+resource "aws_sns_topic_subscription" "sns_alert_ok_us_east_1_to_lambda" {
+  provider = aws.us-east-1
+
+  topic_arn = aws_sns_topic.notification-canada-ca-alert-ok-us-east-1.arn
+  protocol  = "lambda"
+  endpoint  = module.notify_slack_ok.notify_slack_lambda_function_arn
+}
+
+resource "aws_sns_topic_subscription" "sns_alert_warning_us_east_1_to_lambda" {
+  provider = aws.us-east-1
+
+  topic_arn = aws_sns_topic.notification-canada-ca-alert-warning-us-east-1.arn
+  protocol  = "lambda"
+  endpoint  = module.notify_slack_warning.notify_slack_lambda_function_arn
+}
+
+resource "aws_sns_topic_subscription" "sns_alert_critical_us_east_1_to_lambda" {
+  provider = aws.us-east-1
+
+  topic_arn = aws_sns_topic.notification-canada-ca-alert-critical-us-east-1.arn
+  protocol  = "lambda"
+  endpoint  = module.notify_slack_critical.notify_slack_lambda_function_arn
+}
+
+resource "aws_sns_topic_subscription" "alert_critical_us_east_1_to_opsgenie" {
+  provider = aws.us-east-1
+
+  count = var.env == "production" ? 1 : 0
+
+  topic_arn              = aws_sns_topic.notification-canada-ca-alert-critical-us-east-1.arn
+  protocol               = "https"
+  endpoint               = var.cloudwatch_opsgenie_alarm_webhook
+  raw_message_delivery   = false
+  endpoint_auto_confirms = true
+}
+
+resource "aws_sns_topic_subscription" "alert_critical_us_east_1_to_opsgenie_ok" {
+  provider = aws.us-east-1
+
+  count = var.env == "production" ? 1 : 0
+
+  topic_arn              = aws_sns_topic.notification-canada-ca-alert-ok-us-east-1.arn
+  protocol               = "https"
+  endpoint               = var.cloudwatch_opsgenie_alarm_webhook
+  raw_message_delivery   = false
+  endpoint_auto_confirms = true
+}

--- a/aws/common/sns.tf
+++ b/aws/common/sns.tf
@@ -212,7 +212,7 @@ resource "aws_sns_topic_subscription" "sns_alert_ok_us_east_1_to_lambda" {
 
   topic_arn = aws_sns_topic.notification-canada-ca-alert-ok-us-east-1.arn
   protocol  = "lambda"
-  endpoint  = module.notify_slack_ok.notify_slack_lambda_function_arn
+  endpoint  = module.notify_slack_ok_us_east_1.notify_slack_lambda_function_arn
 }
 
 resource "aws_sns_topic_subscription" "sns_alert_warning_us_east_1_to_lambda" {
@@ -220,7 +220,7 @@ resource "aws_sns_topic_subscription" "sns_alert_warning_us_east_1_to_lambda" {
 
   topic_arn = aws_sns_topic.notification-canada-ca-alert-warning-us-east-1.arn
   protocol  = "lambda"
-  endpoint  = module.notify_slack_warning.notify_slack_lambda_function_arn
+  endpoint  = module.notify_slack_warning_us_east_1.notify_slack_lambda_function_arn
 }
 
 resource "aws_sns_topic_subscription" "sns_alert_critical_us_east_1_to_lambda" {
@@ -228,7 +228,7 @@ resource "aws_sns_topic_subscription" "sns_alert_critical_us_east_1_to_lambda" {
 
   topic_arn = aws_sns_topic.notification-canada-ca-alert-critical-us-east-1.arn
   protocol  = "lambda"
-  endpoint  = module.notify_slack_critical.notify_slack_lambda_function_arn
+  endpoint  = module.notify_slack_critical_us_east_1.notify_slack_lambda_function_arn
 }
 
 resource "aws_sns_topic_subscription" "alert_critical_us_east_1_to_opsgenie" {

--- a/aws/ses_receiving_emails/cloudwatch_alarms.tf
+++ b/aws/ses_receiving_emails/cloudwatch_alarms.tf
@@ -14,8 +14,8 @@ resource "aws_cloudwatch_metric_alarm" "logs-1-500-error-1-minute-warning-ses_re
   statistic           = "Sum"
   threshold           = 1
   treat_missing_data  = "notBreaching"
-  alarm_actions       = [var.sns_alert_warning_arn]
-  ok_actions          = [var.sns_alert_warning_arn]
+  alarm_actions       = [var.sns_alert_warning_arn_us_east_1]
+  ok_actions          = [var.sns_alert_warning_arn_us_east_1]
 }
 
 # Will uncomment this after testing the warning alarm first

--- a/aws/ses_receiving_emails/cloudwatch_alarms.tf
+++ b/aws/ses_receiving_emails/cloudwatch_alarms.tf
@@ -15,7 +15,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-1-500-error-1-minute-warning-ses_re
   threshold           = 1
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_warning_arn_us_east_1]
-  ok_actions          = [var.sns_alert_warning_arn_us_east_1]
+  ok_actions          = [var.sns_alert_ok_arn_us_east_1]
 }
 
 # Will uncomment this after testing the warning alarm first

--- a/aws/ses_receiving_emails/variables.tf
+++ b/aws/ses_receiving_emails/variables.tf
@@ -35,3 +35,11 @@ variable "sns_alert_warning_arn" {
 variable "sns_alert_critical_arn" {
   type = string
 }
+
+variable "sns_alert_warning_arn_us_east_1" {
+  type = string
+}
+
+variable "sns_alert_critical_arn_us_east_1" {
+  type = string
+}

--- a/aws/ses_receiving_emails/variables.tf
+++ b/aws/ses_receiving_emails/variables.tf
@@ -28,18 +28,14 @@ variable "schedule_expression" {
   description = "This aws cloudwatch event rule scheule expression that specifies when the scheduler runs."
 }
 
-variable "sns_alert_warning_arn" {
-  type = string
-}
-
-variable "sns_alert_critical_arn" {
-  type = string
-}
-
 variable "sns_alert_warning_arn_us_east_1" {
   type = string
 }
 
 variable "sns_alert_critical_arn_us_east_1" {
+  type = string
+}
+
+variable "sns_alert_ok_arn_us_east_1" {
   type = string
 }

--- a/env/staging/common/.terraform.lock.hcl
+++ b/env/staging/common/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/archive" {
   version = "2.2.0"
   hashes = [
+    "h1:2K5LQkuWRS2YN1/YoNaHn9MAzjuTX8Gaqy6i8Mbfv8Y=",
     "h1:CIWi5G6ob7p2wWoThRQbOB8AbmFlCzp7Ka81hR3cVp0=",
     "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
     "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",

--- a/env/staging/ses_receiving_emails/terragrunt.hcl
+++ b/env/staging/ses_receiving_emails/terragrunt.hcl
@@ -12,6 +12,8 @@ dependency "common" {
   mock_outputs = {
     sns_alert_warning_arn  = ""
     sns_alert_critical_arn = ""
+    sns_alert_warning_arn_us_east_1 = ""
+    sns_alert_critical_arn_us_east_1 = ""
   }
 }
 
@@ -24,6 +26,8 @@ inputs = {
   schedule_expression    = "rate(1 minute)"
   sns_alert_warning_arn  = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn = dependency.common.outputs.sns_alert_critical_arn
+  sns_alert_warning_arn_us_east_1 = dependency.common.outputs.sns_alert_warning_arn_us_east_1
+  sns_alert_critical_arn_us_east_1 = dependency.common.outputs.sns_alert_critical_arn_us_east_1
   notify_sending_domain  = "staging.notification.cdssandbox.xyz"
   sqs_region             = "ca-central-1"
   celery_queue_prefix    = "eks-notification-canada-ca"

--- a/env/staging/ses_receiving_emails/terragrunt.hcl
+++ b/env/staging/ses_receiving_emails/terragrunt.hcl
@@ -10,10 +10,9 @@ dependency "common" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
-    sns_alert_warning_arn  = ""
-    sns_alert_critical_arn = ""
     sns_alert_warning_arn_us_east_1 = ""
     sns_alert_critical_arn_us_east_1 = ""
+    sns_alert_ok_arn_us_east_1 = ""
   }
 }
 
@@ -24,10 +23,9 @@ include {
 inputs = {
   billing_tag_value      = "notification-canada-ca-staging"
   schedule_expression    = "rate(1 minute)"
-  sns_alert_warning_arn  = dependency.common.outputs.sns_alert_warning_arn
-  sns_alert_critical_arn = dependency.common.outputs.sns_alert_critical_arn
   sns_alert_warning_arn_us_east_1 = dependency.common.outputs.sns_alert_warning_arn_us_east_1
   sns_alert_critical_arn_us_east_1 = dependency.common.outputs.sns_alert_critical_arn_us_east_1
+  sns_alert_ok_arn_us_east_1 = dependency.common.outputs.sns_alert_ok_arn_us_east_1
   notify_sending_domain  = "staging.notification.cdssandbox.xyz"
   sqs_region             = "ca-central-1"
   celery_queue_prefix    = "eks-notification-canada-ca"


### PR DESCRIPTION
# Summary | Résumé

In order to have alerts + slack notifications setup in us-east-1 we needed to remake our sns topics.