### PR TITLE
Creating Baseline Config for Scratch Environment

### DIFF
--- a/env/scratch/aws-nuke/scratch-nuke.yaml
+++ b/env/scratch/aws-nuke/scratch-nuke.yaml
@@ -1,0 +1,197 @@
+# Regions to remove resources from
+regions:
+- "global"
+- "us-east-1"
+- "us-west-2"
+- "ca-central-1"
+
+# Only delete resources from accounts that do not match LandingZone filters
+
+accounts:
+  "419291849580": 
+      filters:
+        IAMPolicy:
+        - type: glob
+          value: "*UpdateTrustPolicyAWSAFTExecutionRolePolicy*"
+        - type: glob
+          value: "*AWSLoadBalancerControllerIAMPolicy*"
+        - "arn:aws:iam::419291849580:policy/UpdateTrustPolicyAWSAFTExecutionRolePolicy"
+        CloudWatchLogsLogGroup:
+        - type: glob
+          value: "*aws-controltower*"
+        - type: glob
+          value: "/aws/lambda/aws-controltower-NotificationForwarder"
+        - type: glob
+          value: "/aws-controltower-NotificationForwarder"
+
+        CloudWatchEventsTarget:
+        - type: glob
+          value: "*aws-controltower-*"
+        IAMRolePolicyAttachment:
+        - type: glob
+          value: "aws-controltower-*"
+        - type: glob
+          value: "AWSReservedSSO_*"   
+        - type: glob
+          value: "AWSControlTowerExecution*"
+        - type: glob
+          value: "AWSAFTService*"
+        - type: glob
+          value: "AWSAFTExecution*"
+        - type: glob
+          value: "AWSNuke*"
+        - "group_change_auto_response_role"
+        - "secopsAssetInventorySecurityAuditRole"
+        - "UpdateTrustPolicyAWSAFTExecutionRole"        
+        IAMRolePolicy:
+        - type: glob
+          value: "StackSet-AWSControlTowerGuardHook-*"
+        - type: glob
+          value: "aws-controltower-*"
+        IAMRole:
+        - type: glob
+          value: "AWSServiceRole*"
+        - type: glob
+          value: "AWSReservedSSO*"          
+        - type: glob
+          value: "aws-controltower-*"
+        - type: glob
+          value: "*UpdateTrustPolicyAWSAFTExecutionRole*"
+        - type: glob
+          value: "StackSet-*"
+        - type: glob
+          value: "*group_change_auto_response_role*"
+        - "secopsAssetInventorySecurityAuditRole"
+        - "AWSNuke"
+        - "AWSControlTowerExecution"
+        - "AWSAFTService"
+        - "AWSAFTExecution"
+        - "ApiGatewayCloudWatchRole"
+        - "secopsAssetInventorySecurityAuditRole"
+
+        IAMUserGroupAttachment:
+        - "ops1 -> admins"
+        - "ops2 -> admins"
+        IAMGroupPolicyAttachment:
+        - "admins -> AdministratorAccess"
+        IAMGroup:
+        - "admins"
+        SNSTopic:
+        - type: glob
+          value: "*aws-controltower*"
+        - type: glob
+          value: "*internal-sre-alert*"
+        SNSSubscription:
+        - type: glob
+          value: "*aws-controltower-SecurityNotifications*"
+        LambdaFunction:
+        - type: glob
+          value: "*aws-controltower-NotificationForwarder*"
+
+
+
+# Do not delete any of the following resource types
+resource-types:
+  excludes:
+    - CloudWatchEventsRule
+    - ConfigServiceConfigRule
+    - ConfigServiceDeliveryChannel
+    - ConfigServiceConfigurationRecorder
+    - EC2DHCPOption
+    - ElasticacheCacheParameterGroup
+    - FMSPolicy
+    - FMSNotificationChannel
+    - GuardDutyDetector
+    - IAMUserAccessKey
+    - IAMUserPolicyAttachment
+    - IAMLoginProfile
+    - IAMOpenIDConnectProvider
+    - IAMSAMLProvider
+    - IAMUser
+    - KMSAlias
+    - KMSKey
+    - OpsWorksUserProfile
+    - SecurityHub
+    - CloudFormationStack
+    - CloudWatchLogsResourcePolicy
+    - RedshiftSubnetGroup
+    - SageMakerUserProfiles
+    - SageMakerDomain
+    - SageMakerEndpointConfig
+    - RedshiftSnapshot
+    - RedshiftCluster
+    - SageMakerNotebookInstanceState
+    - SageMakerNotebookInstanceLifecycleConfig
+    - AWS::Timestream::Table
+    - AWS::Timestream::ScheduledQuery
+    - AWS::Timestream::Database
+    - AWS::AppRunner::Service
+    - RedshiftParameterGroup
+    - SageMakerNotebookInstance
+    - SageMakerEndpoint
+    - SESReceiptRuleSet
+    - SESReceiptFilter
+    - SageMakerApp
+    - SageMakerModel
+    - SageMakerUserProfiles
+    - RedshiftSubnetGroup
+    - MachineLearningDataSource
+    - MachineLearningBranchPrediction
+    - MachineLearningMLModel
+    - MachineLearningEvaluation
+    - CloudTrailTrail
+    - NeptuneInstance
+    - CloudFormationType
+    - CloudTrailTrail
+    - MediaConvertQueue
+    - AWSServiceRoleForAmazonEKS
+    - AWSServiceRoleForAmazonEKSNodegroup
+    - AWSServiceRoleForAmazonGuardDuty
+    - AWSServiceRoleForAPIGateway
+    - CloudFrontDistributionDeployment
+    - CloudFrontOriginAccessIdentity
+    - CloudFrontDistribution
+    - IAMVirtualMFADevice
+    - AppStreamImage
+
+
+
+
+# Accounts that will not have resources removed
+account-blocklist:
+- "239043911459"
+- "276192857112"
+- "283582579564"
+- "296255494825"
+- "339850311124"
+- "349837941862"
+- "370045664819"
+- "400061975867"
+- "406214159830"
+- "414662622316"
+- "472286471787"
+- "507252742351"
+- "537819865265"
+- "563894450011"
+- "591111259917"
+- "637287734259"
+- "687401027353"
+- "703399696403"
+- "729164266357"
+- "773858180673"
+- "794722365809"
+- "797698708703"
+- "806545929748"
+- "843973686572"
+- "871282759583"
+- "925306372402"
+- "957818836222"
+- "977382588899"
+# Control Tower Accounts
+- "659087519042" # Org Account
+- "274536870005" # Log Archive
+- "886481071419" # Audit
+- "137554749751" # AFT-Management
+- "127893201980" # Scan Files staging
+- "796730610681" # Linguistic Services
+- "034163289675" # Ct-Test-account Used for testing AFT Provisioning

