### PR TITLE
Re-enabling ACM validation for staging

### DIFF
--- a/aws/cloudfront/acm.tf
+++ b/aws/cloudfront/acm.tf
@@ -26,10 +26,8 @@ resource "aws_route53_record" "assets-notification-canada-ca" {
 }
 
 
-/*
 resource "aws_acm_certificate_validation" "assets-notification-canada-ca" {
   count                   = var.env != "production" ? 1 : 0
   certificate_arn         = aws_acm_certificate.assets-notification-canada-ca.arn
   validation_record_fqdns = [aws_route53_record.assets-notification-canada-ca[0].fqdn]
 }
-*/

--- a/aws/eks/acm.tf
+++ b/aws/eks/acm.tf
@@ -49,14 +49,14 @@ resource "aws_route53_record" "notification-canada-ca" {
   zone_id         = var.route_53_zone_arn
   ttl             = 60
 }
-/*
+
 resource "aws_acm_certificate_validation" "notification-canada-ca" {
   count = var.env != "production" ? 1 : 0
 
   certificate_arn         = aws_acm_certificate.notification-canada-ca.arn
   validation_record_fqdns = [aws_route53_record.notification-canada-ca[0].fqdn]
 }
-*/
+
 resource "aws_route53_record" "notification-canada-ca-alt" {
   count    = var.env != "production" ? 1 : 0
   provider = aws.staging
@@ -68,7 +68,6 @@ resource "aws_route53_record" "notification-canada-ca-alt" {
   zone_id         = var.route_53_zone_arn
   ttl             = 60
 }
-/*
 
 resource "aws_acm_certificate_validation" "notification-canada-ca-alt" {
   count = var.env != "production" ? 1 : 0
@@ -76,4 +75,3 @@ resource "aws_acm_certificate_validation" "notification-canada-ca-alt" {
   certificate_arn         = aws_acm_certificate.notification-canada-ca-alt[0].arn
   validation_record_fqdns = [aws_route53_record.notification-canada-ca-alt[0].fqdn]
 }
-*/


### PR DESCRIPTION
# Summary | Résumé

* Re-enabling ACM certificate validation for staging after staging DNS migration.

# Test instructions | Instructions pour tester la modification

Terragrunt apply in staging