### PR TITLE
Custom domain mx record

### DIFF
--- a/aws/dns/staging.notification.cdssandbox.xyz.tf
+++ b/aws/dns/staging.notification.cdssandbox.xyz.tf
@@ -118,6 +118,15 @@ resource "aws_route53_record" "bounce-staging-notification-sandbox-MX" {
   records = ["10 feedback-smtp.ca-central-1.amazonses.com"]
 }
 
+resource "aws_route53_record" "bounce-staging-custom-notification-sandbox-MX" {
+  count   = var.env == "staging" ? 1 : 0
+  zone_id = aws_route53_zone.notification-sandbox[0].zone_id
+  name    = "bounce.custom-sending-domain.staging.notification.cdssandbox.xyz"
+  type    = "MX"
+  ttl     = "300"
+  records = ["10 feedback-smtp.ca-central-1.amazonses.com"]
+}
+
 resource "aws_route53_record" "bounce-staging-notification-sandbox-TXT" {
   count   = var.env == "staging" ? 1 : 0
   zone_id = aws_route53_zone.notification-sandbox[0].zone_id


### PR DESCRIPTION
# Summary | Résumé

After migrating to the new notify managed staging DNS, we get a warning notice from AWS saying that the custom-domain MX record was missing from notify, and was required for SES. I am adding it back here.

# Test instructions | Instructions pour tester la modification

[ ] Terragrunt Apply in staging
[ ] MX Record shows up in notify sandbox DNS