--- a/env/scratch/cloudfront/.terraform.lock.hcl
+++ b/env/scratch/cloudfront/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.74.2"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:TryIinyNf2gFkYA/d4hD0a76mPSvyl9rMUHePqs6cgs=",
+    "zh:2b1df436ec034ae9416b23b95efd192b2fe271a7c8595493329dcde8e452c036",
+    "zh:3aba9abd4bc8a904378b1f852d025a397ef74f0dbe59134a06fc5abebb259efc",
+    "zh:45700f37e3a97c5b3a8d5d2ec79ae7a8671be8893a6a6c38ae069888d13c20fe",
+    "zh:5b2ca0fde7f9b723018528ea21b151f2ada360a435ef2dcfb666d7fe686b2845",
+    "zh:785c52c6b4724873723b77c78e66024dc7ad951eeacb44a8c0cab2dd3c0f9828",
+    "zh:8b50a307f3324c4e31813abdb08a21c666e302e4c0496d9f8015ae76327cafb4",
+    "zh:ab78cab83e7806030c1b1e4943a6edb149a901380a1a5f7bceb1a1f41098e4c5",
+    "zh:c06a7fbffbbfa7b407990091869c0642dc9e38217da2895b49b42892e86eada6",
+    "zh:e046e30e24b3b95ca8ec0ecac562ac8a47e86f9db0efa460e50c2afce07e084e",
+    "zh:ef02426419de15931bcdfb400d914d720639607415ac623c04cdf425c71ade41",
+    "zh:fb1990e9e162cf1837792e4886a4b6dcb3ffdd511d1ba4b56118127525504032",
+  ]
+}

--- a/env/scratch/cloudfront/terragrunt.hcl
+++ b/env/scratch/cloudfront/terragrunt.hcl
@@ -1,0 +1,41 @@
+dependencies {
+  paths = ["../common", "../dns"]
+}
+
+dependency "common" {
+  config_path = "../common"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["validate"]
+  mock_outputs = {
+    asset_bucket_regional_domain_name = ""
+  }
+}
+
+dependency "dns" {
+  config_path = "../dns"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["validate"]
+  mock_outputs = {
+    aws_acm_assets_notification_canada_ca_arn = ""
+  }
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  asset_bucket_regional_domain_name         = dependency.common.outputs.asset_bucket_regional_domain_name
+  s3_bucket_asset_bucket_id                 = dependency.common.outputs.s3_bucket_asset_bucket_id
+  s3_bucket_asset_bucket_arn                = dependency.common.outputs.s3_bucket_asset_bucket_arn
+  aws_acm_assets_notification_canada_ca_arn = dependency.dns.outputs.aws_acm_assets_notification_canada_ca_arn
+}
+
+terraform {
+  source = "../../../aws//cloudfront"
+}
+

