### PR TITLE
Reduce scope of sqs permission

### DIFF
--- a/aws/ses_receiving_emails/lambda.tf
+++ b/aws/ses_receiving_emails/lambda.tf
@@ -27,7 +27,7 @@ data "aws_iam_policy_document" "ses_recieving_emails_sqs_send" {
       "sqs:SendMessage"
     ]
     effect    = "Allow"
-    resources = ["*"]
+    resources = [format("%s/%s", var.celery_queue_prefix, "notify-internal-tasks")]
   }
 }
 resource "aws_lambda_permission" "ses_receiving_emails" {

--- a/aws/ses_to_sqs_email_callbacks/lambda.tf
+++ b/aws/ses_to_sqs_email_callbacks/lambda.tf
@@ -20,7 +20,7 @@ data "aws_iam_policy_document" "ses_to_sqs_email_callbacks" {
       "sqs:SendMessage"
     ]
     effect    = "Allow"
-    resources = ["*"]
+    resources = ["eks-notification-canada-cadelivery-receipts", ]
   }
 }
 

--- a/aws/sns_to_sqs_sms_callbacks/lambda.tf
+++ b/aws/sns_to_sqs_sms_callbacks/lambda.tf
@@ -20,7 +20,7 @@ data "aws_iam_policy_document" "sns_to_sqs_sms_callbacks" {
       "sqs:SendMessage"
     ]
     effect    = "Allow"
-    resources = ["*"]
+    resources = ["eks-notification-canada-cadelivery-receipts"]
   }
 }
 


### PR DESCRIPTION
# Summary | Résumé

We have 3 lambda functions were the resources have "*" for permission. This PR aims to reduce that:

1. ses_receiving_emails:
https://github.com/cds-snc/notification-lambdas/blob/main/sesreceivingemails/ses_receiving_emails.py#L98

2. ses_to_sqs_email_callbacks:
https://github.com/cds-snc/notification-lambdas/blob/main/sesemailcallbacks/ses_to_sqs_email_callbacks.py#L9-L10

3. sns_to_sqs_sms_callbacks:
https://github.com/cds-snc/notification-lambdas/blob/main/snssmscallbacks/sns_to_sqs_sms_callbacks.py#L64