### PR TITLE
Fix rds.log_retention_period param name

### DIFF
--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -59,7 +59,7 @@ resource "aws_rds_cluster_parameter_group" "default" {
   }
 
   parameter {
-    name  = "log_retention_period"
+    name  = "rds.log_retention_period"
     value = "4320" # 3 days (in minutes)
   }
 


### PR DESCRIPTION
# Summary | Résumé

Changed the db parameter name from `log_retention_period` to `rds.log_retention_period` as per [RDS log documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.Concepts.PostgreSQL.html).

# Test instructions | Instructions pour tester la modification

Deploy to staging (unfortunately).
