### PR TITLE
fix: lambda admin PR review env security group

### DIFF
--- a/aws/elasticache/locals.tf
+++ b/aws/elasticache/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  # Lambda PR review env security group is only included in Staging
-  cluster_security_group_ids = var.env == "staging" ? [var.eks_cluster_securitygroup, aws_security_group.lambda_admin_pr_review[0].id] : [var.eks_cluster_securitygroup]
+  # In Staging we add a Redis cluster specific security group for things like the lambda admin PR review env
+  cluster_security_group_ids = var.env == "staging" ? [var.eks_cluster_securitygroup, aws_security_group.redis_cluster[0].id] : [var.eks_cluster_securitygroup]
 }

--- a/aws/elasticache/outputs.tf
+++ b/aws/elasticache/outputs.tf
@@ -1,0 +1,4 @@
+output "redis_cluster_security_group_id" {
+  description = "ID of the cluster's dedicated security group.  Currenly this is created in Staging only."
+  value       = aws_security_group.redis_cluster.id
+}

--- a/aws/elasticache/outputs.tf
+++ b/aws/elasticache/outputs.tf
@@ -1,4 +1,4 @@
 output "redis_cluster_security_group_id" {
   description = "ID of the cluster's dedicated security group.  Currenly this is created in Staging only."
-  value       = aws_security_group.redis_cluster.id
+  value       = var.env == "staging" ? aws_security_group.redis_cluster[0].id : null
 }

--- a/aws/elasticache/securitygroups.tf
+++ b/aws/elasticache/securitygroups.tf
@@ -1,36 +1,14 @@
 #
-# Security group used by the lambda admin PR review environment communication
-# with the Redis cluster.  It is only created in Staging.
+# Security group used by resources that need to access the cluster
+# in Staging only such as the lambda admin PR review environment.
 #
-resource "aws_security_group" "lambda_admin_pr_review" {
+resource "aws_security_group" "redis_cluster" {
   count       = var.env == "staging" ? 1 : 0
-  name        = "lambda-admin-pr-review"
-  description = "Lambda admin PR review environment and Redis communication"
+  name        = "redis-cluster"
+  description = "Access to the Redis cluster"
   vpc_id      = var.vpc_id
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
   }
-}
-
-resource "aws_security_group_rule" "cluster_ingress_from_lambda" {
-  count             = var.env == "staging" ? 1 : 0
-  description       = "Allow inbound connections to cluster from the lambda admin PR review environment"
-  type              = "ingress"
-  from_port         = 6379
-  to_port           = 6379
-  protocol          = "tcp"
-  self              = true
-  security_group_id = aws_security_group.lambda_admin_pr_review[0].id
-}
-
-resource "aws_security_group_rule" "lambda_egress_to_cluster" {
-  count             = var.env == "staging" ? 1 : 0
-  description       = "Allow outbound connections from the lambda admin PR review environment to the cluster"
-  type              = "egress"
-  from_port         = 6379
-  to_port           = 6379
-  protocol          = "tcp"
-  self              = true
-  security_group_id = aws_security_group.lambda_admin_pr_review[0].id
 }

--- a/aws/lambda-admin-pr/inputs.tf
+++ b/aws/lambda-admin-pr/inputs.tf
@@ -1,0 +1,19 @@
+variable "redis_cluster_security_group_id" {
+  description = "Security group ID for the Redis cluster."
+  type        = string
+}
+
+variable "vpc_endpoint_gateway_prefix_list_ids" {
+  description = "Prefix list IDs of the VPC private gateway endpoints."
+  type        = list(string)
+}
+
+variable "vpc_endpoint_security_group_id" {
+  description = "Security group ID used by the VPC private interface endpoints."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID to create the lambda's security group in."
+  type        = string
+}

--- a/aws/lambda-admin-pr/securitygroups.tf
+++ b/aws/lambda-admin-pr/securitygroups.tf
@@ -31,7 +31,6 @@ resource "aws_security_group_rule" "lambda_egress_to_cluster" {
   from_port                = 6379
   to_port                  = 6379
   protocol                 = "tcp"
-  self                     = true
   source_security_group_id = var.redis_cluster_security_group_id
   security_group_id        = aws_security_group.lambda_admin_pr_review[0].id
 }

