### PR TITLE
More tolerance from scanfiles warning

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -352,7 +352,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-3-scanfiles-timeout-5-minutes-warni
   namespace           = aws_cloudwatch_log_metric_filter.scanfiles-timeout.metric_transformation[0].namespace
   period              = "300"
   statistic           = "Sum"
-  threshold           = 3
+  threshold           = 4
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_warning_arn]
 }


### PR DESCRIPTION
# Summary | Résumé

Increased value for scanfiles timeout warning from 3 to 4 within a 5 minutes period.

