### PR TITLE
Add third lambda to production

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -85,6 +85,11 @@ jobs:
           cd env/production/ses_to_sqs_email_callbacks
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
+      - name: Apply aws/sns_to_sqs_sms_callbacks
+        run: |
+          cd env/production/sns_to_sqs_sms_callbacks
+          terragrunt apply --terragrunt-non-interactive -auto-approve
+
       - name: Apply aws/dns
         run: |
           cd env/production/dns

--- a/.github/workflows/terragrunt_plan_production.yml
+++ b/.github/workflows/terragrunt_plan_production.yml
@@ -84,6 +84,15 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"
 
+      - name: Terragrunt plan sns_to_sqs_sms_callbacks
+        uses: cds-snc/terraform-plan@v1
+        with:
+          directory: "env/production/sns_to_sqs_sms_callbacks"
+          comment-delete: "true"
+          comment-title: "Production: sns_to_sqs_sms_callbacks"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
+
       - name: Terragrunt plan dns
         uses: cds-snc/terraform-plan@v2
         with:

--- a/env/production/sns_to_sqs_sms_callbacks/terragrunt.hcl
+++ b/env/production/sns_to_sqs_sms_callbacks/terragrunt.hcl
@@ -1,0 +1,46 @@
+terraform {
+  source = "git::https://github.com/cds-snc/notification-terraform//aws/sns_to_sqs_sms_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}"
+}
+
+dependencies {
+  paths = ["../common"]
+}
+
+dependency "common" {
+  config_path = "../common"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    sns_deliveries_ca_central_arn           = "arn:aws:logs:ca-central-1:111111111111:log-group:sns/ca-central-1/111111111111/DirectPublishToPhoneNumber"
+    sns_deliveries_ca_central_name          = ""
+    sns_deliveries_failures_ca_central_arn  = "arn:aws:logs:ca-central-1:111111111111:log-group:sns/ca-central-1/111111111111/DirectPublishToPhoneNumber/Failure"
+    sns_deliveries_failures_ca_central_name = ""
+    sns_deliveries_us_west_2_arn            = "arn:aws:logs:us-west-2:111111111111:log-group:sns/us-west-2/111111111111/DirectPublishToPhoneNumber"
+    sns_deliveries_us_west_2_name           = ""
+    sns_deliveries_failures_us_west_2_arn   = "arn:aws:logs:us-west-2:111111111111:log-group:sns/us-west-2/111111111111/DirectPublishToPhoneNumber/Failure"
+    sns_deliveries_failures_us_west_2_name  = ""
+    sns_alert_warning_arn                   = ""
+    sns_alert_critical_arn                  = ""
+  }
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  billing_tag_value                        = "notification-canada-ca-staging"
+  sns_deliveries_ca_central_arn            = dependency.common.outputs.sns_deliveries_ca_central_arn
+  sns_deliveries_ca_central_name           = dependency.common.outputs.sns_deliveries_ca_central_name
+  sns_deliveries_failures_ca_central_arn   = dependency.common.outputs.sns_deliveries_failures_ca_central_arn
+  sns_deliveries_failures_ca_central_name  = dependency.common.outputs.sns_deliveries_failures_ca_central_name
+  sns_deliveries_us_west_2_arn             = dependency.common.outputs.sns_deliveries_us_west_2_arn
+  sns_deliveries_us_west_2_name            = dependency.common.outputs.sns_deliveries_us_west_2_name
+  sns_deliveries_failures_us_west_2_arn    = dependency.common.outputs.sns_deliveries_failures_us_west_2_arn
+  sns_deliveries_failures_us_west_2_name   = dependency.common.outputs.sns_deliveries_failures_us_west_2_name
+  sns_alert_warning_arn                    = dependency.common.outputs.sns_alert_warning_arn
+  sns_alert_critical_arn                   = dependency.common.outputs.sns_alert_critical_arn
+}


### PR DESCRIPTION
# Summary | Résumé

The third lambda is currently live in staging. 
This will add the third lambda sns_to_sqs_sms_callbacks to production 

Once this code is deployed, we will have both the old and new lambda reading from the same SNS topic . This is correct as we do not want the SNS topic to be without a subscriber at any point. 

Having both lambdas live at the same time, doesn't cause any errors (this was tested on staging)