### PR TITLE
ACM Validation and EKS Build Fixes

### DIFF
--- a/aws/cloudfront/acm.tf
+++ b/aws/cloudfront/acm.tf
@@ -26,10 +26,11 @@ resource "aws_route53_record" "assets-notification-canada-ca" {
 }
 
 
-/*
+
 resource "aws_acm_certificate_validation" "assets-notification-canada-ca" {
   count                   = var.env != "production" ? 1 : 0
+  provider                = aws.us-east-1
   certificate_arn         = aws_acm_certificate.assets-notification-canada-ca.arn
   validation_record_fqdns = [aws_route53_record.assets-notification-canada-ca[0].fqdn]
 }
-*/
+

--- a/aws/cloudfront/dns.tf
+++ b/aws/cloudfront/dns.tf
@@ -1,9 +1,10 @@
 resource "aws_route53_record" "assets-notification-CNAME" {
   count = var.env != "production" ? 1 : 0
 
-  zone_id = var.route_53_zone_arn
-  name    = "assets.${var.domain}"
-  type    = "CNAME"
-  ttl     = "300"
-  records = [aws_cloudfront_distribution.asset_bucket.domain_name]
+  provider = aws.staging
+  zone_id  = var.route_53_zone_arn
+  name     = "assets.${var.domain}"
+  type     = "CNAME"
+  ttl      = "300"
+  records  = [aws_cloudfront_distribution.asset_bucket.domain_name]
 }

