### PR TITLE
fix: bump to latest Sentinel layer arn version

### DIFF
--- a/aws/eks/sentinel.tf
+++ b/aws/eks/sentinel.tf
@@ -8,6 +8,8 @@ module "sentinel_forwarder" {
   function_name     = "sentinel-cloud-watch-forwarder"
   billing_tag_value = "notification-canada-ca-${var.env}"
 
+  layer_arn = "arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:37"
+
   customer_id = var.sentinel_customer_id
   shared_key  = var.sentinel_shared_key
 


### PR DESCRIPTION
# Summary
This is to fix the issue with cross-account use of the lambda layer as only the latest version of a layer has a resource based policy that allows its use.

# Related
- #611 