### PR TITLE
fix: increase s3_scan_object function timeout

### DIFF
--- a/aws/common/file_scanning.tf
+++ b/aws/common/file_scanning.tf
@@ -1,5 +1,5 @@
 module "s3_scan_objects" {
-  source = "github.com/cds-snc/terraform-modules?ref=v5.0.0//S3_scan_object"
+  source = "github.com/cds-snc/terraform-modules?ref=v5.1.9//S3_scan_object"
 
   product_name          = "gc-notify"
   s3_upload_bucket_name = "notification-canada-ca-${var.env}-document-download-scan-files"


### PR DESCRIPTION
# Summary
Update to the latest `s3_scan_object` module version which increases the transport lambda's timeout to 120s.  This is to fix the cases where the transport lambda must wait for a new Scan Files lambda function cold start.

This will fix the timeout errors currently occurring and will hopefully also stop the `scanfiles-timeout` errors being seen:

![image](https://github.com/cds-snc/notification-terraform/assets/2110107/eb503055-56ca-4e3e-830e-e2e468243291)


# Related
- cds-snc/platform-core-services#297
- cds-snc/terraform-modules#251