### PR TITLE
fix: update waf rules for new GCA routes

### DIFF
--- a/aws/common/waf.tf
+++ b/aws/common/waf.tf
@@ -77,7 +77,7 @@ resource "aws_wafv2_regex_pattern_set" "re_admin" {
 
   # GCA routes
   regular_expression {
-    regex_string = "/keep-accurate-contact-information|/maintenez-a-jour-les-coordonnees|/delivery-and-failure|/livraison-reussie-et-echec"
+    regex_string = "/keep-accurate-contact-information|/maintenez-a-jour-les-coordonnees|/delivery-and-failure|/livraison-reussie-et-echec|/system-status|/etat-du-systeme"
   }
 
   tags = {


### PR DESCRIPTION
# Summary | Résumé

This PR adds 2 new routes to the firewall rules for the upcoming password reset work:
- `/system-status`
- `/etat-du-systeme`