--- a/env/scratch/common/.terraform.lock.hcl
+++ b/env/scratch/common/.terraform.lock.hcl
@@ -1,0 +1,117 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.2.0"
+  hashes = [
+    "h1:2K5LQkuWRS2YN1/YoNaHn9MAzjuTX8Gaqy6i8Mbfv8Y=",
+    "h1:CIWi5G6ob7p2wWoThRQbOB8AbmFlCzp7Ka81hR3cVp0=",
+    "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
+    "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
+    "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
+    "zh:55c0d7ddddbd0a46d57c51fcfa9b91f14eed081a45101dbfc7fd9d2278aa1403",
+    "zh:73a5dd68379119167934c48afa1101b09abad2deb436cd5c446733e705869d6b",
+    "zh:841fc4ac6dc3479981330974d44ad2341deada8a5ff9e3b1b4510702dfbdbed9",
+    "zh:91be62c9b41edb137f7f835491183628d484e9d6efa82fcb75cfa538c92791c5",
+    "zh:acd5f442bd88d67eb948b18dc2ed421c6c3faee62d3a12200e442bfff0aa7d8b",
+    "zh:ad5720da5524641ad718a565694821be5f61f68f1c3c5d2cfa24426b8e774bef",
+    "zh:e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65",
+    "zh:f6542918faa115df46474a36aabb4c3899650bea036b5f8a5e296be6f8f25767",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.74.2"
+  constraints = "~> 3.0, >= 3.61.0"
+  hashes = [
+    "h1:TryIinyNf2gFkYA/d4hD0a76mPSvyl9rMUHePqs6cgs=",
+    "zh:2b1df436ec034ae9416b23b95efd192b2fe271a7c8595493329dcde8e452c036",
+    "zh:3aba9abd4bc8a904378b1f852d025a397ef74f0dbe59134a06fc5abebb259efc",
+    "zh:45700f37e3a97c5b3a8d5d2ec79ae7a8671be8893a6a6c38ae069888d13c20fe",
+    "zh:5b2ca0fde7f9b723018528ea21b151f2ada360a435ef2dcfb666d7fe686b2845",
+    "zh:785c52c6b4724873723b77c78e66024dc7ad951eeacb44a8c0cab2dd3c0f9828",
+    "zh:8b50a307f3324c4e31813abdb08a21c666e302e4c0496d9f8015ae76327cafb4",
+    "zh:ab78cab83e7806030c1b1e4943a6edb149a901380a1a5f7bceb1a1f41098e4c5",
+    "zh:c06a7fbffbbfa7b407990091869c0642dc9e38217da2895b49b42892e86eada6",
+    "zh:e046e30e24b3b95ca8ec0ecac562ac8a47e86f9db0efa460e50c2afce07e084e",
+    "zh:ef02426419de15931bcdfb400d914d720639607415ac623c04cdf425c71ade41",
+    "zh:fb1990e9e162cf1837792e4886a4b6dcb3ffdd511d1ba4b56118127525504032",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/external" {
+  version     = "2.2.0"
+  constraints = ">= 1.0.0"
+  hashes = [
+    "h1:iU5OVMibHvIxbj2Dye1q3aYpjYXS3bKL9iZWZyh+xTg=",
+    "zh:094c3cfae140fbb70fb0e272b1df833b4d7467c6c819fbf59a3e8ac0922f95b6",
+    "zh:15c3906abbc1cd03a72afd02bda9caeeb5f6ca421292c32ddeb2acd7a3488669",
+    "zh:388c14bceeb1593bb16cadedc8f5ad7d41d398197db049dc0871bc847aa61083",
+    "zh:5696772136b6763faade0cc065fafc2bf06493021b943826be0144790fae514a",
+    "zh:6427c693b1b750644d5b633395e54617dc36ae717a531a5cde8cb0246b6593ca",
+    "zh:7196d9845eeffa3158f5e3067bf8b7ad489490aa26d29e2da1ad4c8924463469",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8850d3ce9e5f5776b9349890ce4e2c4056defe16ed741dc845045942a6d9e025",
+    "zh:a2c6fc6cf087b35ebd6b6f20272ed32d4217ea9936c1dd630baa46d86718a455",
+    "zh:ac709be4ea5c9a6e1ab80e864d24cd9f8e6aaea29fb5dbe1de0897e2e86c3c17",
+    "zh:dcf806f044801fae5b21ae2754dc3c19c68e458d4584965752ce49be75305ff5",
+    "zh:f875b34be86c3439899828978638ef7e2d41a9e5e32397858a0c31daeaa1abc2",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.1.0"
+  constraints = ">= 1.0.0"
+  hashes = [
+    "h1:EYZdckuGU3n6APs97nS2LxZm3dDtGqyM4qaIvsmac8o=",
+    "zh:0f1ec65101fa35050978d483d6e8916664b7556800348456ff3d09454ac1eae2",
+    "zh:36e42ac19f5d68467aacf07e6adcf83c7486f2e5b5f4339e9671f68525fc87ab",
+    "zh:6db9db2a1819e77b1642ec3b5e95042b202aee8151a0256d289f2e141bf3ceb3",
+    "zh:719dfd97bb9ddce99f7d741260b8ece2682b363735c764cac83303f02386075a",
+    "zh:7598bb86e0378fd97eaa04638c1a4c75f960f62f69d3662e6d80ffa5a89847fe",
+    "zh:ad0a188b52517fec9eca393f1e2c9daea362b33ae2eb38a857b6b09949a727c1",
+    "zh:c46846c8df66a13fee6eff7dc5d528a7f868ae0dcf92d79deaac73cc297ed20c",
+    "zh:dc1a20a2eec12095d04bf6da5321f535351a594a636912361db20eb2a707ccc4",
+    "zh:e57ab4771a9d999401f6badd8b018558357d3cbdf3d33cc0c4f83e818ca8e94b",
+    "zh:ebdcde208072b4b0f8d305ebf2bfdc62c926e0717599dcf8ec2fd8c5845031c3",
+    "zh:ef34c52b68933bedd0868a13ccfd59ff1c820f299760b3c02e008dc95e2ece91",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.1.0"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:vpC6bgUQoJ0znqIKVFevOdq+YQw42bRq0u+H3nto8nA=",
+    "zh:02a1675fd8de126a00460942aaae242e65ca3380b5bb192e8773ef3da9073fd2",
+    "zh:53e30545ff8926a8e30ad30648991ca8b93b6fa496272cd23b26763c8ee84515",
+    "zh:5f9200bf708913621d0f6514179d89700e9aa3097c77dac730e8ba6e5901d521",
+    "zh:9ebf4d9704faba06b3ec7242c773c0fbfe12d62db7d00356d4f55385fc69bfb2",
+    "zh:a6576c81adc70326e4e1c999c04ad9ca37113a6e925aefab4765e5a5198efa7e",
+    "zh:a8a42d13346347aff6c63a37cda9b2c6aa5cc384a55b2fe6d6adfa390e609c53",
+    "zh:c797744d08a5307d50210e0454f91ca4d1c7621c68740441cf4579390452321d",
+    "zh:cecb6a304046df34c11229f20a80b24b1603960b794d68361a67c5efe58e62b8",
+    "zh:e1371aa1e502000d9974cfaff5be4cfa02f47b17400005a16f14d2ef30dc2a70",
+    "zh:fc39cc1fe71234a0b0369d5c5c7f876c71b956d23d7d6f518289737a001ba69b",
+    "zh:fea4227271ebf7d9e2b61b89ce2328c7262acd9fd190e1fd6d15a591abfa848e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.1.0"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}

--- a/env/scratch/common/terragrunt.hcl
+++ b/env/scratch/common/terragrunt.hcl
@@ -1,0 +1,40 @@
+terraform {
+  source = "../../../aws//common"
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  sns_monthly_spend_limit                                            = 50
+  sns_monthly_spend_limit_us_west_2                                  = 30
+  alarm_warning_document_download_bucket_size_gb                     = 0.5
+  alarm_warning_inflight_processed_created_delta_threshold           = 100
+  alarm_critical_inflight_processed_created_delta_threshold          = 200
+  alarm_warning_priority_inflight_processed_created_delta_threshold  = 100
+  alarm_critical_priority_inflight_processed_created_delta_threshold = 300
+  alarm_warning_normal_inflight_processed_created_delta_threshold    = 100
+  alarm_critical_normal_inflight_processed_created_delta_threshold   = 200
+  alarm_warning_bulk_inflight_processed_created_delta_threshold      = 100
+  alarm_critical_bulk_inflight_processed_created_delta_threshold     = 200
+  alarm_warning_bulk_processed_created_delta_threshold               = 5000
+  alarm_critical_bulk_processed_created_delta_threshold              = 10000
+  alarm_warning_priority_bulk_processed_created_delta_threshold      = 5000
+  alarm_critical_priority_bulk_processed_created_delta_threshold     = 10000
+  alarm_warning_normal_bulk_processed_created_delta_threshold        = 5000
+  alarm_critical_normal_bulk_processed_created_delta_threshold       = 10000
+  alarm_warning_bulk_bulk_processed_created_delta_threshold          = 5000
+  alarm_critical_bulk_bulk_processed_created_delta_threshold         = 10000
+  alarm_warning_expired_sms_created_threshold                        = 100
+  alarm_critical_expired_sms_created_threshold                       = 200
+  alarm_warning_expired_email_created_threshold                      = 100
+  alarm_critical_expired_email_created_threshold                     = 200
+  billing_tag_value                                                  = "notification-canada-ca-staging"
+  sqs_priority_db_tasks_queue_name                                   = "priority-database-tasks.fifo"
+  sqs_normal_db_tasks_queue_name                                     = "normal-database-tasks"
+  sqs_bulk_db_tasks_queue_name                                       = "bulk-database-tasks"
+}
+
+# See QueueNames in
+# https://github.com/cds-snc/notification-api/blob/master/app/config.py

--- a/env/scratch/database-tools/terragrunt.hcl
+++ b/env/scratch/database-tools/terragrunt.hcl
@@ -1,0 +1,51 @@
+dependencies {
+  paths = ["../common", "../eks"]
+}
+
+dependency "common" {
+  config_path = "../common"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    vpc_id = ""
+    vpc_private_subnets = [
+      "",
+      "",
+      "",
+    ]
+  }
+}
+
+dependency "eks" {
+  config_path = "../eks"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["validate", "plan", "init", "fmt", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    database-tools-securitygroup = ""
+    database-tools-db-securitygroup = ""
+  }
+}
+
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  vpc_private_subnets             = dependency.common.outputs.vpc_private_subnets
+  vpc_id                          = dependency.common.outputs.vpc_id
+  billing_tag_key                 = "CostCenter"
+  billing_tag_value               = "notification-canada-ca-staging"
+  blazer_image_tag                = "latest"
+  database-tools-securitygroup    = dependency.eks.outputs.database-tools-securitygroup
+  database-tools-db-securitygroup = dependency.eks.outputs.database-tools-db-securitygroup
+}
+
+terraform {
+  source = "../../../aws//database-tools"
+}

--- a/env/scratch/dns/.terraform.lock.hcl
+++ b/env/scratch/dns/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.74.2"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:TryIinyNf2gFkYA/d4hD0a76mPSvyl9rMUHePqs6cgs=",
+    "zh:2b1df436ec034ae9416b23b95efd192b2fe271a7c8595493329dcde8e452c036",
+    "zh:3aba9abd4bc8a904378b1f852d025a397ef74f0dbe59134a06fc5abebb259efc",
+    "zh:45700f37e3a97c5b3a8d5d2ec79ae7a8671be8893a6a6c38ae069888d13c20fe",
+    "zh:5b2ca0fde7f9b723018528ea21b151f2ada360a435ef2dcfb666d7fe686b2845",
+    "zh:785c52c6b4724873723b77c78e66024dc7ad951eeacb44a8c0cab2dd3c0f9828",
+    "zh:8b50a307f3324c4e31813abdb08a21c666e302e4c0496d9f8015ae76327cafb4",
+    "zh:ab78cab83e7806030c1b1e4943a6edb149a901380a1a5f7bceb1a1f41098e4c5",
+    "zh:c06a7fbffbbfa7b407990091869c0642dc9e38217da2895b49b42892e86eada6",
+    "zh:e046e30e24b3b95ca8ec0ecac562ac8a47e86f9db0efa460e50c2afce07e084e",
+    "zh:ef02426419de15931bcdfb400d914d720639607415ac623c04cdf425c71ade41",
+    "zh:fb1990e9e162cf1837792e4886a4b6dcb3ffdd511d1ba4b56118127525504032",
+  ]
+}

