### PR TITLE
SNS subscription needs to be function arn and not name

### DIFF
--- a/aws/ses_to_sqs_email_callbacks/lambda.tf
+++ b/aws/ses_to_sqs_email_callbacks/lambda.tf
@@ -20,5 +20,5 @@ resource "aws_lambda_permission" "allow_sns_ses_callbacks" {
 resource "aws_sns_topic_subscription" "ses_sns_to_lambda" {
   topic_arn = var.notification_canada_ca_ses_callback_arn
   protocol  = "lambda"
-  endpoint  = module.ses_to_sqs_email_callbacks.function_name
+  endpoint  = module.ses_to_sqs_email_callbacks.function_arn
 }


### PR DESCRIPTION
# Summary | Résumé

Made an error and put function_name instead of function_arn for endpoint in sns subscription