### PR TITLE
feat: add Salesforce API metric and alarm

### DIFF
--- a/aws/lambda-api/cloudwatch_alarms.tf
+++ b/aws/lambda-api/cloudwatch_alarms.tf
@@ -35,3 +35,19 @@ resource "aws_cloudwatch_metric_alarm" "logs-10-error-5-minutes-critical-lambda-
   ok_actions                = [var.sns_alert_critical_arn]
   insufficient_data_actions = [var.sns_alert_warning_arn]
 }
+
+resource "aws_cloudwatch_metric_alarm" "logs-1-error-1-minute-warning-salesforce-api" {
+  alarm_name                = "logs-1-error-1-minute-warning-salesforce-api"
+  alarm_description         = "One Salesforce API error in 1 minute"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = aws_cloudwatch_log_metric_filter.errors-salesforce-api.metric_transformation[0].name
+  namespace                 = aws_cloudwatch_log_metric_filter.errors-salesforce-api.metric_transformation[0].namespace
+  period                    = "60"
+  statistic                 = "Sum"
+  threshold                 = 1
+  treat_missing_data        = "notBreaching"
+  alarm_actions             = [var.sns_alert_warning_arn]
+  ok_actions                = [var.sns_alert_warning_arn]
+  insufficient_data_actions = [var.sns_alert_warning_arn]
+}

--- a/aws/lambda-api/cloudwatch_logs.tf
+++ b/aws/lambda-api/cloudwatch_logs.tf
@@ -63,3 +63,15 @@ resource "aws_cloudwatch_log_metric_filter" "errors-lambda-api" {
     value     = "1"
   }
 }
+
+resource "aws_cloudwatch_log_metric_filter" "errors-salesforce-api" {
+  name           = "errors-salesforce-api"
+  pattern        = "SF_ERR"
+  log_group_name = aws_cloudwatch_log_group.api_lambda_log_group.name
+
+  metric_transformation {
+    name      = "errors-salesforce-api"
+    namespace = "LogMetrics"
+    value     = "1"
+  }
+}


### PR DESCRIPTION
# Summary
Add a metric alarm that triggers if 1 Salesforce API error is detected within a 1 minute period.

These will be used to alert the Salesforce team when there is a problem with the Notify/Salesforce API interactions.

⏰ [Alarm doc](https://docs.google.com/spreadsheets/d/1gkrL3Trxw0xEkX724C1bwpfeRsTlK2X60wtCjF6MFRA/edit#gid=1175293850) has been updated as well.

# Related
- cds-snc/notification-api#1879
- cds-snc/platform-core-services#370