--- a/env/scratch/dns/terragrunt.hcl
+++ b/env/scratch/dns/terragrunt.hcl
@@ -1,0 +1,42 @@
+dependencies {
+  paths = ["../common", "../ses_receiving_emails"]
+}
+
+dependency "common" {
+  config_path = "../common"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["validate"]
+  mock_outputs = {
+    notification_canada_ca_ses_callback_arn = ""
+  }
+}
+
+dependency "ses_receiving_emails" {
+  config_path = "../ses_receiving_emails"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    lambda_ses_receiving_emails_image_arn = ""
+  }
+}
+
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  notification_canada_ca_ses_callback_arn = dependency.common.outputs.notification_canada_ca_ses_callback_arn
+  ses_custom_sending_domains              = ["custom-sending-domain.staging.notification.cdssandbox.xyz"]
+  lambda_ses_receiving_emails_image_arn   = dependency.ses_receiving_emails.outputs.lambda_ses_receiving_emails_image_arn
+}
+
+terraform {
+  source = "../../../aws//dns"
+}
+

--- a/env/scratch/eks/.terraform.lock.hcl
+++ b/env/scratch/eks/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.74.2"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:TryIinyNf2gFkYA/d4hD0a76mPSvyl9rMUHePqs6cgs=",
+    "zh:2b1df436ec034ae9416b23b95efd192b2fe271a7c8595493329dcde8e452c036",
+    "zh:3aba9abd4bc8a904378b1f852d025a397ef74f0dbe59134a06fc5abebb259efc",
+    "zh:45700f37e3a97c5b3a8d5d2ec79ae7a8671be8893a6a6c38ae069888d13c20fe",
+    "zh:5b2ca0fde7f9b723018528ea21b151f2ada360a435ef2dcfb666d7fe686b2845",
+    "zh:785c52c6b4724873723b77c78e66024dc7ad951eeacb44a8c0cab2dd3c0f9828",
+    "zh:8b50a307f3324c4e31813abdb08a21c666e302e4c0496d9f8015ae76327cafb4",
+    "zh:ab78cab83e7806030c1b1e4943a6edb149a901380a1a5f7bceb1a1f41098e4c5",
+    "zh:c06a7fbffbbfa7b407990091869c0642dc9e38217da2895b49b42892e86eada6",
+    "zh:e046e30e24b3b95ca8ec0ecac562ac8a47e86f9db0efa460e50c2afce07e084e",
+    "zh:ef02426419de15931bcdfb400d914d720639607415ac623c04cdf425c71ade41",
+    "zh:fb1990e9e162cf1837792e4886a4b6dcb3ffdd511d1ba4b56118127525504032",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "3.1.0"
+  hashes = [
+    "h1:fUJX8Zxx38e2kBln+zWr1Tl41X+OuiE++REjrEyiOM4=",
+    "zh:3d46616b41fea215566f4a957b6d3a1aa43f1f75c26776d72a98bdba79439db6",
+    "zh:623a203817a6dafa86f1b4141b645159e07ec418c82fe40acd4d2a27543cbaa2",
+    "zh:668217e78b210a6572e7b0ecb4134a6781cc4d738f4f5d09eb756085b082592e",
+    "zh:95354df03710691773c8f50a32e31fca25f124b7f3d6078265fdf3c4e1384dca",
+    "zh:9f97ab190380430d57392303e3f36f4f7835c74ea83276baa98d6b9a997c3698",
+    "zh:a16f0bab665f8d933e95ca055b9c8d5707f1a0dd8c8ecca6c13091f40dc1e99d",
+    "zh:be274d5008c24dc0d6540c19e22dbb31ee6bfdd0b2cddd4d97f3cd8a8d657841",
+    "zh:d5faa9dce0a5fc9d26b2463cea5be35f8586ab75030e7fa4d4920cd73ee26989",
+    "zh:e9b672210b7fb410780e7b429975adcc76dd557738ecc7c890ea18942eb321a5",
+    "zh:eb1f8368573d2370605d6dbf60f9aaa5b64e55741d96b5fb026dbfe91de67c0d",
+    "zh:fc1e12b713837b85daf6c3bb703d7795eaf1c5177aebae1afcf811dd7009f4b0",
+  ]
+}

--- a/env/scratch/eks/terragrunt.hcl
+++ b/env/scratch/eks/terragrunt.hcl
@@ -1,0 +1,99 @@
+dependencies {
+  paths = ["../common", "../dns", "../cloudfront"]
+}
+
+dependency "common" {
+  config_path = "../common"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    vpc_private_subnets = [
+      "subnet-001e585d12cce4d1e",
+      "subnet-08de34a9e1a7458dc",
+      "subnet-0af8b8402f1d605ff",
+    ]
+    vpc_public_subnets = [
+      "subnet-0cecd9e634daf82d3",
+      "subnet-0c7d18c0c51b28b61",
+      "subnet-0c91f7c6b8211904b",
+    ]
+    sns_alert_warning_arn                     = ""
+    sns_alert_critical_arn                    = ""
+    sns_alert_general_arn                     = ""
+    firehose_waf_logs_iam_role_arn            = ""
+    ip_blocklist_arn                          = ""
+    re_admin_arn                              = ""
+    re_api_arn                                = ""
+    re_document_download_arn                  = ""
+    re_documentation_arn                      = ""
+    private-links-vpc-endpoints-securitygroup = ""
+    private-links-gateway-prefix-list-ids     = []
+  }
+}
+
+dependency "dns" {
+  config_path = "../dns"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["validate"]
+  mock_outputs = {
+    aws_acm_notification_canada_ca_arn     = ""
+    aws_acm_alt_notification_canada_ca_arn = ""
+  }
+}
+
+dependency "cloudfront" {
+  config_path = "../cloudfront"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["validate"]
+  mock_outputs = {
+    cloudfront_assets_arn = ""
+  }
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  aws_acm_notification_canada_ca_arn        = dependency.dns.outputs.aws_acm_notification_canada_ca_arn
+  aws_acm_alt_notification_canada_ca_arn    = dependency.dns.outputs.aws_acm_alt_notification_canada_ca_arn
+  primary_worker_desired_size               = 5
+  primary_worker_instance_types             = ["m5.large"]
+  primary_worker_max_size                   = 7
+  primary_worker_min_size                   = 4
+  vpc_id                                    = dependency.common.outputs.vpc_id
+  vpc_private_subnets                       = dependency.common.outputs.vpc_private_subnets
+  vpc_public_subnets                        = dependency.common.outputs.vpc_public_subnets
+  sns_alert_warning_arn                     = dependency.common.outputs.sns_alert_warning_arn
+  sns_alert_critical_arn                    = dependency.common.outputs.sns_alert_critical_arn
+  sns_alert_general_arn                     = dependency.common.outputs.sns_alert_general_arn
+  firehose_waf_logs_iam_role_arn            = dependency.common.outputs.firehose_waf_logs_iam_role_arn
+  cloudfront_assets_arn                     = dependency.cloudfront.outputs.cloudfront_assets_arn
+  eks_cluster_name                          = "notification-canada-ca-staging-eks-cluster"
+  eks_cluster_version                       = "1.22"
+  eks_addon_coredns_version                 = "v1.8.7-eksbuild.1"
+  eks_addon_kube_proxy_version              = "v1.22.6-eksbuild.1"
+  eks_addon_vpc_cni_version                 = "v1.11.0-eksbuild.1"
+  eks_node_ami_version                      = "1.22.17-20230217"
+  non_api_waf_rate_limit                    = 500
+  api_waf_rate_limit                        = 5000
+  sign_in_waf_rate_limit                    = 100
+  ip_blocklist_arn                          = dependency.common.outputs.ip_blocklist_arn
+  re_admin_arn                              = dependency.common.outputs.re_admin_arn
+  re_api_arn                                = dependency.common.outputs.re_api_arn
+  re_document_download_arn                  = dependency.common.outputs.re_document_download_arn
+  re_documentation_arn                      = dependency.common.outputs.re_documentation_arn
+  private-links-vpc-endpoints-securitygroup = dependency.common.outputs.private-links-vpc-endpoints-securitygroup
+  private-links-gateway-prefix-list-ids     = dependency.common.outputs.private-links-gateway-prefix-list-ids
+}
+
+terraform {
+  source = "../../../aws//eks"
+}

