### PR TITLE
Changing staging alt domain to be under notification.cdssandbox.xyz

### DIFF
--- a/env/staging/env_vars.hcl
+++ b/env/staging/env_vars.hcl
@@ -1,7 +1,7 @@
 inputs = {
   account_id = "239043911459"
   domain     = "staging.notification.cdssandbox.xyz"
-  alt_domain = "staging.notification.alpha.cdssandbox.xyz"
+  alt_domain = "staging.alpha.notification.cdssandbox.xyz"
   env        = "staging"
   staging_account_id = "239043911459"
 }


### PR DESCRIPTION
# Summary | Résumé

Modifying staging alt domain to be underneath the notification.cdssandbox.xyz domain. This is required because the ACM validation needs to be able to create route53 records on the alt domain, which I have not mapped in staging (it is shared with other apps). This will not have any impact on prod, since we will not be migrating the DNS.

# Test instructions | Instructions pour tester la modification

* Terragrunt plan/apply should work
* ACM Validation should work in staging