### PR TITLE
Change bounce rate alarm severity

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -384,7 +384,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-1-bounce-rate-1-minute-critical" {
   statistic           = "Sum"
   threshold           = 1
   treat_missing_data  = "notBreaching"
-  alarm_actions       = [var.sns_alert_critical_arn]
+  alarm_actions       = [var.sns_alert_warning_arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-1-bounce-rate-1-minute-warning" {


### PR DESCRIPTION
# Summary | Résumé

Change alarm severity from critical to warning for a service with a 10% bounce rate.

This is to avoid having alarms in ops genie where there is no immediate support action to take. This could change in the future, once we start suspending the service.