--- a/env/scratch/elasticache/.terraform.lock.hcl
+++ b/env/scratch/elasticache/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.74.2"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:TryIinyNf2gFkYA/d4hD0a76mPSvyl9rMUHePqs6cgs=",
+    "zh:2b1df436ec034ae9416b23b95efd192b2fe271a7c8595493329dcde8e452c036",
+    "zh:3aba9abd4bc8a904378b1f852d025a397ef74f0dbe59134a06fc5abebb259efc",
+    "zh:45700f37e3a97c5b3a8d5d2ec79ae7a8671be8893a6a6c38ae069888d13c20fe",
+    "zh:5b2ca0fde7f9b723018528ea21b151f2ada360a435ef2dcfb666d7fe686b2845",
+    "zh:785c52c6b4724873723b77c78e66024dc7ad951eeacb44a8c0cab2dd3c0f9828",
+    "zh:8b50a307f3324c4e31813abdb08a21c666e302e4c0496d9f8015ae76327cafb4",
+    "zh:ab78cab83e7806030c1b1e4943a6edb149a901380a1a5f7bceb1a1f41098e4c5",
+    "zh:c06a7fbffbbfa7b407990091869c0642dc9e38217da2895b49b42892e86eada6",
+    "zh:e046e30e24b3b95ca8ec0ecac562ac8a47e86f9db0efa460e50c2afce07e084e",
+    "zh:ef02426419de15931bcdfb400d914d720639607415ac623c04cdf425c71ade41",
+    "zh:fb1990e9e162cf1837792e4886a4b6dcb3ffdd511d1ba4b56118127525504032",
+  ]
+}

--- a/env/scratch/elasticache/terragrunt.hcl
+++ b/env/scratch/elasticache/terragrunt.hcl
@@ -1,0 +1,48 @@
+dependencies {
+  paths = ["../common", "../eks"]
+}
+
+dependency "common" {
+  config_path = "../common"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["validate"]
+  mock_outputs = {
+    vpc_id = ""
+    vpc_private_subnets = [
+      "subnet-001e585d12cce4d1e",
+      "subnet-08de34a9e1a7458dc",
+      "subnet-0af8b8402f1d605ff",
+    ]
+  }
+}
+
+dependency "eks" {
+  config_path = "../eks"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["validate"]
+  mock_outputs = {
+    eks-cluster-securitygroup = "sg-0e2c3ef6c5c75b74c"
+  }
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  eks_cluster_securitygroup               = dependency.eks.outputs.eks-cluster-securitygroup
+  elasticache_node_count                  = 1
+  elasticache_node_number_cache_clusters  = 3
+  elasticache_node_type                   = "cache.t3.micro"
+  vpc_private_subnets                     = dependency.common.outputs.vpc_private_subnets
+  sns_alert_warning_arn                   = dependency.common.outputs.sns_alert_warning_arn
+  vpc_id                                  = dependency.common.outputs.vpc_id
+}
+
+terraform {
+  source = "../../../aws//elasticache"
+}

--- a/env/scratch/env_vars.hcl
+++ b/env/scratch/env_vars.hcl
@@ -1,0 +1,6 @@
+inputs = {
+  account_id = "239043911459"
+  domain     = "staging.notification.cdssandbox.xyz"
+  alt_domain = "staging.notification.alpha.cdssandbox.xyz"
+  env        = "staging"
+}

--- a/env/scratch/heartbeat/.terraform.lock.hcl
+++ b/env/scratch/heartbeat/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.74.2"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:TryIinyNf2gFkYA/d4hD0a76mPSvyl9rMUHePqs6cgs=",
+    "zh:2b1df436ec034ae9416b23b95efd192b2fe271a7c8595493329dcde8e452c036",
+    "zh:3aba9abd4bc8a904378b1f852d025a397ef74f0dbe59134a06fc5abebb259efc",
+    "zh:45700f37e3a97c5b3a8d5d2ec79ae7a8671be8893a6a6c38ae069888d13c20fe",
+    "zh:5b2ca0fde7f9b723018528ea21b151f2ada360a435ef2dcfb666d7fe686b2845",
+    "zh:785c52c6b4724873723b77c78e66024dc7ad951eeacb44a8c0cab2dd3c0f9828",
+    "zh:8b50a307f3324c4e31813abdb08a21c666e302e4c0496d9f8015ae76327cafb4",
+    "zh:ab78cab83e7806030c1b1e4943a6edb149a901380a1a5f7bceb1a1f41098e4c5",
+    "zh:c06a7fbffbbfa7b407990091869c0642dc9e38217da2895b49b42892e86eada6",
+    "zh:e046e30e24b3b95ca8ec0ecac562ac8a47e86f9db0efa460e50c2afce07e084e",
+    "zh:ef02426419de15931bcdfb400d914d720639607415ac623c04cdf425c71ade41",
+    "zh:fb1990e9e162cf1837792e4886a4b6dcb3ffdd511d1ba4b56118127525504032",
+  ]
+}

--- a/env/scratch/heartbeat/terragrunt.hcl
+++ b/env/scratch/heartbeat/terragrunt.hcl
@@ -1,0 +1,29 @@
+dependencies {
+  paths = ["../common"]
+}
+
+dependency "common" {
+  config_path = "../common"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs = {
+    sns_alert_warning_arn  = ""
+    sns_alert_critical_arn = ""
+  }
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  billing_tag_value      = "notification-canada-ca-staging"
+  schedule_expression    = "rate(1 minute)"
+  sns_alert_warning_arn  = dependency.common.outputs.sns_alert_warning_arn
+  sns_alert_critical_arn = dependency.common.outputs.sns_alert_critical_arn
+}
+
+terraform {
+  source = "../../../aws//heartbeat"
+}

