### PR TITLE
Force lambda function to read new relic license from env variable

### DIFF
--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -40,7 +40,6 @@ resource "aws_lambda_function" "api" {
       NEW_RELIC_EXTENSION_LOGS_ENABLED      = true
       NEW_RELIC_LAMBDA_EXTENSION_ENABLED    = true
       NEW_RELIC_LICENSE_KEY                 = data.aws_secretsmanager_secret_version.new-relic-license-key.secret_string
-
       FF_CLOUDWATCH_METRICS_ENABLED         = var.ff_cloudwatch_metrics_enabled
     }
   }

--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -39,6 +39,8 @@ resource "aws_lambda_function" "api" {
       NEW_RELIC_DISTRIBUTED_TRACING_ENABLED = var.new_relic_distribution_tracing_enabled
       NEW_RELIC_EXTENSION_LOGS_ENABLED      = true
       NEW_RELIC_LAMBDA_EXTENSION_ENABLED    = true
+      NEW_RELIC_LICENSE_KEY                 = data.aws_secretsmanager_secret_version.new-relic-license-key.secret_string
+
       FF_CLOUDWATCH_METRICS_ENABLED         = var.ff_cloudwatch_metrics_enabled
     }
   }

--- a/aws/lambda-api/secrets_manager.tf
+++ b/aws/lambda-api/secrets_manager.tf
@@ -1,3 +1,4 @@
+
 resource "aws_secretsmanager_secret" "new-relic-license-key" {
   name        = "NEW_RELIC_LICENSE_KEY"
   description = "The New Relic license key, for sending telemetry"
@@ -6,4 +7,11 @@ resource "aws_secretsmanager_secret" "new-relic-license-key" {
 resource "aws_secretsmanager_secret_version" "new-relic-license-key" {
   secret_id     = aws_secretsmanager_secret.new-relic-license-key.id
   secret_string = var.new_relic_license_key
+}
+data "aws_secretsmanager_secret_version" "new-relic-license-key" {
+  secret_id = data.aws_secretsmanager_secret.new-relic-license-key.id
+}
+
+data "aws_secretsmanager_secret" "new-relic-license-key" {
+  name = aws_secretsmanager_secret.new-relic-license-key.name
 }


### PR DESCRIPTION
# Summary | Résumé
We are experiencing issues with the api lambda function reading the new relic license key. In an attempt to validate that the license key is being read correctly, I have added it as an environment variable which is reading directly from the aws secret manager. 

**This might have the effect of exposing the license key in cloud watch logs. I have changed the license key to a throwaway version in staging. After testing is complete, this key will be revoked.**

---
# Test instructions | Instructions pour tester la modification

> After deployment to staging, verify that the lambda function is reading the key correctly.

