### PR TITLE
Adding back manual TXT records for legacy domain validation.

### DIFF
--- a/aws/dns/staging.notification.cdssandbox.xyz.tf
+++ b/aws/dns/staging.notification.cdssandbox.xyz.tf
@@ -19,6 +19,24 @@ resource "aws_route53_record" "staging-notification-sandbox-TXT" {
   ]
 }
 
+resource "aws_route53_record" "staging-custom-domain-aws-ses-sandbox-TXT" {
+  count   = var.env == "staging" ? 1 : 0
+  zone_id = aws_route53_zone.notification-sandbox[0].zone_id
+  name    = "_amazonses.custom-sending-domain.staging.notification.cdssandbox.xyz"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["fXT/J45wZcUoBSnJAwPyfnHVf5E2b7aNayCC5PeQltg="]
+}
+
+resource "aws_route53_record" "staging-custom-domain-ses-sandbox-TXT" {
+  count   = var.env == "staging" ? 1 : 0
+  zone_id = aws_route53_zone.notification-sandbox[0].zone_id
+  name    = "custom-sending-domain.staging.notification.cdssandbox.xyz"
+  type    = "TXT"
+  ttl     = "300"
+  records = ["amazonses:fXT/J45wZcUoBSnJAwPyfnHVf5E2b7aNayCC5PeQltg="]
+}
+
 resource "aws_route53_record" "ses-staging-notification-sandbox-TXT" {
   count   = var.env == "staging" ? 1 : 0
   zone_id = aws_route53_zone.notification-sandbox[0].zone_id


### PR DESCRIPTION
# Summary | Résumé

This adds back TXT DNS records for the custom sending domain in staging. These are considered legacy and should have been replaced with DKIM, but AWS is still warning us about domain validation on these.

# Test instructions | Instructions pour tester la modification

Terragrunt apply in staging shows two new resources (two TXT records)
SES domain validation is successful in staging for the custom-sending-domain