### PR TITLE
Use Maximum instead of Average for metrics evaluation of unavail pods/nodes

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -373,7 +373,7 @@ resource "aws_cloudwatch_metric_alarm" "kubernetes-failed-nodes" {
       metric_name = "cluster_failed_node_count"
       namespace   = "ContainerInsights"
       period      = 300
-      stat        = "Average"
+      stat        = "Maximum"
       unit        = "Count"
       dimensions = {
         Name = aws_eks_cluster.notification-canada-ca-eks-cluster.name
@@ -398,7 +398,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-replicas-unavailable" {
       metric_name = "celery_deployment_replicas_unavailable"
       namespace   = "ContainerInsights/Prometheus"
       period      = 300
-      stat        = "Average"
+      stat        = "Maximum"
       unit        = "Count"
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
@@ -425,7 +425,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-sms-replicas-unavailable" {
       metric_name = "kube_deployment_status_replicas_unavailable"
       namespace   = "ContainerInsights/Prometheus"
       period      = 300
-      stat        = "Average"
+      stat        = "Maximum"
       unit        = "Count"
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
@@ -452,7 +452,7 @@ resource "aws_cloudwatch_metric_alarm" "admin-replicas-unavailable" {
       metric_name = "kube_deployment_status_replicas_unavailable"
       namespace   = "ContainerInsights/Prometheus"
       period      = 300
-      stat        = "Average"
+      stat        = "Maximum"
       unit        = "Count"
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
@@ -479,7 +479,7 @@ resource "aws_cloudwatch_metric_alarm" "api-replicas-unavailable" {
       metric_name = "kube_deployment_status_replicas_unavailable"
       namespace   = "ContainerInsights/Prometheus"
       period      = 300
-      stat        = "Average"
+      stat        = "Maximum"
       unit        = "Count"
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
@@ -506,7 +506,7 @@ resource "aws_cloudwatch_metric_alarm" "documentation-replicas-unavailable" {
       metric_name = "kube_deployment_status_replicas_unavailable"
       namespace   = "ContainerInsights/Prometheus"
       period      = 300
-      stat        = "Average"
+      stat        = "Maximum"
       unit        = "Count"
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
@@ -533,7 +533,7 @@ resource "aws_cloudwatch_metric_alarm" "document-download-api-replicas-unavailab
       metric_name = "kube_deployment_status_replicas_unavailable"
       namespace   = "ContainerInsights/Prometheus"
       period      = 300
-      stat        = "Average"
+      stat        = "Maximum"
       unit        = "Count"
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -365,6 +365,7 @@ resource "aws_cloudwatch_metric_alarm" "kubernetes-failed-nodes" {
   #Setting to warn until we verify that it is working as expected
   alarm_actions      = [var.sns_alert_warning_arn]
   treat_missing_data = "notBreaching"
+  threshold          = 1
 
   metric_query {
     id          = "m1"
@@ -390,6 +391,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-replicas-unavailable" {
   #Setting to warn until we verify that it is working as expected
   alarm_actions      = [var.sns_alert_warning_arn]
   treat_missing_data = "notBreaching"
+  threshold          = 1
 
   metric_query {
     id          = "m1"
@@ -417,6 +419,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-sms-replicas-unavailable" {
   #Setting to warn until we verify that it is working as expected
   alarm_actions      = [var.sns_alert_warning_arn]
   treat_missing_data = "notBreaching"
+  threshold          = 1
 
   metric_query {
     id          = "m1"
@@ -444,6 +447,7 @@ resource "aws_cloudwatch_metric_alarm" "admin-replicas-unavailable" {
   #Setting to warn until we verify that it is working as expected
   alarm_actions      = [var.sns_alert_warning_arn]
   treat_missing_data = "notBreaching"
+  threshold          = 1
 
   metric_query {
     id          = "m1"
@@ -471,6 +475,7 @@ resource "aws_cloudwatch_metric_alarm" "api-replicas-unavailable" {
   #Setting to warn until we verify that it is working as expected
   alarm_actions      = [var.sns_alert_warning_arn]
   treat_missing_data = "notBreaching"
+  threshold          = 1
 
   metric_query {
     id          = "m1"
@@ -498,6 +503,7 @@ resource "aws_cloudwatch_metric_alarm" "documentation-replicas-unavailable" {
   #Setting to warn until we verify that it is working as expected
   alarm_actions      = [var.sns_alert_warning_arn]
   treat_missing_data = "notBreaching"
+  threshold          = 1
 
   metric_query {
     id          = "m1"
@@ -525,6 +531,7 @@ resource "aws_cloudwatch_metric_alarm" "document-download-api-replicas-unavailab
   #Setting to warn until we verify that it is working as expected
   alarm_actions      = [var.sns_alert_warning_arn]
   treat_missing_data = "notBreaching"
+  threshold          = 1
 
   metric_query {
     id          = "m1"


### PR DESCRIPTION
# Summary | Résumé

* Use Maximum instead of Average for metrics evaluation of unavail pods/nodes.
* Added threshold of 1 to breach alarms.

# Test instructions | Instructions pour tester la modification

* Break a k8s deployment in the staging env and watch out for breached alarms.
