### PR TITLE
Adding DNS records for alt-dns in staging

### DIFF
--- a/aws/eks/dns.tf
+++ b/aws/eks/dns.tf
@@ -27,6 +27,36 @@ resource "aws_route53_record" "notificatio-root-WC" {
 
 }
 
+resource "aws_route53_record" "notification-alt-root" {
+  count    = var.env != "production" ? 1 : 0
+  provider = aws.staging
+  zone_id  = var.route_53_zone_arn
+  name     = var.alt_domain
+  type     = "A"
+
+  alias {
+    name                   = aws_alb.notification-canada-ca.dns_name
+    zone_id                = aws_alb.notification-canada-ca.zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "notification-alt-root-WC" {
+  count    = var.env != "production" ? 1 : 0
+  provider = aws.staging
+  name     = "*.${var.alt_domain}"
+  zone_id  = var.route_53_zone_arn
+  type     = "A"
+
+  alias {
+    name                   = aws_alb.notification-canada-ca.dns_name
+    zone_id                = aws_alb.notification-canada-ca.zone_id
+    evaluate_target_health = false
+  }
+
+}
+
+
 resource "aws_route53_record" "api-k8s-scratch-notification-CNAME" {
   count    = var.env != "production" ? 1 : 0
   provider = aws.staging

--- a/aws/lambda-api/dns.tf
+++ b/aws/lambda-api/dns.tf
@@ -30,3 +30,17 @@ resource "aws_route53_record" "api-weighted-100-notification-A" {
     weight = 100
   }
 }
+
+resource "aws_route53_record" "api-notification-alt-A" {
+  count   = var.env != "production" ? 1 : 0
+  zone_id = var.route_53_zone_arn
+  name    = "api.${var.alt_domain}"
+  type    = "A"
+
+  alias {
+    name                   = aws_api_gateway_domain_name.api_lambda.regional_domain_name
+    zone_id                = aws_api_gateway_domain_name.api_lambda.regional_zone_id
+    evaluate_target_health = false
+  }
+
+}


### PR DESCRIPTION
# Summary | Résumé

Adding the alternate domain DNS record entries into staging dns.


# Test instructions | Instructions pour tester la modification

Terragrunt apply in staging works
Validate that new DNS entries are resolvable