### PR TITLE
Drop '%' character from metric patterns

### DIFF
--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -60,7 +60,7 @@ resource "aws_cloudwatch_log_metric_filter" "scanfiles-timeout" {
 
 resource "aws_cloudwatch_log_metric_filter" "bounce-rate-critical" {
   name           = "bounce-rate-critical"
-  pattern        = "critical bounce rate threshold of 10%"
+  pattern        = "critical bounce rate threshold of 10"
   log_group_name = local.eks_application_log_group
 
   metric_transformation {
@@ -72,7 +72,7 @@ resource "aws_cloudwatch_log_metric_filter" "bounce-rate-critical" {
 
 resource "aws_cloudwatch_log_metric_filter" "bounce-rate-warning" {
   name           = "bounce-rate-warning"
-  pattern        = "warning bounce rate threshold of 5%"
+  pattern        = "warning bounce rate threshold of 5"
   log_group_name = local.eks_application_log_group
 
   metric_transformation {

--- a/aws/eks/cloudwatch_queries.tf
+++ b/aws/eks/cloudwatch_queries.tf
@@ -40,7 +40,7 @@ resource "aws_cloudwatch_query_definition" "bounce-rate-critical" {
   query_string = <<QUERY
 fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as pod_name, @logStream
 | filter kubernetes.container_name like /admin|api/
-| filter @message like "critical bounce rate threshold of 10%"
+| filter @message like "critical bounce rate threshold of 10"
 | sort @timestamp desc
 | limit 20
 QUERY
@@ -56,7 +56,7 @@ resource "aws_cloudwatch_query_definition" "bounce-rate-warning" {
   query_string = <<QUERY
 fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as pod_name, @logStream
 | filter kubernetes.container_name like /admin|api/
-| filter @message like "warning bounce rate threshold of 5%"
+| filter @message like "warning bounce rate threshold of 5"
 | sort @timestamp desc
 | limit 20
 QUERY


### PR DESCRIPTION
# Summary | Résumé
Quick fix to the bounce rate alarm metric patterns.
