### PR TITLE
Switching IAM role accountID to always be staging

### DIFF
--- a/env/production/env_vars.hcl
+++ b/env/production/env_vars.hcl
@@ -3,4 +3,5 @@ inputs = {
   domain     = "notification.canada.ca"
   alt_domain = "notification.alpha.canada.ca"
   env        = "production"
+  staging_account_id = "239043911459"
 }

--- a/env/scratch/env_vars.hcl
+++ b/env/scratch/env_vars.hcl
@@ -3,4 +3,5 @@ inputs = {
   domain     = "scratch.notification.cdssandbox.xyz"
   alt_domain = "scratch.notification.alpha.cdssandbox.xyz"
   env        = "scratch"
+  staging_account_id = "239043911459"
 }

--- a/env/staging/env_vars.hcl
+++ b/env/staging/env_vars.hcl
@@ -3,4 +3,5 @@ inputs = {
   domain     = "staging.notification.cdssandbox.xyz"
   alt_domain = "staging.notification.alpha.cdssandbox.xyz"
   env        = "staging"
+  staging_account_id = "239043911459"
 }

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -3,11 +3,12 @@ locals {
 }
 
 inputs = {
-  account_id = "${local.vars.inputs.account_id}"
-  domain     = "${local.vars.inputs.domain}"
-  alt_domain = "${local.vars.inputs.alt_domain}"
-  env        = "${local.vars.inputs.env}"
-  region     = "ca-central-1"
+  account_id         = "${local.vars.inputs.account_id}"
+  domain             = "${local.vars.inputs.domain}"
+  alt_domain         = "${local.vars.inputs.alt_domain}"
+  env                = "${local.vars.inputs.env}"
+  staging_account_id = "${local.vars.inputs.staging_account_id}"
+  region             = "ca-central-1"
   # See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-logging-bucket-permissions
   elb_account_ids = {
     "ca-central-1" = "985666609251"
@@ -50,7 +51,7 @@ provider "aws" {
   alias  = "staging"
   region = "ca-central-1"
   assume_role {
-    role_arn = "arn:aws:iam::${local.vars.inputs.account_id}:role/${local.vars.inputs.env}_dns_manager_role"
+    role_arn = "arn:aws:iam::${local.vars.inputs.staging_account_id}:role/${local.vars.inputs.env}_dns_manager_role"
   }
 }
 EOF


### PR DESCRIPTION
# Summary | Résumé

I had erroneously assigned the current account id to the Assume role configuration of the staging provider, when in fact it always needs to be staging. I've added a new variable called staging_account_id that is now present across all environments and is used for the role assumption.

# Test instructions | Instructions pour tester la modification

Terragrunt plan in any environment