--- a/env/scratch/lambda-admin-pr/.terraform.lock.hcl
+++ b/env/scratch/lambda-admin-pr/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.75.1"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:++H0a4igODgreQL3SJuRz71JZkC69rl41R8xLYM894o=",
+    "zh:11c2ee541ca1da923356c9225575ba294523d7b6af82d6171c912470ef0f90cd",
+    "zh:19fe975993664252b4a2ff1079546f2b186b01d1a025a94a4f15c37e023806c5",
+    "zh:442e7fc145b2debebe9279b283d07f5f736dc1776c2e5b1702728a6eb03789d0",
+    "zh:7a77991b204ae2c16ac29a32226135d5fdbda40c8dafa77c5adf5439a346be77",
+    "zh:89a257933181c15293c15a858fbfe7252129cc57cc2ec05b6c0b595d1bfe9d38",
+    "zh:b1813ea5b6b0fd88ea85b1b21b8e4119566d1bc34feca297b4fb39d0536893cb",
+    "zh:c519f3292ae431bd2381f88a95bd37c52f7a56d91feef88511e929344c180549",
+    "zh:d3dbe88b661c073c174f04f73adc2720372143bdfa12f4fe8f411332e64662cf",
+    "zh:e92a27e3c7295b031b5d62dd9428966c96e3157fc768b3d848a9ac60d1661c8e",
+    "zh:ecd664c0d664fcf2d8a89a01462cb00bcae37da200305aef2de1b8fe185c9cd8",
+    "zh:ed6ce1f9fa96aa28dd65842f852abed25f919d20b5cf53d26cec5b3f4d845725",
+  ]
+}

--- a/env/scratch/lambda-admin-pr/terragrunt.hcl
+++ b/env/scratch/lambda-admin-pr/terragrunt.hcl
@@ -1,0 +1,40 @@
+dependencies {
+  paths = ["../common", "../elasticache"]
+}
+
+dependency "common" {
+  config_path = "../common"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    private-links-gateway-prefix-list-ids     = []
+    private-links-vpc-endpoints-securitygroup = ""
+    vpc_id                                    = ""
+  }
+}
+
+dependency "elasticache" {
+  config_path = "../elasticache"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    redis_cluster_security_group_id = ""
+  }
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  redis_cluster_security_group_id      = dependency.elasticache.outputs.redis_cluster_security_group_id
+  vpc_id                               = dependency.common.outputs.vpc_id
+  vpc_endpoint_gateway_prefix_list_ids = dependency.common.outputs.private-links-gateway-prefix-list-ids
+  vpc_endpoint_security_group_id       = dependency.common.outputs.private-links-vpc-endpoints-securitygroup
+}
+
+terraform {
+  source = "../../../aws//lambda-admin-pr"
+}

--- a/env/scratch/lambda-api/.terraform.lock.hcl
+++ b/env/scratch/lambda-api/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.74.2"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:TryIinyNf2gFkYA/d4hD0a76mPSvyl9rMUHePqs6cgs=",
+    "zh:2b1df436ec034ae9416b23b95efd192b2fe271a7c8595493329dcde8e452c036",
+    "zh:3aba9abd4bc8a904378b1f852d025a397ef74f0dbe59134a06fc5abebb259efc",
+    "zh:45700f37e3a97c5b3a8d5d2ec79ae7a8671be8893a6a6c38ae069888d13c20fe",
+    "zh:5b2ca0fde7f9b723018528ea21b151f2ada360a435ef2dcfb666d7fe686b2845",
+    "zh:785c52c6b4724873723b77c78e66024dc7ad951eeacb44a8c0cab2dd3c0f9828",
+    "zh:8b50a307f3324c4e31813abdb08a21c666e302e4c0496d9f8015ae76327cafb4",
+    "zh:ab78cab83e7806030c1b1e4943a6edb149a901380a1a5f7bceb1a1f41098e4c5",
+    "zh:c06a7fbffbbfa7b407990091869c0642dc9e38217da2895b49b42892e86eada6",
+    "zh:e046e30e24b3b95ca8ec0ecac562ac8a47e86f9db0efa460e50c2afce07e084e",
+    "zh:ef02426419de15931bcdfb400d914d720639607415ac623c04cdf425c71ade41",
+    "zh:fb1990e9e162cf1837792e4886a4b6dcb3ffdd511d1ba4b56118127525504032",
+  ]
+}

--- a/env/scratch/lambda-api/terragrunt.hcl
+++ b/env/scratch/lambda-api/terragrunt.hcl
@@ -1,0 +1,90 @@
+dependencies {
+  paths = ["../common", "../eks", "../dns"]
+}
+
+dependency "common" {
+  config_path = "../common"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    kms_arn = ""
+    vpc_private_subnets = [
+      "",
+      "",
+      "",
+    ]
+    sns_alert_general_arn           = ""
+    sns_alert_warning_arn           = ""
+    sns_alert_critical_arn          = ""
+    s3_bucket_csv_upload_bucket_arn = ""
+    firehose_waf_logs_iam_role_arn  = ""
+    ip_blocklist_arn                = ""
+    re_api_arn                      = ""
+  }
+}
+
+dependency "eks" {
+  config_path = "../eks"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    eks-cluster-securitygroup = ""
+    eks_application_log_group = "eks_application_log_group_name"
+  }
+}
+
+dependency "dns" {
+  config_path = "../dns"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    aws_acm_notification_canada_ca_arn = ""
+  }
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  env                                    = "staging"
+  admin_base_url                         = "https://staging.notification.cdssandbox.xyz"
+  api_domain_name                        = "api.staging.notification.cdssandbox.xyz"
+  api_lambda_domain_name                 = "api-lambda.staging.notification.cdssandbox.xyz"
+  api_lambda_alt_domain_name             = "api.staging.notification.alpha.cdssandbox.xyz"
+  api_image_tag                          = "latest"
+  eks_cluster_securitygroup              = dependency.eks.outputs.eks-cluster-securitygroup
+  vpc_private_subnets                    = dependency.common.outputs.vpc_private_subnets
+  redis_enabled                          = "1"
+  low_demand_min_concurrency             = 1
+  low_demand_max_concurrency             = 5
+  high_demand_min_concurrency            = 1
+  high_demand_max_concurrency            = 10
+  csv_upload_bucket_arn                  = dependency.common.outputs.s3_bucket_csv_upload_bucket_arn
+  firehose_waf_logs_iam_role_arn         = dependency.common.outputs.firehose_waf_logs_iam_role_arn
+  new_relic_app_name                     = "notification-lambda-api-staging"
+  new_relic_distribution_tracing_enabled = "true"
+  notification_queue_prefix              = "eks-notification-canada-ca"
+  redis_enabled                          = 1
+  certificate_arn                        = dependency.dns.outputs.aws_acm_notification_canada_ca_arn
+  certificate_alt_arn                    = dependency.dns.outputs.aws_acm_alt_notification_canada_ca_arn
+  sns_alert_warning_arn                  = dependency.common.outputs.sns_alert_warning_arn
+  sns_alert_critical_arn                 = dependency.common.outputs.sns_alert_critical_arn
+  ff_cloudwatch_metrics_enabled          = "true"
+  ip_blocklist_arn                       = dependency.common.outputs.ip_blocklist_arn
+  re_api_arn                             = dependency.common.outputs.re_api_arn
+  api_waf_rate_limit                     = 5000
+  eks_application_log_group              = dependency.eks.outputs.eks_application_log_group
+}
+
+terraform {
+  source = "../../../aws//lambda-api"
+}

