### PR TITLE
Report less of scan files as we have many warning; waiting for fix

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -361,14 +361,14 @@ resource "aws_cloudwatch_metric_alarm" "logs-10-malware-detected-1-minute-critic
 
 resource "aws_cloudwatch_metric_alarm" "logs-1-scanfiles-timeout-1-minute-warning" {
   alarm_name          = "logs-3-scanfiles-timeout-5-minutes-warning"
-  alarm_description   = "One scanfiles timeout detected error in 1 minute"
+  alarm_description   = "Three scanfiles timeout detected error in 5 minutes"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = aws_cloudwatch_log_metric_filter.scanfiles-timeout.metric_transformation[0].name
   namespace           = aws_cloudwatch_log_metric_filter.scanfiles-timeout.metric_transformation[0].namespace
-  period              = "60"
+  period              = "300"
   statistic           = "Sum"
-  threshold           = 1
+  threshold           = 4
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_warning_arn]
 }

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -359,9 +359,9 @@ resource "aws_cloudwatch_metric_alarm" "logs-10-malware-detected-1-minute-critic
   ok_actions          = [var.sns_alert_critical_arn]
 }
 
-resource "aws_cloudwatch_metric_alarm" "logs-1-scanfiles-timeout-1-minute-warning" {
-  alarm_name          = "logs-3-scanfiles-timeout-5-minutes-warning"
-  alarm_description   = "Three scanfiles timeout detected error in 5 minutes"
+resource "aws_cloudwatch_metric_alarm" "logs-4-scanfiles-timeout-5-minutes-warning" {
+  alarm_name          = "logs-4-scanfiles-timeout-5-minutes-warning"
+  alarm_description   = "Four scanfiles timeout detected error in 5 minutes"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = aws_cloudwatch_log_metric_filter.scanfiles-timeout.metric_transformation[0].name


### PR DESCRIPTION
# Summary | Résumé

Resetting the scan files timeout to larger tolerance values. The previous fixes didn't work so we are getting many of these warnings in the meantime. Let's revert to original values once the fix is in.

# Test instructions | Instructions pour tester la modification

This is reverting to a previous configuration that proved to be more silent.
