### PR TITLE
Remove unit=count from promotheus dimensions

### DIFF
--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -144,6 +144,7 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan eks
+        if: ${{ steps.filter.outputs.eks == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/eks"

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -114,7 +114,6 @@ jobs:
               - 'env/staging/sns_to_sqs_sms_callbacks/**'
 
       - name: Terragrunt plan common
-        if: ${{ steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/common"
@@ -124,7 +123,6 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan ses_receiving_emails
-        if: ${{ steps.filter.outputs.ses_receiving_emails == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/ses_receiving_emails"
@@ -134,7 +132,6 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan dns
-        if: ${{ steps.filter.outputs.dns == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/dns"
@@ -144,7 +141,6 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan eks
-        if: ${{ steps.filter.outputs.eks == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/eks"
@@ -154,7 +150,6 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan elasticache
-        if: ${{ steps.filter.outputs.elasticache == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/elasticache"
@@ -164,7 +159,6 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan rds
-        if: ${{ steps.filter.outputs.rds == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/rds"
@@ -174,7 +168,6 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan cloudfront
-        if: ${{ steps.filter.outputs.cloudfront == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/cloudfront"
@@ -184,7 +177,6 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan lambda-api
-        if: ${{ steps.filter.outputs.lambda-api == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/lambda-api"
@@ -194,7 +186,6 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan lambda-admin-pr
-        if: ${{ steps.filter.outputs.lambda-admin-pr == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/lambda-admin-pr"
@@ -204,7 +195,6 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan performance-test
-        if: ${{ steps.filter.outputs.performance-test == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/performance-test"
@@ -214,7 +204,6 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan heartbeat
-        if: ${{ steps.filter.outputs.heartbeat == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/heartbeat"
@@ -224,7 +213,6 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan database-tools
-        if: ${{ steps.filter.outputs.database-tools == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/database-tools"
@@ -234,7 +222,6 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan lambda-google-cidr
-        if: ${{ steps.filter.outputs.lambda-google-cidr == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/lambda-google-cidr"
@@ -244,7 +231,6 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan ses_to_sqs_email_callbacks
-        if: ${{ steps.filter.outputs.ses_to_sqs_email_callbacks == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/ses_to_sqs_email_callbacks"
@@ -254,7 +240,6 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan sns_to_sqs_sms_callbacks
-        if: ${{ steps.filter.outputs.sns_to_sqs_sms_callbacks == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/sns_to_sqs_sms_callbacks"

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -114,6 +114,7 @@ jobs:
               - 'env/staging/sns_to_sqs_sms_callbacks/**'
 
       - name: Terragrunt plan common
+        if: ${{ steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/common"
@@ -123,6 +124,7 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan ses_receiving_emails
+        if: ${{ steps.filter.outputs.ses_receiving_emails == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/ses_receiving_emails"
@@ -132,6 +134,7 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan dns
+        if: ${{ steps.filter.outputs.dns == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/dns"
@@ -150,6 +153,7 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan elasticache
+        if: ${{ steps.filter.outputs.elasticache == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/elasticache"
@@ -159,6 +163,7 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan rds
+        if: ${{ steps.filter.outputs.rds == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/rds"
@@ -168,6 +173,7 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan cloudfront
+        if: ${{ steps.filter.outputs.cloudfront == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/cloudfront"
@@ -177,6 +183,7 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan lambda-api
+        if: ${{ steps.filter.outputs.lambda-api == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/lambda-api"
@@ -186,6 +193,7 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan lambda-admin-pr
+        if: ${{ steps.filter.outputs.lambda-admin-pr == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/lambda-admin-pr"
@@ -195,6 +203,7 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan performance-test
+        if: ${{ steps.filter.outputs.performance-test == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/performance-test"
@@ -204,6 +213,7 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan heartbeat
+        if: ${{ steps.filter.outputs.heartbeat == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/heartbeat"
@@ -213,6 +223,7 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan database-tools
+        if: ${{ steps.filter.outputs.database-tools == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/database-tools"
@@ -222,6 +233,7 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan lambda-google-cidr
+        if: ${{ steps.filter.outputs.lambda-google-cidr == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/lambda-google-cidr"
@@ -231,6 +243,7 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan ses_to_sqs_email_callbacks
+        if: ${{ steps.filter.outputs.ses_to_sqs_email_callbacks == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/ses_to_sqs_email_callbacks"
@@ -240,6 +253,7 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan sns_to_sqs_sms_callbacks
+        if: ${{ steps.filter.outputs.sns_to_sqs_sms_callbacks == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/sns_to_sqs_sms_callbacks"

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -485,7 +485,6 @@ resource "aws_cloudwatch_metric_alarm" "api-replicas-unavailable" {
       namespace   = "ContainerInsights/Prometheus"
       period      = 300
       stat        = "Maximum"
-      unit        = "Count"
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -375,7 +375,6 @@ resource "aws_cloudwatch_metric_alarm" "kubernetes-failed-nodes" {
       namespace   = "ContainerInsights"
       period      = 300
       stat        = "Maximum"
-      unit        = "Count"
       dimensions = {
         Name = aws_eks_cluster.notification-canada-ca-eks-cluster.name
       }
@@ -401,7 +400,6 @@ resource "aws_cloudwatch_metric_alarm" "celery-replicas-unavailable" {
       namespace   = "ContainerInsights/Prometheus"
       period      = 300
       stat        = "Maximum"
-      unit        = "Count"
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace
@@ -429,7 +427,6 @@ resource "aws_cloudwatch_metric_alarm" "celery-sms-replicas-unavailable" {
       namespace   = "ContainerInsights/Prometheus"
       period      = 300
       stat        = "Maximum"
-      unit        = "Count"
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace
@@ -457,7 +454,6 @@ resource "aws_cloudwatch_metric_alarm" "admin-replicas-unavailable" {
       namespace   = "ContainerInsights/Prometheus"
       period      = 300
       stat        = "Maximum"
-      unit        = "Count"
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace
@@ -512,7 +508,6 @@ resource "aws_cloudwatch_metric_alarm" "documentation-replicas-unavailable" {
       namespace   = "ContainerInsights/Prometheus"
       period      = 300
       stat        = "Maximum"
-      unit        = "Count"
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace
@@ -540,7 +535,6 @@ resource "aws_cloudwatch_metric_alarm" "document-download-api-replicas-unavailab
       namespace   = "ContainerInsights/Prometheus"
       period      = 300
       stat        = "Maximum"
-      unit        = "Count"
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace


### PR DESCRIPTION
# Summary | Résumé

Removing the count unit in promotheus dimensions.

I compared sources of non-working TF metric to a working one in staging and this was the one change that made the difference. Hoping this TF changes make the metric work. 🤞

# Test instructions | Instructions pour tester la modification

* Make an API pod crash in staging env and observe if the alarm triggers.