--- a/aws/lambda-admin-pr/securitygroups.tf
+++ b/aws/lambda-admin-pr/securitygroups.tf
@@ -55,7 +55,7 @@ resource "aws_security_group_rule" "vpc_endpoints_ingress_from_lambda" {
   to_port                  = 443
   protocol                 = "tcp"
   source_security_group_id = aws_security_group.lambda_admin_pr_review[0].id
-  security_group_id        = var.private-links-vpc-endpoints-securitygroup
+  security_group_id        = var.vpc_endpoint_security_group_id
 }
 
 resource "aws_security_group_rule" "lambda_egress_to_vpc_gateway_endpoints" {

--- a/aws/lambda-admin-pr/securitygroups.tf
+++ b/aws/lambda-admin-pr/securitygroups.tf
@@ -1,0 +1,81 @@
+#
+# Security group allowing the lambda admin PR review environment to communicate
+# with the Redis cluster, VPC private endpoints and recieve HTTPS requests.
+#
+resource "aws_security_group" "lambda_admin_pr_review" {
+  count       = var.env == "staging" ? 1 : 0
+  name        = "lambda-admin-pr-review"
+  description = "Lambda admin PR review environment"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}
+
+resource "aws_security_group_rule" "cluster_ingress_from_lambda" {
+  count                    = var.env == "staging" ? 1 : 0
+  description              = "Allow inbound connections to cluster from the lambda admin PR review env"
+  type                     = "ingress"
+  from_port                = 6379
+  to_port                  = 6379
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.lambda_admin_pr_review[0].id
+  security_group_id        = var.redis_cluster_security_group_id
+}
+
+resource "aws_security_group_rule" "lambda_egress_to_cluster" {
+  count                    = var.env == "staging" ? 1 : 0
+  description              = "Allow outbound connections from the lambda admin PR review env to the cluster"
+  type                     = "egress"
+  from_port                = 6379
+  to_port                  = 6379
+  protocol                 = "tcp"
+  self                     = true
+  source_security_group_id = var.redis_cluster_security_group_id
+  security_group_id        = aws_security_group.lambda_admin_pr_review[0].id
+}
+
+resource "aws_security_group_rule" "lambda_egress_to_vpc_interface_endpoints" {
+  count                    = var.env == "staging" ? 1 : 0
+  description              = "Allow outbound connection from the lambda admin PR review env to the VPC private interface endpoints"
+  type                     = "egress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  source_security_group_id = var.vpc_endpoint_security_group_id
+  security_group_id        = aws_security_group.lambda_admin_pr_review[0].id
+}
+
+resource "aws_security_group_rule" "vpc_endpoints_ingress_from_lambda" {
+  count                    = var.env == "staging" ? 1 : 0
+  description              = "Allow inbound connections to VPC private endpoints from the lambda admin PR review env"
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.lambda_admin_pr_review[0].id
+  security_group_id        = var.private-links-vpc-endpoints-securitygroup
+}
+
+resource "aws_security_group_rule" "lambda_egress_to_vpc_gateway_endpoints" {
+  count             = var.env == "staging" ? 1 : 0
+  description       = "Allow outbound connection from the lambda admin PR review env to the VPC gateway endpoints"
+  type              = "egress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.lambda_admin_pr_review[0].id
+  prefix_list_ids   = var.vpc_endpoint_gateway_prefix_list_ids
+}
+
+resource "aws_security_group_rule" "internet_ingress_to_lambda" {
+  count             = var.env == "staging" ? 1 : 0
+  description       = "Allow inbound connections from the internet to the lambda admin PR review env"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.lambda_admin_pr_review[0].id
+  cidr_blocks       = ["0.0.0.0/0"]
+}

--- a/env/staging/lambda-admin-pr/terragrunt.hcl
+++ b/env/staging/lambda-admin-pr/terragrunt.hcl
@@ -1,5 +1,38 @@
+dependencies {
+  paths = ["../common", "../elasticache"]
+}
+
+dependency "common" {
+  config_path = "../common"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    private-links-gateway-prefix-list-ids     = []
+    private-links-vpc-endpoints-securitygroup = ""
+    vpc_id                                    = ""
+  }
+}
+
+dependency "elasticache" {
+  config_path = "../elasticache"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    redis_cluster_security_group_id = ""
+  }
+}
+
 include {
   path = find_in_parent_folders()
+}
+
+inputs = {
+  redis_cluster_security_group_id      = dependency.elasticache.outputs.redis_cluster_security_group_id
+  vpc_id                               = dependency.common.outputs.vpc_id
+  vpc_endpoint_gateway_prefix_list_ids = dependency.common.outputs.private-links-gateway-prefix-list-ids
+  vpc_endpoint_security_group_id       = dependency.common.outputs.private-links-vpc-endpoints-securitygroup
 }
 
 terraform {


### PR DESCRIPTION
# Summary
Update the lambda admin PR review environment function to have its own security group.  This will make it easier to apply fine grained access control to the lambda and Redis cluster.

Also updates the lambda's security group to give it access to the VPC private endpoints and receive requests from the internet on port 443.

# Related
- cds-snc/notification-planning#650
- cds-snc/notification-planning#1017
- cds-snc/platform-core-services#285