### PR TITLE
Remove old lambda invocation and move the image to production

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -80,6 +80,11 @@ jobs:
           cd env/production/ses_receiving_emails
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
+      - name: Apply aws/ses_to_sqs_email_callbacks
+        run: |
+          cd env/production/ses_to_sqs_email_callbacks
+          terragrunt apply --terragrunt-non-interactive -auto-approve
+
       - name: Apply aws/dns
         run: |
           cd env/production/dns

--- a/.github/workflows/terragrunt_plan_production.yml
+++ b/.github/workflows/terragrunt_plan_production.yml
@@ -75,6 +75,15 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"
 
+      - name: Terragrunt plan ses_to_sqs_email_callbacks
+        uses: cds-snc/terraform-plan@v1
+        with:
+          directory: "env/production/ses_to_sqs_email_callbacks"
+          comment-delete: "true"
+          comment-title: "Production: ses_to_sqs_email_callbacks"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
+
       - name: Terragrunt plan dns
         uses: cds-snc/terraform-plan@v2
         with:

--- a/aws/common/lambda.tf
+++ b/aws/common/lambda.tf
@@ -80,12 +80,12 @@ resource "aws_lambda_function" "ses_receiving_emails" {
 ##
 # CloudWatch log groups for SNS deliveries in ca-central-1
 ##
-resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_successes" {
-  action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.sns_to_sqs_sms_callbacks.function_name
-  principal     = "logs.${var.region}.amazonaws.com"
-  source_arn    = "${aws_cloudwatch_log_group.sns_deliveries.arn}:*"
-}
+# resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_successes" {
+#   action        = "lambda:InvokeFunction"
+#   function_name = aws_lambda_function.sns_to_sqs_sms_callbacks.function_name
+#   principal     = "logs.${var.region}.amazonaws.com"
+#   source_arn    = "${aws_cloudwatch_log_group.sns_deliveries.arn}:*"
+# }
 
 resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_failures" {
   action        = "lambda:InvokeFunction"

--- a/aws/common/lambda.tf
+++ b/aws/common/lambda.tf
@@ -80,12 +80,12 @@ resource "aws_lambda_function" "ses_receiving_emails" {
 ##
 # CloudWatch log groups for SNS deliveries in ca-central-1
 ##
-# resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_successes" {
-#   action        = "lambda:InvokeFunction"
-#   function_name = aws_lambda_function.sns_to_sqs_sms_callbacks.function_name
-#   principal     = "logs.${var.region}.amazonaws.com"
-#   source_arn    = "${aws_cloudwatch_log_group.sns_deliveries.arn}:*"
-# }
+resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_successes" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.sns_to_sqs_sms_callbacks.function_name
+  principal     = "logs.${var.region}.amazonaws.com"
+  source_arn    = "${aws_cloudwatch_log_group.sns_deliveries.arn}:*"
+}
 
 resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_failures" {
   action        = "lambda:InvokeFunction"
@@ -114,13 +114,13 @@ resource "aws_lambda_permission" "allow_cloudwatch_logs_sns_failures_us_west_2" 
 ##
 # SNS topic for SES deliveries
 ##
-# TO DO: delete once the ses_to_sqs_email is moved to lambda
-resource "aws_lambda_permission" "allow_sns_ses_callbacks" {
-  action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.ses_to_sqs_email_callbacks.function_name
-  principal     = "sns.amazonaws.com"
-  source_arn    = aws_sns_topic.notification-canada-ca-ses-callback.arn
-}
+# # TO DO: delete once the ses_to_sqs_email is moved to lambda
+# resource "aws_lambda_permission" "allow_sns_ses_callbacks" {
+#   action        = "lambda:InvokeFunction"
+#   function_name = aws_lambda_function.ses_to_sqs_email_callbacks.function_name
+#   principal     = "sns.amazonaws.com"
+#   source_arn    = aws_sns_topic.notification-canada-ca-ses-callback.arn
+# }
 
 ##
 # SNS topics for CloudWatch alarms in us-west-2


### PR DESCRIPTION
# Summary | Résumé

Switch off the old lambda, and switch on the new one

You can see that both lambdas are currently running in staging.
I am testing this by looking at the log output of both the image lambda (ses_to_sqs_email_callbacks) vs the file lambda (ses-to-sqs-email-callbacks)

File log:
<img width="1571" alt="Screenshot 2023-02-08 at 1 25 48 PM" src="https://user-images.githubusercontent.com/8869623/217619378-8dd9aa82-cb35-4999-a651-3dc1178101dc.png">

Image log
<img width="1030" alt="Screenshot 2023-02-08 at 1 25 11 PM" src="https://user-images.githubusercontent.com/8869623/217619380-9ecf24de-2c9b-4eba-a5af-4e02a12cd5d5.png">

Once this PR is merged in, the file lambda will not be invoked and only the image lambda will run. 
This PR once tagged is what will allow us to deploy this code to production