### PR TITLE
fix: admin PR review env to Redis in Staging

### DIFF
--- a/aws/elasticache/elasticache.tf
+++ b/aws/elasticache/elasticache.tf
@@ -30,9 +30,11 @@ resource "aws_elasticache_replication_group" "notification-cluster-cache-multiaz
   maintenance_window   = "thu:04:00-thu:05:00"
   multi_az_enabled     = true
 
-  security_group_ids = [
-    var.eks_cluster_securitygroup
-  ]
+  # Lambda PR review env security group is only included in Staging
+  security_group_ids = compact([
+    var.eks_cluster_securitygroup,
+    var.env == "staging" ? aws_security_group.lambda_admin_pr_review[0].id : ""
+  ])
   subnet_group_name = aws_elasticache_subnet_group.notification-canada-ca-cache-subnet.name
 
   tags = {

--- a/aws/elasticache/elasticache.tf
+++ b/aws/elasticache/elasticache.tf
@@ -30,12 +30,8 @@ resource "aws_elasticache_replication_group" "notification-cluster-cache-multiaz
   maintenance_window   = "thu:04:00-thu:05:00"
   multi_az_enabled     = true
 
-  # Lambda PR review env security group is only included in Staging
-  security_group_ids = compact([
-    var.eks_cluster_securitygroup,
-    var.env == "staging" ? aws_security_group.lambda_admin_pr_review[0].id : ""
-  ])
-  subnet_group_name = aws_elasticache_subnet_group.notification-canada-ca-cache-subnet.name
+  security_group_ids = local.cluster_security_group_ids
+  subnet_group_name  = aws_elasticache_subnet_group.notification-canada-ca-cache-subnet.name
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"

--- a/aws/elasticache/locals.tf
+++ b/aws/elasticache/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  # Lambda PR review env security group is only included in Staging
+  cluster_security_group_ids = var.env == "staging" ? [var.eks_cluster_securitygroup, aws_security_group.lambda_admin_pr_review[0].id] : [var.eks_cluster_securitygroup]
+}

--- a/aws/elasticache/securitygroups.tf
+++ b/aws/elasticache/securitygroups.tf
@@ -1,0 +1,36 @@
+#
+# Security group used by the lambda admin PR review environment communication
+# with the Redis cluster.  It is only created in Staging.
+#
+resource "aws_security_group" "lambda_admin_pr_review" {
+  count       = var.env == "staging" ? 1 : 0
+  name        = "lambda-admin-pr-review"
+  description = "Lambda admin PR review environment and Redis communication"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}
+
+resource "aws_security_group_rule" "cluster_ingress_from_lambda" {
+  count             = var.env == "staging" ? 1 : 0
+  description       = "Allow inbound connections to cluster from the lambda admin PR review environment"
+  type              = "ingress"
+  from_port         = 6379
+  to_port           = 6379
+  protocol          = "tcp"
+  self              = true
+  security_group_id = aws_security_group.lambda_admin_pr_review[0].id
+}
+
+resource "aws_security_group_rule" "lambda_egress_to_cluster" {
+  count             = var.env == "staging" ? 1 : 0
+  description       = "Allow outbound connections from the lambda admin PR review environment to the cluster"
+  type              = "egress"
+  from_port         = 6379
+  to_port           = 6379
+  protocol          = "tcp"
+  self              = true
+  security_group_id = aws_security_group.lambda_admin_pr_review[0].id
+}

--- a/aws/elasticache/variables.tf
+++ b/aws/elasticache/variables.tf
@@ -17,6 +17,10 @@ variable "elasticache_node_type" {
   type = string
 }
 
+variable "vpc_id" {
+  type = string
+}
+
 variable "vpc_private_subnets" {
   type = list(any)
 }

--- a/aws/lambda-admin-pr/iam.tf
+++ b/aws/lambda-admin-pr/iam.tf
@@ -74,3 +74,8 @@ resource "aws_iam_role_policy_attachment" "notify_admin_pr" {
   role       = aws_iam_role.notify_admin_pr.name
   policy_arn = aws_iam_policy.notify_admin_pr.arn
 }
+
+resource "aws_iam_role_policy_attachment" "notify_admin_pr_vpc_access" {
+  role       = aws_iam_role.notify_admin_pr.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}

--- a/env/production/elasticache/terragrunt.hcl
+++ b/env/production/elasticache/terragrunt.hcl
@@ -25,4 +25,5 @@ inputs = {
   elasticache_node_type                   = "cache.t3.micro"
   vpc_private_subnets                     = dependency.common.outputs.vpc_private_subnets
   sns_alert_warning_arn                   = dependency.common.outputs.sns_alert_warning_arn
+  vpc_id                                  = dependency.common.outputs.vpc_id
 }

--- a/env/staging/elasticache/terragrunt.hcl
+++ b/env/staging/elasticache/terragrunt.hcl
@@ -9,6 +9,7 @@ dependency "common" {
   # module hasn't been applied yet.
   mock_outputs_allowed_terraform_commands = ["validate"]
   mock_outputs = {
+    vpc_id = ""
     vpc_private_subnets = [
       "subnet-001e585d12cce4d1e",
       "subnet-08de34a9e1a7458dc",
@@ -39,6 +40,7 @@ inputs = {
   elasticache_node_type                   = "cache.t3.micro"
   vpc_private_subnets                     = dependency.common.outputs.vpc_private_subnets
   sns_alert_warning_arn                   = dependency.common.outputs.sns_alert_warning_arn
+  vpc_id                                  = dependency.common.outputs.vpc_id
 }
 
 terraform {


### PR DESCRIPTION
# Summary
Create a new Redis security group that will allow the lambda admin PR review environment access to the cluster's replication group in Staging only.

This will also require updating the lambda function to be deployed as part of the VPC and to use the same
security group.

# Related
- cds-snc/notification-planning#650
- cds-snc/notification-planning#1017
- cds-snc/platform-core-services#285