### PR TITLE
Task/move sqs callback

### DIFF
--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -133,6 +133,11 @@ jobs:
           cd env/staging/lambda-google-cidr
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
+      - name: Apply aws/ses_to_sqs_email_callbacks
+        run: |
+          cd env/staging/ses_to_sqs_email_callbacks
+          terragrunt apply --terragrunt-non-interactive -auto-approve
+
       - name: Bump version and push tag
         if: github.event_name != 'workflow_dispatch' # We don't want to tag new versions when launched via workflow_dispatch since only environment variables changed
         uses: mathieudutour/github-tag-action@v4.6

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -106,6 +106,9 @@ jobs:
             ses_receiving_emails:
               - 'aws/ses_receiving_emails/**'
               - 'env/staging/ses_receiving_emails/**'
+            ses_to_sqs_email_callbacks:
+              - 'aws/ses_to_sqs_email_callbacks/**'
+              - 'env/staging/ses_to_sqs_email_callbacks/**'
 
       - name: Terragrunt plan common
         if: ${{ steps.filter.outputs.common == 'true' }}
@@ -234,5 +237,15 @@ jobs:
           directory: "env/staging/lambda-google-cidr"
           comment-delete: "true"
           comment-title: "Staging: lambda-google-cidr"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
+
+      - name: Terragrunt plan ses_to_sqs_email_callbacks
+        if: ${{ steps.filter.outputs.ses_to_sqs_email_callbacks == 'true' || steps.filter.outputs.common == 'true' }}
+        uses: cds-snc/terraform-plan@v1
+        with:
+          directory: "env/staging/ses_to_sqs_email_callbacks"
+          comment-delete: "true"
+          comment-title: "Staging: ses_to_sqs_email_callbacks"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"

--- a/aws/common/lambda.tf
+++ b/aws/common/lambda.tf
@@ -114,6 +114,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_failures_us_west_2" 
 ##
 # SNS topic for SES deliveries
 ##
+# TO DO: delete once the ses_to_sqs_email is moved to lambda
 resource "aws_lambda_permission" "allow_sns_ses_callbacks" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.ses_to_sqs_email_callbacks.function_name

--- a/aws/ses_to_sqs_email_callbacks/cloudwatch_alarms.tf
+++ b/aws/ses_to_sqs_email_callbacks/cloudwatch_alarms.tf
@@ -1,0 +1,35 @@
+# Note to maintainers:
+# Updating alarms? Update the Google Sheet also!
+# https://docs.google.com/spreadsheets/d/1gkrL3Trxw0xEkX724C1bwpfeRsTlK2X60wtCjF6MFRA/edit
+#
+
+resource "aws_cloudwatch_metric_alarm" "logs-1-500-error-1-minute-warning-ses_to_sqs_email_callbacks-api" {
+  alarm_name          = "logs-1-500-error-1-minute-warning-ses_to_sqs_email_callbacks-api"
+  alarm_description   = "One 500 error in 1 minute for ses_to_sqs_email_callbacks api"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.ses_to_sqs_email_callbacks-500-errors-api.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.ses_to_sqs_email_callbacks-500-errors-api.metric_transformation[0].namespace
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [var.sns_alert_warning_arn]
+  ok_actions          = [var.sns_alert_warning_arn]
+}
+
+# I will switch this on after testing
+# resource "aws_cloudwatch_metric_alarm" "logs-10-500-error-5-minutes-critical-ses_receiving_emails-api" {
+#   alarm_name          = "logs-10-500-error-5-minutes-critical-ses_receiving_emails-api"
+#   alarm_description   = "Ten 500 errors in 5 minutes for ses_receiving_emails api"
+#   comparison_operator = "GreaterThanOrEqualToThreshold"
+#   evaluation_periods  = "1"
+#   metric_name         = aws_cloudwatch_log_metric_filter.ses_receiving_emails-500-errors-api.metric_transformation[0].name
+#   namespace           = aws_cloudwatch_log_metric_filter.ses_receiving_emails-500-errors-api.metric_transformation[0].namespace
+#   period              = "300"
+#   statistic           = "Sum"
+#   threshold           = 10
+#   treat_missing_data  = "notBreaching"
+#   alarm_actions       = [var.sns_alert_critical_arn]
+#   ok_actions          = [var.sns_alert_critical_arn]
+# }

