### PR TITLE
capitalizing E on emails

### DIFF
--- a/aws/common/dashboards.tf
+++ b/aws/common/dashboards.tf
@@ -179,7 +179,7 @@ EOF
 }
 
 resource "aws_cloudwatch_dashboard" "emails" {
-  dashboard_name = "emails"
+  dashboard_name = "Emails"
   dashboard_body = <<EOF
 {
     "widgets": [


### PR DESCRIPTION
# Summary | Résumé

Need to capitalize E on "Emails" dashboard so that we don't have to delete it in prod to recreate. In staging it was lower case.

# Test instructions | Instructions pour tester la modification

Verify that dashboard is named "Emails" in staging after apply (existing dashboard will be destroyed)
Verify that no changes are required on PR to prod