### PR TITLE
Relax scan-files timeout warning alert to 3 events within 5 minutes

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -343,16 +343,16 @@ resource "aws_cloudwatch_metric_alarm" "logs-10-malware-detected-1-minute-critic
   ok_actions          = [var.sns_alert_critical_arn]
 }
 
-resource "aws_cloudwatch_metric_alarm" "logs-1-scanfiles-timeout-1-minute-warning" {
-  alarm_name          = "logs-1-scanfiles-timeout-1-minute-warning"
-  alarm_description   = "One scanfiles timeout detected error in 1 minute"
+resource "aws_cloudwatch_metric_alarm" "logs-3-scanfiles-timeout-5-minutes-warning" {
+  alarm_name          = "logs-3-scanfiles-timeout-5-minutes-warning"
+  alarm_description   = "Three scanfiles timeout detected error in 5 minutes"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = aws_cloudwatch_log_metric_filter.scanfiles-timeout.metric_transformation[0].name
   namespace           = aws_cloudwatch_log_metric_filter.scanfiles-timeout.metric_transformation[0].namespace
-  period              = "60"
+  period              = "300"
   statistic           = "Sum"
-  threshold           = 1
+  threshold           = 3
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_warning_arn]
 }


### PR DESCRIPTION
# Summary | Résumé

We are getting too many warning noise around scan-file at the moment. The files scan can take more than 11 minutes, at least to what we receive on our end. Until we find the root cause and resolve, we will relax this alarm. 

I checked historical data to see what we had so far. We can get 2 scanfiles-timeout events within 5 minutes, but not 3. Hence why I established this threshold within these changes to have no noise about this unless current state degrades further.