--- a/aws/ses_to_sqs_email_callbacks/cloudwatch_logs.tf
+++ b/aws/ses_to_sqs_email_callbacks/cloudwatch_logs.tf
@@ -1,0 +1,25 @@
+#
+# SES Receiving Emails CloudWatch logging
+#
+
+resource "aws_cloudwatch_log_group" "ses_to_sqs_email_callbacks_log_group" {
+  name              = "ses_to_sqs_email_callbacks_log_group"
+  retention_in_days = 90
+  tags = {
+    CostCenter  = "notification-canada-ca-${var.env}"
+    Environment = var.env
+    Application = "lambda"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "ses_to_sqs_email_callbacks-500-errors-api" {
+  name           = "ses_to_sqs_email_callbacks-500-errors-api"
+  pattern        = "\"\\\"levelname\\\": \\\"ERROR\\\"\""
+  log_group_name = "/aws/lambda/${module.ses_to_sqs_email_callbacks.function_name}"
+
+  metric_transformation {
+    name      = "500-errors-ses_to_sqs_email_callbacks-api"
+    namespace = "LogMetrics"
+    value     = "1"
+  }
+}

--- a/aws/ses_to_sqs_email_callbacks/ecr.tf
+++ b/aws/ses_to_sqs_email_callbacks/ecr.tf
@@ -1,0 +1,10 @@
+resource "aws_ecr_repository" "ses_to_sqs_email_callbacks" {
+  # The :latest tag is used in Staging
+
+  name                 = "notify/ses_to_sqs_email_callbacks"
+  image_tag_mutability = "MUTABLE" #tfsec:ignore:AWS078
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}

--- a/aws/ses_to_sqs_email_callbacks/lambda.tf
+++ b/aws/ses_to_sqs_email_callbacks/lambda.tf
@@ -1,0 +1,18 @@
+module "ses_to_sqs_email_callbacks" {
+  source                 = "github.com/cds-snc/terraform-modules?ref=v4.0.3//lambda"
+  name                   = "ses_to_sqs_email_callbacks"
+  billing_tag_value      = var.billing_tag_value
+  ecr_arn                = aws_ecr_repository.ses_to_sqs_email_callbacks.arn
+  enable_lambda_insights = true
+  image_uri              = "${aws_ecr_repository.ses_to_sqs_email_callbacks.repository_url}:latest"
+  timeout                = 60
+  memory                 = 1024
+
+}
+
+resource "aws_lambda_permission" "allow_sns_ses_callbacks" {
+  action        = "lambda:InvokeFunction"
+  function_name = module.ses_to_sqs_email_callbacks.function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = var.notification_canada_ca_ses_callback_arn
+}

--- a/aws/ses_to_sqs_email_callbacks/variables.tf
+++ b/aws/ses_to_sqs_email_callbacks/variables.tf
@@ -1,0 +1,15 @@
+variable "billing_tag_value" {
+  type        = string
+  description = "Identifies the billing code."
+}
+variable "sns_alert_warning_arn" {
+  type = string
+}
+
+variable "sns_alert_critical_arn" {
+  type = string
+}
+
+variable "notification_canada_ca_ses_callback_arn" {
+  type = string
+}

--- a/env/staging/ses_to_sqs_email_callbacks/terragrunt.hcl
+++ b/env/staging/ses_to_sqs_email_callbacks/terragrunt.hcl
@@ -1,0 +1,32 @@
+dependencies {
+  paths = ["../common"]
+}
+
+dependency "common" {
+  config_path = "../common"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    notification_canada_ca_ses_callback_arn = ""
+    sns_alert_warning_arn          = ""
+    sns_alert_critical_arn         = ""
+  }
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  billing_tag_value                       = "notification-canada-ca-staging"
+  notification_canada_ca_ses_callback_arn = dependency.common.outputs.notification_canada_ca_ses_callback_arn
+  sns_alert_warning_arn                   = dependency.common.outputs.sns_alert_warning_arn
+  sns_alert_critical_arn                  = dependency.common.outputs.sns_alert_critical_arn
+}
+
+terraform {
+  source = "../../../aws//ses_to_sqs_email_callbacks"
+}


### PR DESCRIPTION
# Summary | Résumé

Move `ses_to_sqs_email_callbacks` to an image lambda. This needs to be tested on staging. Will test this after its been merged.