### PR TITLE
Adding a warning for K8s node failure

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -357,15 +357,14 @@ resource "aws_cloudwatch_metric_alarm" "logs-3-scanfiles-timeout-5-minutes-warni
   alarm_actions       = [var.sns_alert_warning_arn]
 }
 
-
 resource "aws_cloudwatch_metric_alarm" "kubernetes-failed-nodes" {
-  alarm_name                = "kubernetes-failed-nodes"
-  comparison_operator       = "GreaterThanUpperThreshold"
-  evaluation_periods        = 1
-  threshold_metric_id       = "ad1"
-  alarm_description         = "Kubernetes failed node anomalies"
+  alarm_name          = "kubernetes-failed-nodes"
+  comparison_operator = "GreaterThanUpperThreshold"
+  evaluation_periods  = 1
+  threshold_metric_id = "ad1"
+  alarm_description   = "Kubernetes failed node anomalies"
   #Setting to warn until we verify that it is working as expected
-  alarm_actions             = [var.sns_alert_warning_arn]
+  alarm_actions = [var.sns_alert_warning_arn]
 
   metric_query {
     id          = "ad1"

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -363,8 +363,8 @@ resource "aws_cloudwatch_metric_alarm" "kubernetes-failed-nodes" {
   evaluation_periods  = 1
   alarm_description   = "Kubernetes failed node anomalies"
   #Setting to warn until we verify that it is working as expected
-  alarm_actions = [var.sns_alert_warning_arn]
-  treat_missing_data  = "notBreaching"
+  alarm_actions      = [var.sns_alert_warning_arn]
+  treat_missing_data = "notBreaching"
 
   metric_query {
     id          = "m1"
@@ -375,7 +375,6 @@ resource "aws_cloudwatch_metric_alarm" "kubernetes-failed-nodes" {
       period      = 300
       stat        = "Average"
       unit        = "Count"
-
       dimensions = {
         Name = aws_eks_cluster.notification-canada-ca-eks-cluster.name
       }

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -359,19 +359,12 @@ resource "aws_cloudwatch_metric_alarm" "logs-3-scanfiles-timeout-5-minutes-warni
 
 resource "aws_cloudwatch_metric_alarm" "kubernetes-failed-nodes" {
   alarm_name          = "kubernetes-failed-nodes"
-  comparison_operator = "GreaterThanUpperThreshold"
+  comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
-  threshold_metric_id = "ad1"
   alarm_description   = "Kubernetes failed node anomalies"
   #Setting to warn until we verify that it is working as expected
   alarm_actions = [var.sns_alert_warning_arn]
-
-  metric_query {
-    id          = "ad1"
-    expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
-    label       = "cluster_failed_node_count (expected)"
-    return_data = "true"
-  }
+  treat_missing_data  = "notBreaching"
 
   metric_query {
     id          = "m1"

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -356,3 +356,37 @@ resource "aws_cloudwatch_metric_alarm" "logs-3-scanfiles-timeout-5-minutes-warni
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_warning_arn]
 }
+
+
+resource "aws_cloudwatch_metric_alarm" "kubernetes-failed-nodes" {
+  alarm_name                = "kubernetes-failed-nodes"
+  comparison_operator       = "GreaterThanUpperThreshold"
+  evaluation_periods        = 1
+  threshold_metric_id       = "ad1"
+  alarm_description         = "Kubernetes failed node anomalies"
+  #Setting to warn until we verify that it is working as expected
+  alarm_actions             = [var.sns_alert_warning_arn]
+
+  metric_query {
+    id          = "ad1"
+    expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
+    label       = "cluster_failed_node_count (expected)"
+    return_data = "true"
+  }
+
+  metric_query {
+    id          = "m1"
+    return_data = "true"
+    metric {
+      metric_name = "cluster_failed_node_count"
+      namespace   = "ContainerInsights"
+      period      = 300
+      stat        = "Average"
+      unit        = "Count"
+
+      dimensions = {
+        Name = aws_eks_cluster.notification-canada-ca-eks-cluster.name
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Summary | Résumé

Creating a cloudwatch anomaly alert which will trigger if node failure occurs.  Currently set to warning while we verify that it works as expected.

