### PR TITLE
Add ses permission for lambda

### DIFF
--- a/aws/ses_receiving_emails/lambda.tf
+++ b/aws/ses_receiving_emails/lambda.tf
@@ -50,3 +50,12 @@ data "aws_iam_policy_document" "ses_recieving_emails_sqs_send" {
     resources = ["*"]
   }
 }
+
+resource "aws_lambda_permission" "ses_receiving_emails" {
+  action        = "lambda:InvokeFunction"
+  function_name = module.ses_receiving_emails.function_name
+  principal     = "ses.amazonaws.com"
+  # tfsec:ignore:AWS058 Ensure that lambda function permission has a source arn specified
+  # can ignore this because we specify `source_account` instead of `source_arn`
+  source_account = var.account_id
+}


### PR DESCRIPTION
# Summary | Résumé

This was an issue when we merged the #629 
https://github.com/cds-snc/notification-terraform/actions/runs/4105259741/jobs/7081868021

Added the permissions here: 
https://github.com/cds-snc/notification-terraform/blob/main/aws/common/lambda.tf#L142-L153

into our ses_receiving_lambda folder