--- a/env/scratch/lambda-google-cidr/terragrunt.hcl
+++ b/env/scratch/lambda-google-cidr/terragrunt.hcl
@@ -1,0 +1,33 @@
+dependencies {
+  paths = ["../common", "../eks"]
+}
+
+dependency "common" {
+  config_path = "../common"
+}
+
+dependency "eks" {
+  config_path = "../eks"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["validate", "plan", "init", "fmt", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    google_cidr_prefix_list_id      = ""
+  }
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  billing_tag_value                  = "notification-canada-ca-staging"
+  google_cidr_schedule_expression    = "rate(1 day)"
+  google_cidr_prefix_list_id         = dependency.eks.outputs.google_cidr_prefix_list_id
+}
+
+terraform {
+  source = "../../../aws//lambda-google-cidr"
+}

--- a/env/scratch/performance-test/.terraform.lock.hcl
+++ b/env/scratch/performance-test/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.74.2"
+  constraints = "~> 3.0, >= 3.36.0"
+  hashes = [
+    "h1:TryIinyNf2gFkYA/d4hD0a76mPSvyl9rMUHePqs6cgs=",
+    "zh:2b1df436ec034ae9416b23b95efd192b2fe271a7c8595493329dcde8e452c036",
+    "zh:3aba9abd4bc8a904378b1f852d025a397ef74f0dbe59134a06fc5abebb259efc",
+    "zh:45700f37e3a97c5b3a8d5d2ec79ae7a8671be8893a6a6c38ae069888d13c20fe",
+    "zh:5b2ca0fde7f9b723018528ea21b151f2ada360a435ef2dcfb666d7fe686b2845",
+    "zh:785c52c6b4724873723b77c78e66024dc7ad951eeacb44a8c0cab2dd3c0f9828",
+    "zh:8b50a307f3324c4e31813abdb08a21c666e302e4c0496d9f8015ae76327cafb4",
+    "zh:ab78cab83e7806030c1b1e4943a6edb149a901380a1a5f7bceb1a1f41098e4c5",
+    "zh:c06a7fbffbbfa7b407990091869c0642dc9e38217da2895b49b42892e86eada6",
+    "zh:e046e30e24b3b95ca8ec0ecac562ac8a47e86f9db0efa460e50c2afce07e084e",
+    "zh:ef02426419de15931bcdfb400d914d720639607415ac623c04cdf425c71ade41",
+    "zh:fb1990e9e162cf1837792e4886a4b6dcb3ffdd511d1ba4b56118127525504032",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}

--- a/env/scratch/performance-test/terragrunt.hcl
+++ b/env/scratch/performance-test/terragrunt.hcl
@@ -1,0 +1,61 @@
+dependencies {
+  paths = ["../common", "../eks"]
+}
+
+dependency "common" {
+  config_path = "../common"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    vpc_id = ""
+    vpc_public_subnets = [
+      "",
+      "",
+      "",
+    ]
+    private-links-vpc-endpoints-securitygroup = ""
+    private-links-gateway-prefix-list-ids = []
+  }
+}
+
+dependency "eks" {
+  config_path = "../eks"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    eks-cluster-securitygroup = ""
+  }
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  eks_cluster_securitygroup = dependency.eks.outputs.eks-cluster-securitygroup
+  vpc_public_subnets        = dependency.common.outputs.vpc_public_subnets
+  vpc_id                    = dependency.common.outputs.vpc_id
+  aws_pinpoint_region       = "ca-central-1"
+
+  billing_tag_key                             = "CostCenter"
+  billing_tag_value                           = "notification-canada-ca-staging"
+  schedule_expression                         = "cron(0 0 * * ? *)"
+  perf_test_aws_s3_bucket                     = "notify-performance-test-results-staging"
+  perf_test_csv_directory_path                = "/tmp/notify_performance_test"
+  perf_test_sms_template_id                   = "d5fea9f3-f69d-481e-9186-b7f4eaa5cf63"
+  perf_test_bulk_email_template_id            = "fa759679-30f2-4666-94e2-bd4921329c46"
+  perf_test_email_template_id                 = "fa759679-30f2-4666-94e2-bd4921329c46"
+  perf_test_email_with_attachment_template_id = "fa759679-30f2-4666-94e2-bd4921329c46"
+  perf_test_email_with_link_template_id       = "9fb324a5-821d-4b54-9d52-d9ba1fa8373a"
+  private-links-vpc-endpoints-securitygroup   = dependency.common.outputs.private-links-vpc-endpoints-securitygroup
+  private-links-gateway-prefix-list-ids       = dependency.common.outputs.private-links-gateway-prefix-list-ids
+}
+
+terraform {
+  source = "../../../aws//performance-test"
+}

