### PR TITLE
Fixing dkim validation DNS records to use proper domains

### DIFF
--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -148,7 +148,7 @@ jobs:
           terragrunt: "true"
 
       - name: Terragrunt plan ses_validation_dns_entries
-        if: ${{ steps.filter.outputs.dns == 'true' || steps.filter.outputs.common == 'true' }}
+        if: ${{ steps.filter.outputs.ses_validation_dns_entries == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v3
         with:
           directory: "env/staging/ses_validation_dns_entries"

--- a/aws/ses_validation_dns_entries/sesValidationDnsEntries.tf
+++ b/aws/ses_validation_dns_entries/sesValidationDnsEntries.tf
@@ -1,31 +1,34 @@
 resource "aws_route53_record" "ses_custom_domain_dkim_record" {
-  for_each = { for cd in jsondecode(var.custom_sending_domains_dkim) : "${cd.domain}.${cd.token}" => cd }
-  provider = aws.staging
-  zone_id  = var.route53_zone_arn
-  name     = "${each.value.token}._domainkey"
-  type     = "CNAME"
-  ttl      = "600"
-  records  = ["${each.value.token}.dkim.amazonses.com"]
+  for_each        = { for cd in jsondecode(var.custom_sending_domains_dkim) : "${cd.domain}.${cd.token}" => cd }
+  provider        = aws.staging
+  zone_id         = var.route53_zone_arn
+  name            = "${each.value.token}._domainkey.${each.value.domain}"
+  type            = "CNAME"
+  ttl             = "600"
+  allow_overwrite = true
+  records         = ["${each.value.token}.dkim.amazonses.com"]
 }
 
 
 resource "aws_route53_record" "notification_canada_ca_dkim_record" {
-  for_each = { for s in jsondecode(var.notification_canada_ca_dkim) : "${s}" => s }
-  provider = aws.staging
-  zone_id  = var.route53_zone_arn
-  name     = "${each.value}._domainkey"
-  type     = "CNAME"
-  ttl      = "600"
-  records  = ["${each.value}.dkim.amazonses.com"]
+  for_each        = { for s in jsondecode(var.notification_canada_ca_dkim) : "${s}" => s }
+  provider        = aws.staging
+  zone_id         = var.route53_zone_arn
+  name            = "${each.value}._domainkey.${var.domain}"
+  type            = "CNAME"
+  ttl             = "600"
+  allow_overwrite = true
+  records         = ["${each.value}.dkim.amazonses.com"]
 }
 
 
 resource "aws_route53_record" "ses_cic_trvapply_vrtdemande_dkim_record" {
-  for_each = { for cd in jsondecode(var.cic_trvapply_vrtdemande_dkim) : "${cd.domain}.${cd.token}" => cd }
-  provider = aws.staging
-  zone_id  = var.route53_zone_arn
-  name     = "${each.value.token}._domainkey"
-  type     = "CNAME"
-  ttl      = "600"
-  records  = ["${each.value.token}.dkim.amazonses.com"]
+  for_each        = { for cd in jsondecode(var.cic_trvapply_vrtdemande_dkim) : "${cd.domain}.${cd.token}" => cd }
+  provider        = aws.staging
+  zone_id         = var.route53_zone_arn
+  name            = "${each.value.token}._domainkey.${each.value.domain}"
+  type            = "CNAME"
+  ttl             = "600"
+  allow_overwrite = true
+  records         = ["${each.value.token}.dkim.amazonses.com"]
 }


### PR DESCRIPTION
# Summary | Résumé

We were creating the DKIM records as per the TF documentation, but for some reason they were omitting the environment prefix (ex. _staging_.notification.cdssandbox.xyz). I've explicitly set the FQDN on the records now to remediate this.

Also fixing the pathing filter in staging plan github workflow for the new ses validation records. 

# Test instructions | Instructions pour tester la modification

Terraform apply creates the proper DNS records with the FQDN. 
DKIM Validation succeeds.