### PR TITLE
Aligned alarms with latest SLOs

### DIFF
--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -294,14 +294,14 @@ resource "aws_cloudwatch_metric_alarm" "ses-complaint-rate-critical" {
 
 resource "aws_cloudwatch_metric_alarm" "sqs-sms-stuck-in-queue-warning" {
   alarm_name          = "sqs-sms-stuck-in-queue-warning"
-  alarm_description   = "ApproximateAgeOfOldestMessage in SMS queue is older than 1 minute in a 5-minute period"
+  alarm_description   = "ApproximateAgeOfOldestMessage in SMS queue is older than 10 minutes in a 5 minutes"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = "5"
   metric_name         = "ApproximateAgeOfOldestMessage"
   namespace           = "AWS/SQS"
-  period              = 60 * 5
+  period              = 60
   statistic           = "Average"
-  threshold           = 60
+  threshold           = 60 * 10
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
   dimensions = {
     QueueName = "${var.celery_queue_prefix}${var.sqs_sms_queue_name}"
@@ -310,14 +310,14 @@ resource "aws_cloudwatch_metric_alarm" "sqs-sms-stuck-in-queue-warning" {
 
 resource "aws_cloudwatch_metric_alarm" "sqs-sms-stuck-in-queue-critical" {
   alarm_name          = "sqs-sms-stuck-in-queue-critical"
-  alarm_description   = "ApproximateAgeOfOldestMessage in SMS queue is older than 1 minute for 10 minutes"
+  alarm_description   = "ApproximateAgeOfOldestMessage in SMS queue is older than 15 minutes for 5 minutes"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "10"
+  evaluation_periods  = "5"
   metric_name         = "ApproximateAgeOfOldestMessage"
   namespace           = "AWS/SQS"
   period              = 60
   statistic           = "Average"
-  threshold           = 60
+  threshold           = 60 * 15
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   ok_actions          = [aws_sns_topic.notification-canada-ca-alert-ok.arn]
   dimensions = {
@@ -358,6 +358,39 @@ resource "aws_cloudwatch_metric_alarm" "sqs-throttled-sms-stuck-in-queue-critica
   }
 }
 
+resource "aws_cloudwatch_metric_alarm" "sqs-priority-queue-delay-warning" {
+  alarm_name          = "sqs-priority-queue-delay-warning"
+  alarm_description   = "ApproximateAgeOfOldestMessage in email queue >= 20 minutes for 1 minute"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "ApproximateAgeOfOldestMessage"
+  namespace           = "AWS/SQS"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = 20
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
+  dimensions = {
+    QueueName = "${var.celery_queue_prefix}${sqs_priority_queue_name}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "sqs-priority-queue-delay-critical" {
+  alarm_name          = "sqs-priority-queue-delay-critical"
+  alarm_description   = "ApproximateAgeOfOldestMessage in high priority queue >= 60 seconds for 1 minute"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "ApproximateAgeOfOldestMessage"
+  namespace           = "AWS/SQS"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = 60
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
+  ok_actions          = [aws_sns_topic.notification-canada-ca-alert-ok.arn]
+  dimensions = {
+    QueueName = "${var.celery_queue_prefix}${sqs_priority_queue_name}"
+  }
+}
+
 resource "aws_cloudwatch_metric_alarm" "sqs-email-queue-delay-warning" {
   alarm_name          = "sqs-email-queue-delay-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in email queue >= 30 minutes for 5 minutes"
@@ -370,7 +403,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-email-queue-delay-warning" {
   threshold           = 60 * 30
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
   dimensions = {
-    QueueName = "${var.celery_queue_prefix}send-email-tasks"
+    QueueName = "${var.celery_queue_prefix}${sqs_email_queue_name}"
   }
 }
 
@@ -387,7 +420,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-email-queue-delay-critical" {
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   ok_actions          = [aws_sns_topic.notification-canada-ca-alert-ok.arn]
   dimensions = {
-    QueueName = "${var.celery_queue_prefix}send-email-tasks"
+    QueueName = "${var.celery_queue_prefix}${sqs_email_queue_name}"
   }
 }
 
@@ -403,7 +436,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-bulk-queue-delay-warning" {
   threshold           = 60 * 60
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
   dimensions = {
-    QueueName = "${var.celery_queue_prefix}bulk-tasks"
+    QueueName = "${var.celery_queue_prefix}${sqs_bulk_queue_name}"
   }
 }
 
@@ -420,7 +453,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-bulk-queue-delay-critical" {
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   ok_actions          = [aws_sns_topic.notification-canada-ca-alert-ok.arn]
   dimensions = {
-    QueueName = "${var.celery_queue_prefix}bulk-tasks"
+    QueueName = "${var.celery_queue_prefix}${sqs_bulk_queue_name}"
   }
 }
 

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -360,9 +360,9 @@ resource "aws_cloudwatch_metric_alarm" "sqs-throttled-sms-stuck-in-queue-critica
 
 resource "aws_cloudwatch_metric_alarm" "sqs-priority-queue-delay-warning" {
   alarm_name          = "sqs-priority-queue-delay-warning"
-  alarm_description   = "ApproximateAgeOfOldestMessage in email queue >= 20 minutes for 1 minute"
+  alarm_description   = "ApproximateAgeOfOldestMessage in high priority queue >= 20 seconds for 3 minutes"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = "3"
   metric_name         = "ApproximateAgeOfOldestMessage"
   namespace           = "AWS/SQS"
   period              = 60

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -370,7 +370,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-priority-queue-delay-warning" {
   threshold           = 20
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
   dimensions = {
-    QueueName = "${var.celery_queue_prefix}${sqs_priority_queue_name}"
+    QueueName = "${var.celery_queue_prefix}${var.sqs_priority_queue_name}"
   }
 }
 
@@ -387,7 +387,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-priority-queue-delay-critical" {
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   ok_actions          = [aws_sns_topic.notification-canada-ca-alert-ok.arn]
   dimensions = {
-    QueueName = "${var.celery_queue_prefix}${sqs_priority_queue_name}"
+    QueueName = "${var.celery_queue_prefix}${var.sqs_priority_queue_name}"
   }
 }
 
@@ -403,7 +403,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-email-queue-delay-warning" {
   threshold           = 60 * 30
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
   dimensions = {
-    QueueName = "${var.celery_queue_prefix}${sqs_email_queue_name}"
+    QueueName = "${var.celery_queue_prefix}${var.sqs_email_queue_name}"
   }
 }
 
