### PR TITLE
Enabling redis cluster logs

### DIFF
--- a/aws/elasticache/cloudwatch_log.tf
+++ b/aws/elasticache/cloudwatch_log.tf
@@ -1,9 +1,9 @@
 resource "aws_cloudwatch_log_group" "notification-canada-ca-elasticache-slow-logs" {
   name              = "/aws/elasticache/notify-${var.env}-cluster-cache-az/slow-logs"
-  retention_in_days = 14
+  retention_in_days = 90
 }
 
 resource "aws_cloudwatch_log_group" "notification-canada-ca-elasticache-engine-logs" {
   name              = "/aws/elasticache/notify-${var.env}-cluster-cache-az/engine-logs"
-  retention_in_days = 14
+  retention_in_days = 90
 }

--- a/aws/elasticache/cloudwatch_log.tf
+++ b/aws/elasticache/cloudwatch_log.tf
@@ -1,0 +1,9 @@
+resource "aws_cloudwatch_log_group" "notification-canada-ca-elasticache-slow-logs" {
+  name              = "/aws/elasticache/notify-${var.env}-cluster-cache-az/slow-logs"
+  retention_in_days = 14
+}
+
+resource "aws_cloudwatch_log_group" "notification-canada-ca-elasticache-engine-logs" {
+  name              = "/aws/elasticache/notify-${var.env}-cluster-cache-az/engine-logs"
+  retention_in_days = 14
+}

--- a/aws/elasticache/elasticache.tf
+++ b/aws/elasticache/elasticache.tf
@@ -33,6 +33,20 @@ resource "aws_elasticache_replication_group" "notification-cluster-cache-multiaz
   security_group_ids = local.cluster_security_group_ids
   subnet_group_name  = aws_elasticache_subnet_group.notification-canada-ca-cache-subnet.name
 
+  log_delivery_configuration {
+    destination      = aws_cloudwatch_log_group.notification-canada-ca-elasticache-slow-logs.name
+    destination_type = "cloudwatch-logs"
+    log_format       = "json"
+    log_type         = "slow-log"
+  }
+
+  log_delivery_configuration {
+    destination      = aws_cloudwatch_log_group.notification-canada-ca-elasticache-engine-logs.name
+    destination_type = "cloudwatch-logs"
+    log_format       = "json"
+    log_type         = "engine-log"
+  }
+
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
   }


### PR DESCRIPTION
# Summary | Résumé

Enabling elasticache logs for redis cluster.
---

# Test instructions | Instructions pour tester la modification

* Check that new log groups are created and receiving events after deployment in staging
