### PR TITLE
Increased blazer audit logs to 5 years

### DIFF
--- a/aws/database-tools/cloudwatch_logs.tf
+++ b/aws/database-tools/cloudwatch_logs.tf
@@ -1,4 +1,4 @@
 resource "aws_cloudwatch_log_group" "blazer" {
   name              = aws_ecs_cluster.blazer.name
-  retention_in_days = 14
+  retention_in_days = 1827 # 5 years
 }


### PR DESCRIPTION
# Summary | Résumé

Increased blazer logs for 5 years for keeping access for a long time. It might require less, but blazer logs are so small, we can afford keeping these for a long time for auditing purposes.

# Test instructions | Instructions pour tester la modification

Check in 2 weeks after this merge if we keep track of audits, executing appropriate queries in CloudWatch under the `blazer` folder.
