### PR TITLE
Pre-Commit hook for terraform format checking

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -11,8 +11,3 @@ for D in $(find ./aws -mindepth 1 -maxdepth 1 -type d); do
         fi
     popd
 done
-
-
-
-
-

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,18 @@
+#!/bin/bash
+RED='\033[0;31m'
+echo "checking terraform formatting"
+for D in $(find ./aws -mindepth 1 -maxdepth 1 -type d); do
+    pushd $D 
+        if $(terraform fmt); then
+            echo "Formatting Check Passed"
+        else
+            printf "${RED}Formatting Check for $D Failed"
+            exit 1
+        fi
+    popd
+done
+
+
+
+
+


### PR DESCRIPTION
# Summary | Résumé
I'm tired of committing badly formatted terraform code, so I've created a pre-commit hook that iterates through all folders in ./aws and runs terraform fmt. If it fails, it abandons the commit and alerts you which folders need to be fixed.

# Setup instructions | Instructions pour tester la modification
This is optional and configured on a per user basis. If you don't want to run this pre-commit hook yourself, do nothing. If you do want to do it, you must configure the repository to read hooks from the hooks folder:

git config core.hooksPath hooks

# Test instructions
1. Write some bad terraform code
2. Try to commit it

