### PR TITLE
Adding config file for aws-nuke in scratch environment

### DIFF
--- a/env/scratch/aws-nuke/scratch-nuke.yaml
+++ b/env/scratch/aws-nuke/scratch-nuke.yaml
@@ -1,0 +1,197 @@
+# Regions to remove resources from
+regions:
+- "global"
+- "us-east-1"
+- "us-west-2"
+- "ca-central-1"
+
+# Only delete resources from accounts that do not match LandingZone filters
+
+accounts:
+  "419291849580": 
+      filters:
+        IAMPolicy:
+        - type: glob
+          value: "*UpdateTrustPolicyAWSAFTExecutionRolePolicy*"
+        - type: glob
+          value: "*AWSLoadBalancerControllerIAMPolicy*"
+        - "arn:aws:iam::419291849580:policy/UpdateTrustPolicyAWSAFTExecutionRolePolicy"
+        CloudWatchLogsLogGroup:
+        - type: glob
+          value: "*aws-controltower*"
+        - type: glob
+          value: "/aws/lambda/aws-controltower-NotificationForwarder"
+        - type: glob
+          value: "/aws-controltower-NotificationForwarder"
+
+        CloudWatchEventsTarget:
+        - type: glob
+          value: "*aws-controltower-*"
+        IAMRolePolicyAttachment:
+        - type: glob
+          value: "aws-controltower-*"
+        - type: glob
+          value: "AWSReservedSSO_*"   
+        - type: glob
+          value: "AWSControlTowerExecution*"
+        - type: glob
+          value: "AWSAFTService*"
+        - type: glob
+          value: "AWSAFTExecution*"
+        - type: glob
+          value: "AWSNuke*"
+        - "group_change_auto_response_role"
+        - "secopsAssetInventorySecurityAuditRole"
+        - "UpdateTrustPolicyAWSAFTExecutionRole"        
+        IAMRolePolicy:
+        - type: glob
+          value: "StackSet-AWSControlTowerGuardHook-*"
+        - type: glob
+          value: "aws-controltower-*"
+        IAMRole:
+        - type: glob
+          value: "AWSServiceRole*"
+        - type: glob
+          value: "AWSReservedSSO*"          
+        - type: glob
+          value: "aws-controltower-*"
+        - type: glob
+          value: "*UpdateTrustPolicyAWSAFTExecutionRole*"
+        - type: glob
+          value: "StackSet-*"
+        - type: glob
+          value: "*group_change_auto_response_role*"
+        - "secopsAssetInventorySecurityAuditRole"
+        - "AWSNuke"
+        - "AWSControlTowerExecution"
+        - "AWSAFTService"
+        - "AWSAFTExecution"
+        - "ApiGatewayCloudWatchRole"
+        - "secopsAssetInventorySecurityAuditRole"
+
+        IAMUserGroupAttachment:
+        - "ops1 -> admins"
+        - "ops2 -> admins"
+        IAMGroupPolicyAttachment:
+        - "admins -> AdministratorAccess"
+        IAMGroup:
+        - "admins"
+        SNSTopic:
+        - type: glob
+          value: "*aws-controltower*"
+        - type: glob
+          value: "*internal-sre-alert*"
+        SNSSubscription:
+        - type: glob
+          value: "*aws-controltower-SecurityNotifications*"
+        LambdaFunction:
+        - type: glob
+          value: "*aws-controltower-NotificationForwarder*"
+
+
+
+# Do not delete any of the following resource types
+resource-types:
+  excludes:
+    - CloudWatchEventsRule
+    - ConfigServiceConfigRule
+    - ConfigServiceDeliveryChannel
+    - ConfigServiceConfigurationRecorder
+    - EC2DHCPOption
+    - ElasticacheCacheParameterGroup
+    - FMSPolicy
+    - FMSNotificationChannel
+    - GuardDutyDetector
+    - IAMUserAccessKey
+    - IAMUserPolicyAttachment
+    - IAMLoginProfile
+    - IAMOpenIDConnectProvider
+    - IAMSAMLProvider
+    - IAMUser
+    - KMSAlias
+    - KMSKey
+    - OpsWorksUserProfile
+    - SecurityHub
+    - CloudFormationStack
+    - CloudWatchLogsResourcePolicy
+    - RedshiftSubnetGroup
+    - SageMakerUserProfiles
+    - SageMakerDomain
+    - SageMakerEndpointConfig
+    - RedshiftSnapshot
+    - RedshiftCluster
+    - SageMakerNotebookInstanceState
+    - SageMakerNotebookInstanceLifecycleConfig
+    - AWS::Timestream::Table
+    - AWS::Timestream::ScheduledQuery
+    - AWS::Timestream::Database
+    - AWS::AppRunner::Service
+    - RedshiftParameterGroup
+    - SageMakerNotebookInstance
+    - SageMakerEndpoint
+    - SESReceiptRuleSet
+    - SESReceiptFilter
+    - SageMakerApp
+    - SageMakerModel
+    - SageMakerUserProfiles
+    - RedshiftSubnetGroup
+    - MachineLearningDataSource
+    - MachineLearningBranchPrediction
+    - MachineLearningMLModel
+    - MachineLearningEvaluation
+    - CloudTrailTrail
+    - NeptuneInstance
+    - CloudFormationType
+    - CloudTrailTrail
+    - MediaConvertQueue
+    - AWSServiceRoleForAmazonEKS
+    - AWSServiceRoleForAmazonEKSNodegroup
+    - AWSServiceRoleForAmazonGuardDuty
+    - AWSServiceRoleForAPIGateway
+    - CloudFrontDistributionDeployment
+    - CloudFrontOriginAccessIdentity
+    - CloudFrontDistribution
+    - IAMVirtualMFADevice
+    - AppStreamImage
+
+
+
+
+# Accounts that will not have resources removed
+account-blocklist:
+- "239043911459"
+- "276192857112"
+- "283582579564"
+- "296255494825"
+- "339850311124"
+- "349837941862"
+- "370045664819"
+- "400061975867"
+- "406214159830"
+- "414662622316"
+- "472286471787"
+- "507252742351"
+- "537819865265"
+- "563894450011"
+- "591111259917"
+- "637287734259"
+- "687401027353"
+- "703399696403"
+- "729164266357"
+- "773858180673"
+- "794722365809"
+- "797698708703"
+- "806545929748"
+- "843973686572"
+- "871282759583"
+- "925306372402"
+- "957818836222"
+- "977382588899"
+# Control Tower Accounts
+- "659087519042" # Org Account
+- "274536870005" # Log Archive
+- "886481071419" # Audit
+- "137554749751" # AFT-Management
+- "127893201980" # Scan Files staging
+- "796730610681" # Linguistic Services
+- "034163289675" # Ct-Test-account Used for testing AFT Provisioning


### PR DESCRIPTION
# Summary | Résumé

This is the configuration file for running [aws-nuke](https://github.com/rebuy-de/aws-nuke) in upcoming scratch environments. This has no impact on staging or production environments, and is currently explicitly set to my scratch environment. We can modify this config file in the future to include additional scratch accounts. This is more of a utility PR that will be used when terragrunt fails to properly delete. 

# Test instructions | Instructions pour tester la modification

aws-nuke --config scratch-nuke.yaml --profile ben-scratch