### PR TITLE
Revert "Increasing the monthly spend limit for SNS on staging"

### DIFF
--- a/env/staging/common/terragrunt.hcl
+++ b/env/staging/common/terragrunt.hcl
@@ -7,8 +7,8 @@ include {
 }
 
 inputs = {
-  sns_monthly_spend_limit                                            = 100
-  sns_monthly_spend_limit_us_west_2                                  = 75
+  sns_monthly_spend_limit                                            = 50
+  sns_monthly_spend_limit_us_west_2                                  = 30
   alarm_warning_document_download_bucket_size_gb                     = 0.5
   alarm_warning_inflight_processed_created_delta_threshold           = 100
   alarm_critical_inflight_processed_created_delta_threshold          = 200


### PR DESCRIPTION
Doesn't look like our AWS quota was increased - I'll revert this for now and check w/ AWS Support

Reverts cds-snc/notification-terraform#697