### PR TITLE
Added alarm for critical usage of Redis memory + DB log toned down

### DIFF
--- a/aws/elasticache/cloudwatch_alarms.tf
+++ b/aws/elasticache/cloudwatch_alarms.tf
@@ -10,6 +10,7 @@ resource "aws_cloudwatch_metric_alarm" "redis-elasticache-medium-cpu-warning" {
   statistic           = "Average"
   threshold           = 50
   alarm_actions       = [var.sns_alert_warning_arn]
+  ok_actions          = [var.sns_alert_warning_arn]
   treat_missing_data  = "breaching"
 
   dimensions = {
@@ -29,6 +30,7 @@ resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-cpu-warning" {
   statistic           = "Average"
   threshold           = 70
   alarm_actions       = [var.sns_alert_warning_arn]
+  ok_actions          = [var.sns_alert_warning_arn]
   treat_missing_data  = "breaching"
   dimensions = {
     CacheClusterId = "${aws_elasticache_replication_group.notification-cluster-cache-multiaz-group.id}-00${count.index + 1}"
@@ -47,6 +49,26 @@ resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-db-memory-warning
   statistic           = "Average"
   threshold           = 60
   alarm_actions       = [var.sns_alert_warning_arn]
+  ok_actions          = [var.sns_alert_warning_arn]
+  treat_missing_data  = "missing"
+  dimensions = {
+    CacheClusterId = "${aws_elasticache_replication_group.notification-cluster-cache-multiaz-group.id}-00${count.index + 1}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-db-memory-critical" {
+  count               = var.elasticache_node_number_cache_clusters
+  alarm_name          = "redis-elasticache-high-db-memory-critical-CacheCluster00${count.index + 1}"
+  alarm_description   = "Average DB Memory on Redis ElastiCache >= 85% during 1 minute"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "DatabaseMemoryUsagePercentage"
+  namespace           = "AWS/ElastiCache"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = 85
+  alarm_actions       = [var.sns_alert_critical_arn]
+  ok_actions          = [var.sns_alert_critical_arn]
   treat_missing_data  = "missing"
   dimensions = {
     CacheClusterId = "${aws_elasticache_replication_group.notification-cluster-cache-multiaz-group.id}-00${count.index + 1}"
@@ -65,6 +87,7 @@ resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-connection-warnin
   statistic           = "Average"
   threshold           = 1000
   alarm_actions       = [var.sns_alert_warning_arn]
+  ok_actions          = [var.sns_alert_warning_arn]
   treat_missing_data  = "missing"
   dimensions = {
     CacheClusterId = "${aws_elasticache_replication_group.notification-cluster-cache-multiaz-group.id}-00${count.index + 1}"

--- a/aws/elasticache/variables.tf
+++ b/aws/elasticache/variables.tf
@@ -28,3 +28,7 @@ variable "vpc_private_subnets" {
 variable "sns_alert_warning_arn" {
   type = string
 }
+
+variable "sns_alert_critical_arn" {
+  type = string
+}

--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -55,7 +55,12 @@ resource "aws_rds_cluster_parameter_group" "default" {
 
   parameter {
     name  = "log_statement"
-    value = "all"
+    value = "ddl"
+  }
+
+  parameter {
+    name  = "log_retention_period"
+    value = "4320" # 3 days (in minutes)
   }
 
   tags = {

--- a/env/production/elasticache/terragrunt.hcl
+++ b/env/production/elasticache/terragrunt.hcl
@@ -19,11 +19,12 @@ include {
 }
 
 inputs = {
-  eks_cluster_securitygroup               = dependency.eks.outputs.eks-cluster-securitygroup
-  elasticache_node_count                  = 1
-  elasticache_node_number_cache_clusters  = 3
-  elasticache_node_type                   = "cache.t3.micro"
-  vpc_private_subnets                     = dependency.common.outputs.vpc_private_subnets
-  sns_alert_warning_arn                   = dependency.common.outputs.sns_alert_warning_arn
-  vpc_id                                  = dependency.common.outputs.vpc_id
+  eks_cluster_securitygroup              = dependency.eks.outputs.eks-cluster-securitygroup
+  elasticache_node_count                 = 1
+  elasticache_node_number_cache_clusters = 3
+  elasticache_node_type                  = "cache.t3.micro"
+  vpc_private_subnets                    = dependency.common.outputs.vpc_private_subnets
+  sns_alert_warning_arn                  = dependency.common.outputs.sns_alert_warning_arn
+  sns_alert_critical_arn                 = dependency.common.outputs.sns_alert_critical_arn
+  vpc_id                                 = dependency.common.outputs.vpc_id
 }

--- a/env/scratch/elasticache/terragrunt.hcl
+++ b/env/scratch/elasticache/terragrunt.hcl
@@ -34,13 +34,14 @@ include {
 }
 
 inputs = {
-  eks_cluster_securitygroup               = dependency.eks.outputs.eks-cluster-securitygroup
-  elasticache_node_count                  = 1
-  elasticache_node_number_cache_clusters  = 3
-  elasticache_node_type                   = "cache.t3.micro"
-  vpc_private_subnets                     = dependency.common.outputs.vpc_private_subnets
-  sns_alert_warning_arn                   = dependency.common.outputs.sns_alert_warning_arn
-  vpc_id                                  = dependency.common.outputs.vpc_id
+  eks_cluster_securitygroup              = dependency.eks.outputs.eks-cluster-securitygroup
+  elasticache_node_count                 = 1
+  elasticache_node_number_cache_clusters = 3
+  elasticache_node_type                  = "cache.t3.micro"
+  vpc_private_subnets                    = dependency.common.outputs.vpc_private_subnets
+  sns_alert_warning_arn                  = dependency.common.outputs.sns_alert_warning_arn
+  sns_alert_critical_arn                 = dependency.common.outputs.sns_alert_critical_arn
+  vpc_id                                 = dependency.common.outputs.vpc_id
 }
 
 terraform {

--- a/env/staging/elasticache/terragrunt.hcl
+++ b/env/staging/elasticache/terragrunt.hcl
@@ -34,13 +34,14 @@ include {
 }
 
 inputs = {
-  eks_cluster_securitygroup               = dependency.eks.outputs.eks-cluster-securitygroup
-  elasticache_node_count                  = 1
-  elasticache_node_number_cache_clusters  = 3
-  elasticache_node_type                   = "cache.t3.micro"
-  vpc_private_subnets                     = dependency.common.outputs.vpc_private_subnets
-  sns_alert_warning_arn                   = dependency.common.outputs.sns_alert_warning_arn
-  vpc_id                                  = dependency.common.outputs.vpc_id
+  eks_cluster_securitygroup              = dependency.eks.outputs.eks-cluster-securitygroup
+  elasticache_node_count                 = 1
+  elasticache_node_number_cache_clusters = 3
+  elasticache_node_type                  = "cache.t3.micro"
+  vpc_private_subnets                    = dependency.common.outputs.vpc_private_subnets
+  sns_alert_warning_arn                  = dependency.common.outputs.sns_alert_warning_arn
+  sns_alert_critical_arn                 = dependency.common.outputs.sns_alert_critical_arn
+  vpc_id                                 = dependency.common.outputs.vpc_id
 }
 
 terraform {


### PR DESCRIPTION
# Summary | Résumé

* Added critical alarm for Redis memory usage around 85%.
* Do not log all DB statements (only ddl).

# Test instructions | Instructions pour tester la modification

* Review the TF plan
* Review the applied changes in staging
