### PR TITLE
New relic key env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # .tfstate files
 *.tfstate
 *.tfstate.*
+*.tfvars
 
 # Crash log files
 crash.log

--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -40,7 +40,6 @@ resource "aws_lambda_function" "api" {
       NEW_RELIC_EXTENSION_LOGS_ENABLED      = true
       NEW_RELIC_LAMBDA_EXTENSION_ENABLED    = true
       NEW_RELIC_LICENSE_KEY                 = data.aws_secretsmanager_secret_version.new-relic-license-key.secret_string
-
       FF_CLOUDWATCH_METRICS_ENABLED         = var.ff_cloudwatch_metrics_enabled
     }
   }

--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -39,6 +39,8 @@ resource "aws_lambda_function" "api" {
       NEW_RELIC_DISTRIBUTED_TRACING_ENABLED = var.new_relic_distribution_tracing_enabled
       NEW_RELIC_EXTENSION_LOGS_ENABLED      = true
       NEW_RELIC_LAMBDA_EXTENSION_ENABLED    = true
+      NEW_RELIC_LICENSE_KEY                 = data.aws_secretsmanager_secret_version.new-relic-license-key.secret_string
+
       FF_CLOUDWATCH_METRICS_ENABLED         = var.ff_cloudwatch_metrics_enabled
     }
   }

--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -39,7 +39,7 @@ resource "aws_lambda_function" "api" {
       NEW_RELIC_DISTRIBUTED_TRACING_ENABLED = var.new_relic_distribution_tracing_enabled
       NEW_RELIC_EXTENSION_LOGS_ENABLED      = true
       NEW_RELIC_LAMBDA_EXTENSION_ENABLED    = true
-      NEW_RELIC_LICENSE_KEY_SECRET          = "NEW_RELIC_LICENSE_KEY"
+      NEW_RELIC_LICENSE_KEY                 = data.aws_secretsmanager_secret_version.new-relic-license-key.secret_string
       FF_CLOUDWATCH_METRICS_ENABLED         = var.ff_cloudwatch_metrics_enabled
     }
   }

--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -39,7 +39,7 @@ resource "aws_lambda_function" "api" {
       NEW_RELIC_DISTRIBUTED_TRACING_ENABLED = var.new_relic_distribution_tracing_enabled
       NEW_RELIC_EXTENSION_LOGS_ENABLED      = true
       NEW_RELIC_LAMBDA_EXTENSION_ENABLED    = true
-      NEW_RELIC_LICENSE_KEY                 = data.aws_secretsmanager_secret_version.new-relic-license-key.secret_string
+      NEW_RELIC_LICENSE_KEY_SECRET          = "NEW_RELIC_LICENSE_KEY"
       FF_CLOUDWATCH_METRICS_ENABLED         = var.ff_cloudwatch_metrics_enabled
     }
   }

--- a/aws/lambda-api/secrets_manager.tf
+++ b/aws/lambda-api/secrets_manager.tf
@@ -1,3 +1,4 @@
+
 resource "aws_secretsmanager_secret" "new-relic-license-key" {
   name        = "NEW_RELIC_LICENSE_KEY"
   description = "The New Relic license key, for sending telemetry"
@@ -6,4 +7,11 @@ resource "aws_secretsmanager_secret" "new-relic-license-key" {
 resource "aws_secretsmanager_secret_version" "new-relic-license-key" {
   secret_id     = aws_secretsmanager_secret.new-relic-license-key.id
   secret_string = var.new_relic_license_key
+}
+data "aws_secretsmanager_secret_version" "new-relic-license-key" {
+  secret_id = data.aws_secretsmanager_secret.new-relic-license-key.id
+}
+
+data "aws_secretsmanager_secret" "new-relic-license-key" {
+  name = aws_secretsmanager_secret.new-relic-license-key.name
 }


### PR DESCRIPTION
# Summary | Résumé

Reverting to setting new relic environment variable in lambda api to be read by environment variable instead of aws secrets manager.

---

# Test instructions | Instructions pour tester la modification

Deploy to staging, and verify that new relic can see the api lambda in that environment. 

