### PR TITLE
fix: update s3_scan_object to be async

### DIFF
--- a/aws/common/file_scanning.tf
+++ b/aws/common/file_scanning.tf
@@ -1,8 +1,9 @@
 module "s3_scan_objects" {
-  source = "github.com/cds-snc/terraform-modules?ref=v5.1.9//S3_scan_object"
+  source = "github.com/cds-snc/terraform-modules?ref=v5.1.11//S3_scan_object"
 
   product_name          = "gc-notify"
   s3_upload_bucket_name = "notification-canada-ca-${var.env}-document-download-scan-files"
+  log_level             = "DEBUG"
 
   billing_tag_value = var.billing_tag_value
 }


### PR DESCRIPTION
# Summary
Update the module to the latest version which sends S3 events asynchronously to Scan Files.

Also increases the transport lambda logging level to help debug the timeout issues.

# Related
- cds-snc/platform-core-services#297
- cds-snc/terraform-modules#253