### PR TITLE
Setting google_cidr size for staging to equal production

### DIFF
--- a/aws/eks/securitygroups.tf
+++ b/aws/eks/securitygroups.tf
@@ -131,7 +131,7 @@ resource "aws_security_group_rule" "notification-canada-ca-alb-quicksight-ingres
 resource "aws_ec2_managed_prefix_list" "google_cidrs" {
   name           = "Google Service CIDRs"
   address_family = "IPv4"
-  max_entries    = var.env != "production" ? 20 : 100
+  max_entries    = var.env == "production" || var.env == "staging" ? 100 : 20
 
   tags = {
     CostCentre = "notification-canada-ca-${var.env}"


### PR DESCRIPTION
# Summary | Résumé

Fixing issue w/ google_cidr prefix list being too small in staging after ACM migration.

# Test instructions | Instructions pour tester la modification

terragrunt plan shows no changes (since the size is already correct in staging)