### PR TITLE
no news is good news

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -353,6 +353,6 @@ resource "aws_cloudwatch_metric_alarm" "logs-1-scanfiles-timeout-1-minute-warnin
   period              = "60"
   statistic           = "Sum"
   threshold           = 1
-  treat_missing_data  = "ignore"
+  treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_warning_arn]
 }


### PR DESCRIPTION
# Summary | Résumé

Set the malware scanning timeout warning to not breaching (so no timeouts means all is good)

