### PR TITLE
Add alarms for malware detection

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -313,3 +313,32 @@ resource "aws_cloudwatch_metric_alarm" "ddos-detected-load-balancer-critical" {
     ResourceArn = aws_shield_protection.notification-canada-ca.resource_arn
   }
 }
+
+resource "aws_cloudwatch_metric_alarm" "logs-1-malware-detected-1-minute-warning" {
+  alarm_name          = "logs-1-malware-detected-1-minute-warning"
+  alarm_description   = "One malware detected error in 1 minute"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.malware-detected.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.malware-detected.metric_transformation[0].namespace
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [var.sns_alert_warning_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "logs-10-malware-detected-1-minute-critical" {
+  alarm_name          = "logs-10-malware-detected-1-minute-critical"
+  alarm_description   = "Ten malware detected errors in 1 minute"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.malware-detected.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.malware-detected.metric_transformation[0].namespace
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = 10
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [var.sns_alert_critical_arn]
+  ok_actions          = [var.sns_alert_critical_arn]
+}

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -36,7 +36,7 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error" {
 
 resource "aws_cloudwatch_log_metric_filter" "malware-detected" {
   name           = "malware-detected"
-  pattern        = "Malicious content detected"
+  pattern        = "Malicious content detected! Download and attachment failed"
   log_group_name = local.eks_application_log_group
 
   metric_transformation {

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -36,11 +36,11 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error" {
 
 resource "aws_cloudwatch_log_metric_filter" "malware-detected" {
   name           = "malware-detected"
-  pattern        = "?\"ERROR/Worker\" ?\"ERROR/ForkPoolWorker\" ?\"WorkerLostError\""
+  pattern        = "Malicious content detected"
   log_group_name = local.eks_application_log_group
 
   metric_transformation {
-    name      = "celery-error"
+    name      = "malware-detected"
     namespace = "LogMetrics"
     value     = "1"
   }

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -33,3 +33,15 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error" {
     value     = "1"
   }
 }
+
+resource "aws_cloudwatch_log_metric_filter" "malware-detected" {
+  name           = "malware-detected"
+  pattern        = "?\"ERROR/Worker\" ?\"ERROR/ForkPoolWorker\" ?\"WorkerLostError\""
+  log_group_name = local.eks_application_log_group
+
+  metric_transformation {
+    name      = "celery-error"
+    namespace = "LogMetrics"
+    value     = "1"
+  }
+}


### PR DESCRIPTION
# Summary | Résumé

This PR adds a warning and a critical alarm for when malware is detected.

- Warning occurs when 1 event of malware detection happens in a 1 minute period
- Critical occurs when 10 events of malware detection happens in a 1 minute period