### PR TITLE
Add permissions for sqs

### DIFF
--- a/aws/ses_to_sqs_email_callbacks/lambda.tf
+++ b/aws/ses_to_sqs_email_callbacks/lambda.tf
@@ -8,6 +8,20 @@ module "ses_to_sqs_email_callbacks" {
   timeout                = 60
   memory                 = 1024
 
+  policies = [
+    data.aws_iam_policy_document.ses_to_sqs_email_callbacks.json
+  ]
+}
+
+data "aws_iam_policy_document" "ses_to_sqs_email_callbacks" {
+  statement {
+    actions = [
+      "sqs:Get*",
+      "sqs:SendMessage"
+    ]
+    effect    = "Allow"
+    resources = ["*"]
+  }
 }
 
 resource "aws_lambda_permission" "allow_sns_ses_callbacks" {


### PR DESCRIPTION
# Summary | Résumé

The lambda is failing as we can't read from SQS. This is the same permission that was added here:
https://github.com/cds-snc/notification-terraform/blob/main/aws/ses_receiving_emails/lambda.tf#L18-L32

so this is similar but for the next lambda

<img width="1529" alt="Screenshot 2023-02-08 at 11 45 23 AM" src="https://user-images.githubusercontent.com/8869623/217595601-697fd9c8-0e78-4e83-b3c8-ca4444c81c1d.png">
