### PR TITLE
fix: allow admin PR review env egress to internet

### DIFF
--- a/aws/lambda-admin-pr/securitygroups.tf
+++ b/aws/lambda-admin-pr/securitygroups.tf
@@ -78,3 +78,14 @@ resource "aws_security_group_rule" "internet_ingress_to_lambda" {
   security_group_id = aws_security_group.lambda_admin_pr_review[0].id
   cidr_blocks       = ["0.0.0.0/0"]
 }
+
+resource "aws_security_group_rule" "lambda_egress_to_internet" {
+  count             = var.env == "staging" ? 1 : 0
+  description       = "Allow outbound connections from lambda admin PR review env to the internet"
+  type              = "egress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.lambda_admin_pr_review[0].id
+  cidr_blocks       = ["0.0.0.0/0"]
+}


### PR DESCRIPTION
# Summary
Update the lambda admin PR review to allow egress to the internet on 443 TCP.  This is to allow it to communicate with the Notify API.

# Related
- cds-snc/notification-planning#650
- cds-snc/notification-planning#1017
- cds-snc/platform-core-services#285