### PR TITLE
Added WAF rules for documentation website

### DIFF
--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -73,6 +73,11 @@ output "re_document_download_arn" {
   description = "The ARN of the regex pattern set for the allowed URLs of the document download API"
 }
 
+output "re_documentation_arn" {
+  value       = aws_wafv2_regex_pattern_set.re_documentation.arn
+  description = "The ARN of the regex pattern set for the allowed URLs of the documentation website"
+}
+
 output "private-links-vpc-endpoints-securitygroup" {
   value       = aws_security_group.vpc_endpoints.id
   description = "private links vpc endpoint security group id"

--- a/aws/common/waf.tf
+++ b/aws/common/waf.tf
@@ -115,3 +115,21 @@ resource "aws_wafv2_regex_pattern_set" "re_document_download" {
   }
 }
 
+resource "aws_wafv2_regex_pattern_set" "re_documentation" {
+  name        = "re_documentation"
+  description = "Regex matching valid documentation website endpoints"
+  scope       = "REGIONAL"
+
+  # WAF Regex blocks are combined with OR logic. 
+  # Regex support is limited, please see: 
+  # https://docs.aws.amazon.com/waf/latest/developerguide/waf-regex-pattern-set-managing.html
+
+  regular_expression {
+    regex_string = "/en|/en/|/en/start.*|/en/send|/en/status.*|/en/testing.*|/en/keys.*|/en/limits.*|/en/callbacks.*|/en/architecture.*|/en/clients.*"
+  }
+
+  regular_expression {
+    regex_string = "/fr|/fr/|/fr/commencer.*|/fr/envoyer.*|/fr/etat.*|/fr/cles.*|/fr/limites.*|/fr/rappel.*|/fr/architecture.*|/fr/clients.*"
+  }
+
+}

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -128,6 +128,11 @@ variable "re_document_download_arn" {
   type        = string
 }
 
+variable "re_documentation_arn" {
+  description = "Regular expression to match the documentation website"
+  type        = string
+}
+
 variable "private-links-vpc-endpoints-securitygroup" {
   type        = string
   description = "Security group for vpc endpoints to enable private link"

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -308,6 +308,27 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
           }
         }
 
+        statement {
+          not_statement {
+            statement {
+              regex_pattern_set_reference_statement {
+                arn = var.re_documentation_arn
+                field_to_match {
+                  uri_path {}
+                }
+                text_transformation {
+                  priority = 1
+                  type     = "COMPRESS_WHITE_SPACE"
+                }
+                text_transformation {
+                  priority = 2
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+          }
+        }
+
         # filter out non-matching paths for admin
         statement {
           not_statement {

--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -18,6 +18,7 @@ dependency "common" {
     re_admin_arn                              = ""
     re_api_arn                                = ""
     re_document_download_arn                  = ""
+    re_documentation_arn                      = ""
     private-links-vpc-endpoints-securitygroup = ""
     private-links-gateway-prefix-list-ids     = []
   }
@@ -63,6 +64,7 @@ inputs = {
   re_admin_arn                              = dependency.common.outputs.re_admin_arn
   re_api_arn                                = dependency.common.outputs.re_api_arn
   re_document_download_arn                  = dependency.common.outputs.re_document_download_arn
+  re_documentation_arn                      = dependency.common.outputs.re_documentation_arn
   private-links-vpc-endpoints-securitygroup = dependency.common.outputs.private-links-vpc-endpoints-securitygroup
   private-links-gateway-prefix-list-ids     = dependency.common.outputs.private-links-gateway-prefix-list-ids
 }

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -28,6 +28,7 @@ dependency "common" {
     re_admin_arn                              = ""
     re_api_arn                                = ""
     re_document_download_arn                  = ""
+    re_documentation_arn                      = ""
     private-links-vpc-endpoints-securitygroup = ""
     private-links-gateway-prefix-list-ids     = []
   }
@@ -88,6 +89,7 @@ inputs = {
   re_admin_arn                              = dependency.common.outputs.re_admin_arn
   re_api_arn                                = dependency.common.outputs.re_api_arn
   re_document_download_arn                  = dependency.common.outputs.re_document_download_arn
+  re_documentation_arn                      = dependency.common.outputs.re_documentation_arn
   private-links-vpc-endpoints-securitygroup = dependency.common.outputs.private-links-vpc-endpoints-securitygroup
   private-links-gateway-prefix-list-ids     = dependency.common.outputs.private-links-gateway-prefix-list-ids
 }


### PR DESCRIPTION
# Summary | Résumé

Added WAF rule for the documentation website.

Because we just changed the WAF rules to restrict all URLs, no matter what the host is (we did discriminate on the host before), we need to define all URLs served by our applications in our K8s space. The documentation website was never defined and by making this change, we need to include it now.

# Test instructions | Instructions pour tester la modification

[Hit this URL](https://staging.notification.cdssandbox.xyz/en) and see if you have a 200 or 404 status code (working) or 204 (blocked by WAF).

Unfortunately, we do not have documentation website in staging, although it is running in staging environment. We need to [setup a DNS record just like production](https://github.com/cds-snc/dns/blob/5c636c892b57f580f37bdd4707bf9a01b82ecc41/terraform/notification.canada.ca-zone.tf#L121C51-L129) to replicate the environment.
