### PR TITLE
set ApiRateLimit to block

### DIFF
--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -482,7 +482,15 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 210
 
     action {
-      count {}
+      block {
+        custom_response {
+          response_code = 429
+          response_header {
+            name  = "waf-block"
+            value = "RateLimitRestriction"
+          }
+        }
+      }
     }
     visibility_config {
       cloudwatch_metrics_enabled = true

--- a/aws/lambda-api/waf.tf
+++ b/aws/lambda-api/waf.tf
@@ -276,7 +276,15 @@ resource "aws_wafv2_web_acl" "api_lambda" {
     priority = 210
 
     action {
-      count {}
+      block {
+        custom_response {
+          response_code = 429
+          response_header {
+            name  = "waf-block"
+            value = "RateLimitRestriction"
+          }
+        }
+      }
     }
     visibility_config {
       cloudwatch_metrics_enabled = true


### PR DESCRIPTION
# Summary | Résumé

We forgot to turn this from `count` to `block` !

Checked in Athena and we've never marked anything as `count` but still a useful rule to help mitigate a DOS attack on api.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