--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -137,3 +137,7 @@ output "sns_deliveries_failures_us_west_2_name" {
 output "sqs_notify_internal_tasks_arn" {
   value = aws_sqs_queue.notify_internal_tasks_queue.arn
 }
+
+output "cbs_satellite_bucket_name" {
+  value = var.create_cbs_bucket ? var.cbs_satellite_bucket_name : ""
+}

--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -419,9 +419,11 @@ module "cbs_logs_bucket" {
   source = "github.com/cds-snc/terraform-modules?ref=v5.1.8//S3_log_bucket"
   count  = var.create_cbs_bucket ? 1 : 0
 
-  bucket_name       = var.cbs_satellite_bucket_name
-  force_destroy     = var.force_destroy_s3
-  billing_tag_value = "notification-canada-ca-${var.env}"
+  bucket_name                    = var.cbs_satellite_bucket_name
+  force_destroy                  = var.force_destroy_s3
+  billing_tag_value              = "notification-canada-ca-${var.env}"
+  attach_lb_log_delivery_policy  = true
+  attach_elb_log_delivery_policy = true
 
   lifecycle_rule = { "lifecycle_rule" : { "enabled" : "true", "expiration" : { "days" : "90" } } }
 

--- a/aws/dns/scratch.notification.cdssandbox.xyz.tf
+++ b/aws/dns/scratch.notification.cdssandbox.xyz.tf
@@ -1,0 +1,79 @@
+# MX Records - To Be Automated
+
+resource "aws_route53_record" "scratch-notification-sandbox-MX" {
+  count    = var.env == "scratch" ? 1 : 0
+  provider = aws.staging
+  zone_id  = var.route53_zone_arn
+  name     = var.domain
+  type     = "MX"
+  ttl      = "300"
+  records  = ["10 inbound-smtp.us-east-1.amazonaws.com"]
+}
+
+resource "aws_route53_record" "bounce-scratch-notification-sandbox-MX" {
+  count    = var.env == "scratch" ? 1 : 0
+  provider = aws.staging
+  zone_id  = var.route53_zone_arn
+  name     = "bounce.${var.domain}"
+  type     = "MX"
+  ttl      = "300"
+  records  = ["10 feedback-smtp.ca-central-1.amazonses.com"]
+}
+
+resource "aws_route53_record" "bounce-scratch-custom-notification-sandbox-MX" {
+  count    = var.env == "scratch" ? 1 : 0
+  provider = aws.staging
+  zone_id  = var.route53_zone_arn
+  name     = "bounce.custom-sending-domain.${var.domain}"
+  type     = "MX"
+  ttl      = "300"
+  records  = ["10 feedback-smtp.ca-central-1.amazonses.com"]
+}
+
+# SES TXT Record - To Be Automated
+
+resource "aws_route53_record" "ses-scratch-notification-sandbox-TXT" {
+  count    = var.env == "scratch" ? 1 : 0
+  provider = aws.staging
+  zone_id  = var.route53_zone_arn
+  name     = "_amazonses.${var.domain}"
+  type     = "TXT"
+  ttl      = "300"
+  records = ["vJFwJM0wnPRWKFXsoiVl9/gLXFP4RL5Xfl4C9JTp3VI=",
+    "AwTGEoIByR4QGirawhDmRdJmxFO/U0fX3NMrSOJpuI4="
+  ]
+}
+
+resource "aws_route53_record" "dmarc-scratch-notification-sandbox-TXT" {
+  count    = var.env == "scratch" ? 1 : 0
+  provider = aws.staging
+  zone_id  = var.route53_zone_arn
+  name     = "_dmarc.${var.domain}"
+  type     = "TXT"
+  ttl      = "300"
+  records  = ["v=DMARC1; p=reject; sp=reject; pct=100; rua=mailto:dmarc@cyber.gc.ca; ruf=mailto:dmarc@cyber.gc.ca"]
+}
+
+# Google Site Verification
+
+resource "aws_route53_record" "scratch-notification-sandbox-TXT" {
+  count    = var.env == "scratch" ? 1 : 0
+  provider = aws.staging
+  zone_id  = var.route53_zone_arn
+  name     = var.domain
+  type     = "TXT"
+  ttl      = "300"
+  records = ["v=spf1 include:amazonses.com ~all",
+    "google-site-verification=u0zkO-jbYi1qW2G65mfXbuNl14BCO1O9uk-BV2wTlD8"
+  ]
+}
+
+resource "aws_route53_record" "bounce-scratch-notification-sandbox-TXT" {
+  count    = var.env == "scratch" ? 1 : 0
+  provider = aws.staging
+  zone_id  = var.route53_zone_arn
+  name     = "bounce.${var.domain}"
+  type     = "TXT"
+  ttl      = "300"
+  records  = ["v=spf1 include:amazonses.com ~all"]
+}

--- a/aws/dns/ses.tf
+++ b/aws/dns/ses.tf
@@ -6,6 +6,8 @@ resource "aws_ses_domain_dkim" "notification-canada-ca" {
   domain = var.domain
 }
 
+# TODO: SES Domain Validation Records Programmatically
+
 resource "aws_ses_identity_notification_topic" "notification-canada-ca-bounce-topic" {
   topic_arn                = var.notification_canada_ca_ses_callback_arn
   notification_type        = "Bounce"

--- a/aws/dns/staging.notification.cdssandbox.xyz.tf
+++ b/aws/dns/staging.notification.cdssandbox.xyz.tf
@@ -118,6 +118,15 @@ resource "aws_route53_record" "bounce-staging-notification-sandbox-MX" {
   records = ["10 feedback-smtp.ca-central-1.amazonses.com"]
 }
 
+resource "aws_route53_record" "bounce-staging-custom-notification-sandbox-MX" {
+  count   = var.env == "staging" ? 1 : 0
+  zone_id = aws_route53_zone.notification-sandbox[0].zone_id
+  name    = "bounce.custom-sending-domain.staging.notification.cdssandbox.xyz"
+  type    = "MX"
+  ttl     = "300"
+  records = ["10 feedback-smtp.ca-central-1.amazonses.com"]
+}
+
 resource "aws_route53_record" "bounce-staging-notification-sandbox-TXT" {
   count   = var.env == "staging" ? 1 : 0
   zone_id = aws_route53_zone.notification-sandbox[0].zone_id

--- a/aws/dns/variables.tf
+++ b/aws/dns/variables.tf
@@ -15,3 +15,9 @@ variable "scratch_account_ids" {
   description = "Used by staging DNS zone to set up cross account IAM"
   default     = "\"AWS\": \"419291849580\", \"AWS\": \"239043911459\", \"AWS\": \"296255494825\""
 }
+
+variable "route53_zone_arn" {
+  type        = string
+  description = "Used in non-staging environments to provide the DNS Zone ARN"
+  default     = ""
+}

--- a/aws/eks/acm.tf
+++ b/aws/eks/acm.tf
@@ -39,41 +39,60 @@ resource "aws_acm_certificate" "notification-canada-ca-alt" {
 }
 
 resource "aws_route53_record" "notification-canada-ca" {
-  count    = var.env != "production" ? 1 : 0
+
   provider = aws.staging
 
+  for_each = {
+    for dvo in aws_acm_certificate.notification-canada-ca.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
   allow_overwrite = true
-  name            = tolist(aws_acm_certificate.notification-canada-ca.domain_validation_options)[0].resource_record_name
-  records         = [tolist(aws_acm_certificate.notification-canada-ca.domain_validation_options)[0].resource_record_value]
-  type            = tolist(aws_acm_certificate.notification-canada-ca.domain_validation_options)[0].resource_record_type
-  zone_id         = var.route_53_zone_arn
+  name            = each.value.name
+  records         = [each.value.record]
+  type            = each.value.type
   ttl             = 60
+  zone_id         = var.route_53_zone_arn
+
 }
-/*
+
 resource "aws_acm_certificate_validation" "notification-canada-ca" {
-  count = var.env != "production" ? 1 : 0
+
+  depends_on = [aws_route53_record.notification-canada-ca]
 
   certificate_arn         = aws_acm_certificate.notification-canada-ca.arn
-  validation_record_fqdns = [aws_route53_record.notification-canada-ca[0].fqdn]
+  validation_record_fqdns = [for record in aws_route53_record.notification-canada-ca : record.fqdn]
+
 }
-*/
+
 resource "aws_route53_record" "notification-canada-ca-alt" {
-  count    = var.env != "production" ? 1 : 0
+
   provider = aws.staging
 
+  for_each = {
+    for dvo in aws_acm_certificate.notification-canada-ca-alt[0].domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
   allow_overwrite = true
-  name            = tolist(aws_acm_certificate.notification-canada-ca-alt[0].domain_validation_options)[0].resource_record_name
-  records         = [tolist(aws_acm_certificate.notification-canada-ca-alt[0].domain_validation_options)[0].resource_record_value]
-  type            = tolist(aws_acm_certificate.notification-canada-ca-alt[0].domain_validation_options)[0].resource_record_type
-  zone_id         = var.route_53_zone_arn
+  name            = each.value.name
+  records         = [each.value.record]
+  type            = each.value.type
   ttl             = 60
+  zone_id         = var.route_53_zone_arn
+
 }
-/*
 
 resource "aws_acm_certificate_validation" "notification-canada-ca-alt" {
-  count = var.env != "production" ? 1 : 0
+
+  depends_on = [aws_route53_record.notification-canada-ca-alt]
 
   certificate_arn         = aws_acm_certificate.notification-canada-ca-alt[0].arn
-  validation_record_fqdns = [aws_route53_record.notification-canada-ca-alt[0].fqdn]
+  validation_record_fqdns = [for record in aws_route53_record.notification-canada-ca-alt : record.fqdn]
 }
-*/

--- a/aws/eks/alb.tf
+++ b/aws/eks/alb.tf
@@ -18,7 +18,7 @@ resource "aws_alb" "notification-canada-ca" {
     enabled = true
   }
 
-  enable_deletion_protection = true
+  enable_deletion_protection = var.enable_delete_protection
 
   tags = {
     Name       = "notification-canada-ca"
@@ -27,6 +27,9 @@ resource "aws_alb" "notification-canada-ca" {
 }
 
 resource "aws_alb_listener" "notification-canada-ca" {
+
+  depends_on = [aws_acm_certificate_validation.notification-canada-ca, aws_acm_certificate_validation.notification-canada-ca-alt]
+
   load_balancer_arn = aws_alb.notification-canada-ca.id
   port              = 443
   protocol          = "HTTPS"

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -7,13 +7,19 @@ resource "aws_cloudwatch_log_group" "notification-canada-ca-eks-cluster-logs" {
   retention_in_days = 14
 }
 
+resource "aws_cloudwatch_log_group" "notification-canada-ca-eks-application-logs" {
+  name              = "/aws/containerinsights/${var.eks_cluster_name}/application"
+  retention_in_days = 14
+}
+
+
 ###
 # AWS EKS Cloudwatch log metric filters
 ###
 resource "aws_cloudwatch_log_metric_filter" "web-500-errors" {
   name           = "web-500-errors"
   pattern        = "\"\\\" 500 \""
-  log_group_name = local.eks_application_log_group
+  log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs.name
 
   metric_transformation {
     name      = "500-errors"
@@ -25,7 +31,7 @@ resource "aws_cloudwatch_log_metric_filter" "web-500-errors" {
 resource "aws_cloudwatch_log_metric_filter" "celery-error" {
   name           = "celery-error"
   pattern        = "?\"ERROR/Worker\" ?\"ERROR/ForkPoolWorker\" ?\"WorkerLostError\""
-  log_group_name = local.eks_application_log_group
+  log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs.name
 
   metric_transformation {
     name      = "celery-error"
@@ -37,7 +43,7 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error" {
 resource "aws_cloudwatch_log_metric_filter" "malware-detected" {
   name           = "malware-detected"
   pattern        = jsonencode("Malicious content detected! Download and attachment failed")
-  log_group_name = local.eks_application_log_group
+  log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs.name
 
   metric_transformation {
     name      = "malware-detected"
@@ -49,7 +55,7 @@ resource "aws_cloudwatch_log_metric_filter" "malware-detected" {
 resource "aws_cloudwatch_log_metric_filter" "scanfiles-timeout" {
   name           = "scanfiles-timeout"
   pattern        = "Malware scan timed out for notification.id"
-  log_group_name = local.eks_application_log_group
+  log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs.name
 
   metric_transformation {
     name      = "scanfiles-timeout"
@@ -61,7 +67,7 @@ resource "aws_cloudwatch_log_metric_filter" "scanfiles-timeout" {
 resource "aws_cloudwatch_log_metric_filter" "bounce-rate-critical" {
   name           = "bounce-rate-critical"
   pattern        = "critical bounce rate threshold of 10"
-  log_group_name = local.eks_application_log_group
+  log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs.name
 
   metric_transformation {
     name      = "bounce-rate-critical"
@@ -73,7 +79,7 @@ resource "aws_cloudwatch_log_metric_filter" "bounce-rate-critical" {
 resource "aws_cloudwatch_log_metric_filter" "bounce-rate-warning" {
   name           = "bounce-rate-warning"
   pattern        = "warning bounce rate threshold of 5"
-  log_group_name = local.eks_application_log_group
+  log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs.name
 
   metric_transformation {
     name      = "bounce-rate-warning"

--- a/aws/eks/dns.tf
+++ b/aws/eks/dns.tf
@@ -1,8 +1,9 @@
 resource "aws_route53_record" "notification-root" {
-  count   = var.env != "production" ? 1 : 0
-  zone_id = var.route_53_zone_arn
-  name    = var.domain
-  type    = "A"
+  count    = var.env != "production" ? 1 : 0
+  provider = aws.staging
+  zone_id  = var.route_53_zone_arn
+  name     = var.domain
+  type     = "A"
 
   alias {
     name                   = aws_alb.notification-canada-ca.dns_name
@@ -12,10 +13,11 @@ resource "aws_route53_record" "notification-root" {
 }
 
 resource "aws_route53_record" "notificatio-root-WC" {
-  count   = var.env != "production" ? 1 : 0
-  name    = "*.${var.domain}"
-  zone_id = var.route_53_zone_arn
-  type    = "A"
+  count    = var.env != "production" ? 1 : 0
+  provider = aws.staging
+  name     = "*.${var.domain}"
+  zone_id  = var.route_53_zone_arn
+  type     = "A"
 
   alias {
     name                   = aws_alb.notification-canada-ca.dns_name
@@ -23,4 +25,34 @@ resource "aws_route53_record" "notificatio-root-WC" {
     evaluate_target_health = false
   }
 
+}
+
+resource "aws_route53_record" "api-k8s-scratch-notification-sandbox-CNAME" {
+  count    = var.env != "production" ? 1 : 0
+  provider = aws.staging
+  zone_id  = var.route_53_zone_arn
+  name     = "api-k8s.${var.domain}"
+  type     = "CNAME"
+  ttl      = "60"
+  records  = [aws_alb.notification-canada-ca.dns_name]
+}
+
+resource "aws_route53_record" "api-weighted-0-scratch-notification-sandbox-A" {
+  # Send no API traffic to K8s
+  count          = var.env != "production" ? 1 : 0
+  provider       = aws.staging
+  zone_id        = var.route_53_zone_arn
+  name           = "api.${var.domain}"
+  type           = "A"
+  set_identifier = "loadbalancer"
+
+  alias {
+    name                   = aws_alb.notification-canada-ca.dns_name
+    zone_id                = aws_alb.notification-canada-ca.zone_id
+    evaluate_target_health = false
+  }
+
+  weighted_routing_policy {
+    weight = 0
+  }
 }

--- a/aws/eks/securitygroups.tf
+++ b/aws/eks/securitygroups.tf
@@ -131,7 +131,7 @@ resource "aws_security_group_rule" "notification-canada-ca-alb-quicksight-ingres
 resource "aws_ec2_managed_prefix_list" "google_cidrs" {
   name           = "Google Service CIDRs"
   address_family = "IPv4"
-  max_entries    = 100
+  max_entries    = var.env != "production" ? 20 : 100
 
   tags = {
     CostCentre = "notification-canada-ca-${var.env}"

--- a/aws/eks/sentinel.tf
+++ b/aws/eks/sentinel.tf
@@ -7,6 +7,7 @@ locals {
 # see https://github.com/cds-snc/terraform-modules/issues/203 
 # and https://docs.google.com/document/d/16LLelZ7WEKrnbocrl0Az74JqkCv5DBZ9QILRBUFJQt8/edit#heading=h.z87ipkd84djw
 module "sentinel_forwarder" {
+  count             = var.enable_sentinel_forwarding ? 1 : 0
   source            = "github.com/cds-snc/terraform-modules?ref=v4.0.2//sentinel_forwarder"
   function_name     = "sentinel-cloud-watch-forwarder"
   billing_tag_value = "notification-canada-ca-${var.env}"
@@ -21,18 +22,20 @@ module "sentinel_forwarder" {
 
 
 resource "aws_cloudwatch_log_subscription_filter" "admin_api_request" {
+  count           = var.enable_sentinel_forwarding ? 1 : 0
   name            = "Admin API request"
   log_group_name  = local.eks_application_log_group
   filter_pattern  = "Admin API request"
-  destination_arn = module.sentinel_forwarder.lambda_arn
+  destination_arn = module.sentinel_forwarder[0].lambda_arn
   distribution    = "Random"
 }
 
 
 resource "aws_cloudwatch_log_subscription_filter" "blazer_logging" {
+  count           = var.enable_sentinel_forwarding ? 1 : 0
   name            = "Blazer logging"
   log_group_name  = "blazer"
   filter_pattern  = "Audit "
-  destination_arn = module.sentinel_forwarder.lambda_arn
+  destination_arn = module.sentinel_forwarder[0].lambda_arn
   distribution    = "Random"
 }

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -158,3 +158,14 @@ variable "route_53_zone_arn" {
   description = "Used by the scratch environment to reference cdssandbox in staging"
   default     = "/hostedzone/Z04028033PLSHVOO9ZJ1Z"
 }
+
+variable "enable_sentinel_forwarding" {
+  type        = bool
+  description = "Flag to enable or disable log forwarding to sentinel."
+  default     = true
+}
+variable "enable_delete_protection" {
+  type        = bool
+  description = "Flag to enable or disable delete protection on resources."
+  default     = true
+}

--- a/aws/lambda-api/dns.tf
+++ b/aws/lambda-api/dns.tf
@@ -1,0 +1,32 @@
+resource "aws_route53_record" "api-lambda-scratch-notification-sandbox-A" {
+  count   = var.env == "scratch" ? 1 : 0
+  zone_id = var.route_53_zone_arn
+  name    = "api-lambda.${var.domain}"
+  type    = "A"
+
+  alias {
+    name                   = aws_api_gateway_domain_name.api_lambda.regional_domain_name
+    zone_id                = aws_api_gateway_domain_name.api_lambda.regional_zone_id
+    evaluate_target_health = false
+  }
+
+}
+
+resource "aws_route53_record" "api-weighted-100-scratch-notification-sandbox-A" {
+  # Send all API traffic to Lambda
+  count          = var.env == "scratch" ? 1 : 0
+  zone_id        = var.route_53_zone_arn
+  name           = "api.${var.domain}"
+  type           = "A"
+  set_identifier = "lambda"
+
+  alias {
+    name                   = aws_api_gateway_domain_name.api_lambda.regional_domain_name
+    zone_id                = aws_api_gateway_domain_name.api_lambda.regional_zone_id
+    evaluate_target_health = false
+  }
+
+  weighted_routing_policy {
+    weight = 100
+  }
+}

--- a/env/scratch/eks/.terraform.lock.hcl
+++ b/env/scratch/eks/.terraform.lock.hcl
@@ -1,39 +1,63 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.74.2"
-  constraints = "~> 3.0"
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.3.0"
   hashes = [
-    "h1:TryIinyNf2gFkYA/d4hD0a76mPSvyl9rMUHePqs6cgs=",
-    "zh:2b1df436ec034ae9416b23b95efd192b2fe271a7c8595493329dcde8e452c036",
-    "zh:3aba9abd4bc8a904378b1f852d025a397ef74f0dbe59134a06fc5abebb259efc",
-    "zh:45700f37e3a97c5b3a8d5d2ec79ae7a8671be8893a6a6c38ae069888d13c20fe",
-    "zh:5b2ca0fde7f9b723018528ea21b151f2ada360a435ef2dcfb666d7fe686b2845",
-    "zh:785c52c6b4724873723b77c78e66024dc7ad951eeacb44a8c0cab2dd3c0f9828",
-    "zh:8b50a307f3324c4e31813abdb08a21c666e302e4c0496d9f8015ae76327cafb4",
-    "zh:ab78cab83e7806030c1b1e4943a6edb149a901380a1a5f7bceb1a1f41098e4c5",
-    "zh:c06a7fbffbbfa7b407990091869c0642dc9e38217da2895b49b42892e86eada6",
-    "zh:e046e30e24b3b95ca8ec0ecac562ac8a47e86f9db0efa460e50c2afce07e084e",
-    "zh:ef02426419de15931bcdfb400d914d720639607415ac623c04cdf425c71ade41",
-    "zh:fb1990e9e162cf1837792e4886a4b6dcb3ffdd511d1ba4b56118127525504032",
+    "h1:pTPG9Kf1Qg2aPsZLXDa6OvLqsEXaMrKnp0Z4Q/TIBPA=",
+    "zh:0869128d13abe12b297b0cd13b8767f10d6bf047f5afc4215615aabc39c2eb4f",
+    "zh:481ed837d63ba3aa45dd8736da83e911e3509dee0e7961bf5c00ed2644f807b3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9f08fe2977e2166849be24fb9f394e4d2697414d463f7996fd0d7beb4e19a29c",
+    "zh:9fe566deeafd460d27999ca0bbfd85426a5fcfcb40007b23884deb76da127b6f",
+    "zh:a1bd9a60925d9769e0da322e4523330ee86af9dc2e770cba1d0247a999ef29cb",
+    "zh:bb4094c8149f74308b22a87e1ac19bcccca76e8ef021b571074d9bccf1c0c6f0",
+    "zh:c8984c9def239041ce41ec8e19bbd76a49e74ed2024ff736dad60429dee89bcc",
+    "zh:ea4bb5ae73db1de3a586e62f39106f5e56770804a55aa5e6b4f642df973e0e75",
+    "zh:f44a9d596ecc3a8c5653f56ba0cd202ad93b49f76767f4608daf7260b813289e",
+    "zh:f5c5e6cc9f7f070020ab7d95fcc9ed8e20d5cf219978295a71236e22cbb6d508",
+    "zh:fd2273f51dcc8f43403bf1e425ba9db08a57c3ddcba5ad7a51742ccde21ca611",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.67.0"
+  constraints = ">= 3.46.0, ~> 4.0"
+  hashes = [
+    "h1:P43vwcDPG99x5WBbmqwUPgfJrfXf6/ucAIbGlRb7k1w=",
+    "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
+    "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
+    "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
+    "zh:4a002990b9f4d6d225d82cb2fb8805789ffef791999ee5d9cb1fef579aeff8f1",
+    "zh:559a2b5ace06b878c6de3ecf19b94fbae3512562f7a51e930674b16c2f606e29",
+    "zh:6a07da13b86b9753b95d4d8218f6dae874cf34699bca1470d6effbb4dee7f4b7",
+    "zh:768b3bfd126c3b77dc975c7c0e5db3207e4f9997cf41aa3385c63206242ba043",
+    "zh:7be5177e698d4b547083cc738b977742d70ed68487ce6f49ecd0c94dbf9d1362",
+    "zh:8b562a818915fb0d85959257095251a05c76f3467caa3ba95c583ba5fe043f9b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c385d03a958b54e2afd5279cd8c7cbdd2d6ca5c7d6a333e61092331f38af7cf",
+    "zh:b3ca45f2821a89af417787df8289cb4314b273d29555ad3b2a5ab98bb4816b3b",
+    "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
+    "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
+    "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/tls" {
-  version = "3.1.0"
+  version = "4.0.4"
   hashes = [
-    "h1:fUJX8Zxx38e2kBln+zWr1Tl41X+OuiE++REjrEyiOM4=",
-    "zh:3d46616b41fea215566f4a957b6d3a1aa43f1f75c26776d72a98bdba79439db6",
-    "zh:623a203817a6dafa86f1b4141b645159e07ec418c82fe40acd4d2a27543cbaa2",
-    "zh:668217e78b210a6572e7b0ecb4134a6781cc4d738f4f5d09eb756085b082592e",
-    "zh:95354df03710691773c8f50a32e31fca25f124b7f3d6078265fdf3c4e1384dca",
-    "zh:9f97ab190380430d57392303e3f36f4f7835c74ea83276baa98d6b9a997c3698",
-    "zh:a16f0bab665f8d933e95ca055b9c8d5707f1a0dd8c8ecca6c13091f40dc1e99d",
-    "zh:be274d5008c24dc0d6540c19e22dbb31ee6bfdd0b2cddd4d97f3cd8a8d657841",
-    "zh:d5faa9dce0a5fc9d26b2463cea5be35f8586ab75030e7fa4d4920cd73ee26989",
-    "zh:e9b672210b7fb410780e7b429975adcc76dd557738ecc7c890ea18942eb321a5",
-    "zh:eb1f8368573d2370605d6dbf60f9aaa5b64e55741d96b5fb026dbfe91de67c0d",
-    "zh:fc1e12b713837b85daf6c3bb703d7795eaf1c5177aebae1afcf811dd7009f4b0",
+    "h1:Wd3RqmQW60k2QWPN4sK5CtjGuO1d+CRNXgC+D4rKtXc=",
+    "zh:23671ed83e1fcf79745534841e10291bbf34046b27d6e68a5d0aab77206f4a55",
+    "zh:45292421211ffd9e8e3eb3655677700e3c5047f71d8f7650d2ce30242335f848",
+    "zh:59fedb519f4433c0fdb1d58b27c210b27415fddd0cd73c5312530b4309c088be",
+    "zh:5a8eec2409a9ff7cd0758a9d818c74bcba92a240e6c5e54b99df68fff312bbd5",
+    "zh:5e6a4b39f3171f53292ab88058a59e64825f2b842760a4869e64dc1dc093d1fe",
+    "zh:810547d0bf9311d21c81cc306126d3547e7bd3f194fc295836acf164b9f8424e",
+    "zh:824a5f3617624243bed0259d7dd37d76017097dc3193dac669be342b90b2ab48",
+    "zh:9361ccc7048be5dcbc2fafe2d8216939765b3160bd52734f7a9fd917a39ecbd8",
+    "zh:aa02ea625aaf672e649296bce7580f62d724268189fe9ad7c1b36bb0fa12fa60",
+    "zh:c71b4cd40d6ec7815dfeefd57d88bc592c0c42f5e5858dcc88245d371b4b8b1e",
+    "zh:dabcd52f36b43d250a3d71ad7abfa07b5622c69068d989e60b79b2bb4f220316",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/env/scratch/eks/terragrunt.hcl
+++ b/env/scratch/eks/terragrunt.hcl
@@ -1,5 +1,5 @@
 dependencies {
-  paths = ["../common", "../dns", "../cloudfront"]
+  paths = ["../common", "../cloudfront"]
 }
 
 dependency "common" {
@@ -34,18 +34,6 @@ dependency "common" {
   }
 }
 
-dependency "dns" {
-  config_path = "../dns"
-
-  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
-  # module hasn't been applied yet.
-  mock_outputs_allowed_terraform_commands = ["validate"]
-  mock_outputs = {
-    aws_acm_notification_canada_ca_arn     = ""
-    aws_acm_alt_notification_canada_ca_arn = ""
-  }
-}
-
 dependency "cloudfront" {
   config_path = "../cloudfront"
 
@@ -62,8 +50,6 @@ include {
 }
 
 inputs = {
-  aws_acm_notification_canada_ca_arn        = dependency.dns.outputs.aws_acm_notification_canada_ca_arn
-  aws_acm_alt_notification_canada_ca_arn    = dependency.dns.outputs.aws_acm_alt_notification_canada_ca_arn
   primary_worker_desired_size               = 5
   primary_worker_instance_types             = ["m5.large"]
   primary_worker_max_size                   = 7

--- a/env/scratch/env_vars.hcl
+++ b/env/scratch/env_vars.hcl
@@ -1,7 +1,7 @@
 inputs = {
   account_id = "419291849580"
   domain     = "scratch.notification.cdssandbox.xyz"
-  alt_domain = "scratch.notification.alpha.cdssandbox.xyz"
+  alt_domain = "alpha.scratch.notification.cdssandbox.xyz"
   env        = "scratch"
   staging_account_id = "239043911459"
 }


### PR DESCRIPTION
# Summary | Résumé

Again apologies for the large PRs - so much untangling to do.

* ACM Validation is now working in scratch, and should be working in staging (To be confirmed on merge)
* Moved DNS resources around to avoid reciprocal references. It is better than it was, but this will still be a work in progress (improvements for a later date)
* Created application log group resource in terraform **Needs to be imported in staging once PR is approved*
* Had to put a conditional limit on the google_cidr prefix list due to quotas in scratch. 

# Test instructions | Instructions pour tester la modification

* Terragrunt plan in staging
* Analyze plan results, document changes
* Import resources as necessary
* Terragrunt apply in staging
* Repeat above for production.
