### PR TITLE
fix: upgrade to SQS queue scan files

### DIFF
--- a/aws/common/file_scanning.tf
+++ b/aws/common/file_scanning.tf
@@ -1,9 +1,6 @@
 module "s3_scan_objects" {
-  source = "github.com/cds-snc/terraform-modules?ref=v5.1.11//S3_scan_object"
+  source = "github.com/cds-snc/terraform-modules?ref=v6.0.1//S3_scan_object"
 
-  product_name          = "gc-notify"
   s3_upload_bucket_name = "notification-canada-ca-${var.env}-document-download-scan-files"
-  log_level             = "DEBUG"
-
-  billing_tag_value = var.billing_tag_value
+  billing_tag_value     = var.billing_tag_value
 }


### PR DESCRIPTION
# Summary
Upgrade the `s3_scan_object` module to the version that uses an SQS queue to deliver S3 object notifications to the Scan Files API.

In performance testing this has resulted in a substantially higher throughput for S3 object create events as they can be batched in groups of 10 and do not get constrained by transport lambda throttling errors.

# Related
- cds-snc/platform-core-services#297