### PR TITLE
feat: add new GCA url

### DIFF
--- a/aws/eks/admin_waf_regex_patterns.tf
+++ b/aws/eks/admin_waf_regex_patterns.tf
@@ -44,7 +44,7 @@ resource "aws_wafv2_regex_pattern_set" "re_admin" {
 
   # GCA routes
   regular_expression {
-    regex_string = "/other-services|/autres-services|/service-level-agreement|/accord-niveaux-de-service|/service-level-objectives|/objectifs-niveau-de-service"
+    regex_string = "/other-services|/autres-services|/service-level-agreement|/accord-niveaux-de-service|/service-level-objectives|/objectifs-niveau-de-service|/pourquoi-notification-gc"
   }
 
   tags = {


### PR DESCRIPTION
# Summary | Résumé

This PR adds a new GCA URL: `/pourquoi-notification-gc`.  It also leaves in place the old URL (`pourquoi-gc-notification`) so that the redirect continues to work.