--- a/env/scratch/rds/.terraform.lock.hcl
+++ b/env/scratch/rds/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.74.2"
+  constraints = "~> 3.0, >= 3.38.0"
+  hashes = [
+    "h1:TryIinyNf2gFkYA/d4hD0a76mPSvyl9rMUHePqs6cgs=",
+    "zh:2b1df436ec034ae9416b23b95efd192b2fe271a7c8595493329dcde8e452c036",
+    "zh:3aba9abd4bc8a904378b1f852d025a397ef74f0dbe59134a06fc5abebb259efc",
+    "zh:45700f37e3a97c5b3a8d5d2ec79ae7a8671be8893a6a6c38ae069888d13c20fe",
+    "zh:5b2ca0fde7f9b723018528ea21b151f2ada360a435ef2dcfb666d7fe686b2845",
+    "zh:785c52c6b4724873723b77c78e66024dc7ad951eeacb44a8c0cab2dd3c0f9828",
+    "zh:8b50a307f3324c4e31813abdb08a21c666e302e4c0496d9f8015ae76327cafb4",
+    "zh:ab78cab83e7806030c1b1e4943a6edb149a901380a1a5f7bceb1a1f41098e4c5",
+    "zh:c06a7fbffbbfa7b407990091869c0642dc9e38217da2895b49b42892e86eada6",
+    "zh:e046e30e24b3b95ca8ec0ecac562ac8a47e86f9db0efa460e50c2afce07e084e",
+    "zh:ef02426419de15931bcdfb400d914d720639607415ac623c04cdf425c71ade41",
+    "zh:fb1990e9e162cf1837792e4886a4b6dcb3ffdd511d1ba4b56118127525504032",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.1.0"
+  hashes = [
+    "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}

--- a/env/scratch/rds/terragrunt.hcl
+++ b/env/scratch/rds/terragrunt.hcl
@@ -1,0 +1,48 @@
+dependencies {
+  paths = ["../common", "../eks"]
+}
+
+dependency "common" {
+  config_path = "../common"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["validate"]
+  mock_outputs = {
+    kms_arn = ""
+    vpc_private_subnets = [
+      "subnet-001e585d12cce4d1e",
+      "subnet-08de34a9e1a7458dc",
+      "subnet-0af8b8402f1d605ff",
+    ]
+    sns_alert_general_arn = ""
+  }
+}
+
+dependency "eks" {
+  config_path = "../eks"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["validate"]
+  mock_outputs = {
+    eks-cluster-securitygroup = "sg-0e2c3ef6c5c75b74c"
+  }
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  eks_cluster_securitygroup = dependency.eks.outputs.eks-cluster-securitygroup
+  kms_arn                   = dependency.common.outputs.kms_arn
+  rds_instance_count        = 3
+  rds_instance_type         = "db.r6g.large"
+  vpc_private_subnets       = dependency.common.outputs.vpc_private_subnets
+  sns_alert_general_arn     = dependency.common.outputs.sns_alert_general_arn
+}
+
+terraform {
+  source = "../../../aws//rds"
+}

--- a/env/scratch/ses_receiving_emails/terragrunt.hcl
+++ b/env/scratch/ses_receiving_emails/terragrunt.hcl
@@ -1,0 +1,58 @@
+dependencies {
+  paths = ["../common"]
+}
+
+dependency "common" {
+  config_path = "../common"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    sns_alert_warning_arn_us_east_1 = ""
+    sns_alert_critical_arn_us_east_1 = ""
+    sns_alert_ok_arn_us_east_1 = ""
+    sqs_notify_internal_tasks_arn = ""
+  }
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  billing_tag_value                       = "notification-canada-ca-staging"
+  schedule_expression                     = "rate(1 minute)"
+  sns_alert_warning_arn_us_east_1         = dependency.common.outputs.sns_alert_warning_arn_us_east_1
+  sns_alert_critical_arn_us_east_1        = dependency.common.outputs.sns_alert_critical_arn_us_east_1
+  sns_alert_ok_arn_us_east_1              = dependency.common.outputs.sns_alert_ok_arn_us_east_1
+  notify_sending_domain                   = "staging.notification.cdssandbox.xyz"
+  sqs_region                              = "ca-central-1"
+  celery_queue_prefix                     = "eks-notification-canada-ca"
+  gc_notify_service_email                 = "gc.notify.notification.gc@staging.notification.cdssandbox.xyz"
+  sqs_notify_internal_tasks_arn           = dependency.common.outputs.sqs_notify_internal_tasks_arn
+}
+
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite"
+  contents  = <<EOF
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+provider "aws" {
+  region              = "us-east-1"
+  allowed_account_ids = [var.account_id]
+}
+EOF
+}
+
+terraform {
+  source = "../../../aws//ses_receiving_emails"
+}

--- a/env/scratch/ses_to_sqs_email_callbacks/terragrunt.hcl
+++ b/env/scratch/ses_to_sqs_email_callbacks/terragrunt.hcl
@@ -1,0 +1,34 @@
+dependencies {
+  paths = ["../common"]
+}
+
+dependency "common" {
+  config_path = "../common"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    notification_canada_ca_ses_callback_arn = ""
+    sns_alert_warning_arn          = ""
+    sns_alert_critical_arn         = ""
+    sns_alert_ok_arn               = ""
+  }
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  billing_tag_value                       = "notification-canada-ca-staging"
+  notification_canada_ca_ses_callback_arn = dependency.common.outputs.notification_canada_ca_ses_callback_arn
+  sns_alert_warning_arn                   = dependency.common.outputs.sns_alert_warning_arn
+  sns_alert_critical_arn                  = dependency.common.outputs.sns_alert_critical_arn
+  sns_alert_ok_arn                        = dependency.common.outputs.sns_alert_ok_arn
+}
+
+terraform {
+  source = "../../../aws//ses_to_sqs_email_callbacks"
+}

--- a/env/scratch/sns_to_sqs_sms_callbacks/terragrunt.hcl
+++ b/env/scratch/sns_to_sqs_sms_callbacks/terragrunt.hcl
@@ -1,0 +1,48 @@
+dependencies {
+  paths = ["../common"]
+}
+
+dependency "common" {
+  config_path = "../common"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    sns_deliveries_ca_central_arn           = "arn:aws:logs:ca-central-1:111111111111:log-group:sns/ca-central-1/111111111111/DirectPublishToPhoneNumber"
+    sns_deliveries_ca_central_name          = ""
+    sns_deliveries_failures_ca_central_arn  = "arn:aws:logs:ca-central-1:111111111111:log-group:sns/ca-central-1/111111111111/DirectPublishToPhoneNumber/Failure"
+    sns_deliveries_failures_ca_central_name = ""
+    sns_deliveries_us_west_2_arn            = "arn:aws:logs:us-west-2:111111111111:log-group:sns/us-west-2/111111111111/DirectPublishToPhoneNumber"
+    sns_deliveries_us_west_2_name           = ""
+    sns_deliveries_failures_us_west_2_arn   = "arn:aws:logs:us-west-2:111111111111:log-group:sns/us-west-2/111111111111/DirectPublishToPhoneNumber/Failure"
+    sns_deliveries_failures_us_west_2_name  = ""
+    sns_alert_warning_arn                   = ""
+    sns_alert_critical_arn                  = ""
+    sns_alert_ok_arn                        = ""
+  }
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  billing_tag_value                        = "notification-canada-ca-staging"
+  sns_deliveries_ca_central_arn            = dependency.common.outputs.sns_deliveries_ca_central_arn
+  sns_deliveries_ca_central_name           = dependency.common.outputs.sns_deliveries_ca_central_name
+  sns_deliveries_failures_ca_central_arn   = dependency.common.outputs.sns_deliveries_failures_ca_central_arn
+  sns_deliveries_failures_ca_central_name  = dependency.common.outputs.sns_deliveries_failures_ca_central_name
+  sns_deliveries_us_west_2_arn             = dependency.common.outputs.sns_deliveries_us_west_2_arn
+  sns_deliveries_us_west_2_name            = dependency.common.outputs.sns_deliveries_us_west_2_name
+  sns_deliveries_failures_us_west_2_arn    = dependency.common.outputs.sns_deliveries_failures_us_west_2_arn
+  sns_deliveries_failures_us_west_2_name   = dependency.common.outputs.sns_deliveries_failures_us_west_2_name
+  sns_alert_warning_arn                    = dependency.common.outputs.sns_alert_warning_arn
+  sns_alert_critical_arn                   = dependency.common.outputs.sns_alert_critical_arn
+  sns_alert_ok_arn                         = dependency.common.outputs.sns_alert_ok_arn
+}
+
+terraform {
+  source = "../../../aws//sns_to_sqs_sms_callbacks"
+}


### PR DESCRIPTION
# Summary | Résumé

This is the baseline terragrunt config for the scratch environment. At this point, it is a straight copy of staging. In further PRs I will be updating it to reflect scratch.

# Test instructions | Instructions pour tester la modification
 N/A
