### PR TITLE
Fixing celery replica alarm and adding celery-beat

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -374,7 +374,7 @@ resource "aws_cloudwatch_metric_alarm" "kubernetes-failed-nodes" {
       metric_name = "cluster_failed_node_count"
       namespace   = "ContainerInsights"
       period      = 300
-      stat        = "Maximum"
+      stat        = "Average"
       dimensions = {
         Name = aws_eks_cluster.notification-canada-ca-eks-cluster.name
       }
@@ -399,7 +399,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-replicas-unavailable" {
       metric_name = "kube_deployment_status_replicas_unavailable"
       namespace   = "ContainerInsights/Prometheus"
       period      = 300
-      stat        = "Maximum"
+      stat        = "Average"
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace
@@ -426,7 +426,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-beat-replicas-unavailable" {
       metric_name = "kube_deployment_status_replicas_unavailable"
       namespace   = "ContainerInsights/Prometheus"
       period      = 300
-      stat        = "Maximum"
+      stat        = "Average"
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace
@@ -453,7 +453,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-sms-replicas-unavailable" {
       metric_name = "kube_deployment_status_replicas_unavailable"
       namespace   = "ContainerInsights/Prometheus"
       period      = 300
-      stat        = "Maximum"
+      stat        = "Average"
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace
@@ -480,7 +480,7 @@ resource "aws_cloudwatch_metric_alarm" "admin-replicas-unavailable" {
       metric_name = "kube_deployment_status_replicas_unavailable"
       namespace   = "ContainerInsights/Prometheus"
       period      = 300
-      stat        = "Maximum"
+      stat        = "Average"
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace
@@ -507,7 +507,7 @@ resource "aws_cloudwatch_metric_alarm" "api-replicas-unavailable" {
       metric_name = "kube_deployment_status_replicas_unavailable"
       namespace   = "ContainerInsights/Prometheus"
       period      = 300
-      stat        = "Maximum"
+      stat        = "Average"
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace
@@ -534,7 +534,7 @@ resource "aws_cloudwatch_metric_alarm" "documentation-replicas-unavailable" {
       metric_name = "kube_deployment_status_replicas_unavailable"
       namespace   = "ContainerInsights/Prometheus"
       period      = 300
-      stat        = "Maximum"
+      stat        = "Average"
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace
@@ -561,7 +561,7 @@ resource "aws_cloudwatch_metric_alarm" "document-download-api-replicas-unavailab
       metric_name = "kube_deployment_status_replicas_unavailable"
       namespace   = "ContainerInsights/Prometheus"
       period      = 300
-      stat        = "Maximum"
+      stat        = "Average"
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -397,7 +397,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-replicas-unavailable" {
     id          = "m1"
     return_data = "true"
     metric {
-      metric_name = "celery_deployment_replicas_unavailable"
+      metric_name = "kube_deployment_status_replicas_unavailable"
       namespace   = "ContainerInsights/Prometheus"
       period      = 300
       stat        = "Maximum"
@@ -406,6 +406,33 @@ resource "aws_cloudwatch_metric_alarm" "celery-replicas-unavailable" {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace
         deployment  = "celery"
+      }
+    }
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "celery-beat-replicas-unavailable" {
+  alarm_name          = "celery-beat-replicas-unavailable"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  alarm_description   = "Celery Beat Replicas Unavailable"
+  #Setting to warn until we verify that it is working as expected
+  alarm_actions      = [var.sns_alert_warning_arn]
+  treat_missing_data = "notBreaching"
+  threshold          = 1
+
+  metric_query {
+    id          = "m1"
+    return_data = "true"
+    metric {
+      metric_name = "kube_deployment_status_replicas_unavailable"
+      namespace   = "ContainerInsights/Prometheus"
+      period      = 300
+      stat        = "Maximum"
+      dimensions = {
+        ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
+        namespace   = var.notify_k8s_namespace
+        deployment  = "celery-beat"
       }
     }
   }


### PR DESCRIPTION
# Summary | Résumé

There was a typo in the alarm for unavailable replica for Celery that these changes fix. I also added a definition for the celery-beat replicate set which was missing.

# Test instructions | Instructions pour tester la modification

* Make the k8s deployment fail and trigger the alarm in the *staging* environment.
