### PR TITLE
Use the minimum stat for unavail celery replicas

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -443,7 +443,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-replicas-unavailable" {
       metric_name = "kube_deployment_status_replicas_unavailable"
       namespace   = "ContainerInsights/Prometheus"
       period      = 300
-      stat        = "Average"
+      stat        = "Minimum"
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace


### PR DESCRIPTION
# Summary | Résumé

The celery unavail replicas alarm is too sensitive with `average` statistic and for a 5 minutes period. Switching to `minimum` that will enforce a longer period of time to be valid in order to trigger the alarm.

# Test instructions | Instructions pour tester la modification

* Trigger a failed Celery deployment in staging environment once deployed and see if/how the alarm triggers.