@@ -420,7 +420,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-email-queue-delay-critical" {
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   ok_actions          = [aws_sns_topic.notification-canada-ca-alert-ok.arn]
   dimensions = {
-    QueueName = "${var.celery_queue_prefix}${sqs_email_queue_name}"
+    QueueName = "${var.celery_queue_prefix}${var.sqs_email_queue_name}"
   }
 }
 
@@ -436,7 +436,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-bulk-queue-delay-warning" {
   threshold           = 60 * 60
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
   dimensions = {
-    QueueName = "${var.celery_queue_prefix}${sqs_bulk_queue_name}"
+    QueueName = "${var.celery_queue_prefix}${var.sqs_bulk_queue_name}"
   }
 }
 
@@ -453,7 +453,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-bulk-queue-delay-critical" {
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   ok_actions          = [aws_sns_topic.notification-canada-ca-alert-ok.arn]
   dimensions = {
-    QueueName = "${var.celery_queue_prefix}${sqs_bulk_queue_name}"
+    QueueName = "${var.celery_queue_prefix}${var.sqs_bulk_queue_name}"
   }
 }
 
@@ -472,7 +472,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-throttled-sms-tasks-receive-rat
   alarm_actions = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
   ok_actions    = [aws_sns_topic.notification-canada-ca-alert-ok.arn]
   dimensions = {
-    QueueName = "${var.celery_queue_prefix}send-throttled-sms-tasks"
+    QueueName = "${var.celery_queue_prefix}${var.sqs_throttled_sms_queue_name}"
   }
 }
 

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -294,7 +294,7 @@ resource "aws_cloudwatch_metric_alarm" "ses-complaint-rate-critical" {
 
 resource "aws_cloudwatch_metric_alarm" "sqs-sms-stuck-in-queue-warning" {
   alarm_name          = "sqs-sms-stuck-in-queue-warning"
-  alarm_description   = "ApproximateAgeOfOldestMessage in SMS queue is older than 10 minutes in a 5 minutes"
+  alarm_description   = "ApproximateAgeOfOldestMessage in SMS queue is older than 10 minutes for 5 minutes"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "5"
   metric_name         = "ApproximateAgeOfOldestMessage"

--- a/aws/common/variables.tf
+++ b/aws/common/variables.tf
@@ -54,11 +54,32 @@ variable "celery_queue_prefix" {
   default = "eks-notification-canada-ca"
 }
 
+variable "sqs_email_queue_name" {
+  type = string
+  # See QueueNames in
+  # https://github.com/cds-snc/notification-api/blob/master/app/config.py
+  default = "send-email-tasks"
+}
+
 variable "sqs_sms_queue_name" {
   type = string
   # See QueueNames in
   # https://github.com/cds-snc/notification-api/blob/master/app/config.py
   default = "send-sms-tasks"
+}
+
+variable "sqs_priority_queue_name" {
+  type = string
+  # See QueueNames in
+  # https://github.com/cds-snc/notification-api/blob/master/app/config.py
+  default = "priority-tasks"
+}
+
+variable "sqs_bulk_queue_name" {
+  type = string
+  # See QueueNames in
+  # https://github.com/cds-snc/notification-api/blob/master/app/config.py
+  default = "bulk-tasks"
 }
 
 variable "sqs_throttled_sms_queue_name" {


### PR DESCRIPTION
# Summary | Résumé

Performed alarms changes that aligned with [latest internally published SLOs](https://docs.google.com/spreadsheets/d/1cJjCzqC9JOAq005jWg9OjmeYoQvLkPaAFkCaIZTcaWA/edit#gid=0) for our performance of different priority queues and notifications types.

* Aligned the evaluation periods of `sqs-sms-stuck-in-queue-critical` and `sqs-sms-stuck-in-queue-warning` alarms to be the same as their email counterparts.
* Aligned the evaluation periods of `sqs-sms-stuck-in-queue-critical` and `sqs-sms-stuck-in-queue-warning` alarms with latest SLOs values: increase values with our latest expectations (e.g. Notify is slower on that).
* Added alarms for priority queue. We didn't have one before surprisingly for the sending high priority queue. 
* Extracted a few hardcoded values for queue names into variables to align with the rest of the code base.

A few caveats: 

* SQS is not using bulk priorities at the moment so we can't track this sort of priority at the moment.
* The priority queue is used by both the SMS and email notification types, which is not ideal as we'd prefer tailored values for each of these. Fortunately, the SLO expectations for both are pretty similar (i.e. emails 20s/60s, sms 10s/60s).
* I haven't modified the SMS throttled alarm. We don't have solid SLOs on that one as we should rework how these are processed in a queue refactoring in the future.

# Test instructions | Instructions pour tester la modification

* Let's monitor our metrics in the next week to see if the alarms trigger or not based on the sending latency of GCNotify.
