### PR TITLE
Added notify URL to blazer runtime

### DIFF
--- a/aws/database-tools/variables.tf
+++ b/aws/database-tools/variables.tf
@@ -35,6 +35,11 @@ variable "notify_o11y_google_oauth_client_secret" {
   description = "Google OAuth client secret for Notify observability tools"
 }
 
+variable "notify_url" {
+  type        = string
+  description = "The URL of the Notify service for Blazer to connect to, given proper environment"
+}
+
 variable "sqlalchemy_database_reader_uri" {
   type        = string
   sensitive   = true

--- a/env/production/database-tools/terragrunt.hcl
+++ b/env/production/database-tools/terragrunt.hcl
@@ -30,7 +30,7 @@ dependency "eks" {
   mock_outputs_allowed_terraform_commands = ["validate", "plan", "init", "fmt", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
-    database-tools-securitygroup = ""
+    database-tools-securitygroup    = ""
     database-tools-db-securitygroup = ""
   }
 }
@@ -48,4 +48,5 @@ inputs = {
   blazer_image_tag                = "53254711eb1da91f834d933e9663c87bc5974d3d"
   database-tools-securitygroup    = dependency.eks.outputs.database-tools-securitygroup
   database-tools-db-securitygroup = dependency.eks.outputs.database-tools-db-securitygroup
+  notify_url                      = "https://notification.canada.ca"
 }

--- a/env/scratch/database-tools/terragrunt.hcl
+++ b/env/scratch/database-tools/terragrunt.hcl
@@ -26,7 +26,7 @@ dependency "eks" {
   mock_outputs_allowed_terraform_commands = ["validate", "plan", "init", "fmt", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
-    database-tools-securitygroup = ""
+    database-tools-securitygroup    = ""
     database-tools-db-securitygroup = ""
   }
 }
@@ -44,6 +44,7 @@ inputs = {
   blazer_image_tag                = "latest"
   database-tools-securitygroup    = dependency.eks.outputs.database-tools-securitygroup
   database-tools-db-securitygroup = dependency.eks.outputs.database-tools-db-securitygroup
+  notify_url                      = "https://staging.notification.cdssandbox.xyz/"
 }
 
 terraform {

--- a/env/staging/database-tools/terragrunt.hcl
+++ b/env/staging/database-tools/terragrunt.hcl
@@ -26,7 +26,7 @@ dependency "eks" {
   mock_outputs_allowed_terraform_commands = ["validate", "plan", "init", "fmt", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
-    database-tools-securitygroup = ""
+    database-tools-securitygroup    = ""
     database-tools-db-securitygroup = ""
   }
 }
@@ -44,6 +44,7 @@ inputs = {
   blazer_image_tag                = "latest"
   database-tools-securitygroup    = dependency.eks.outputs.database-tools-securitygroup
   database-tools-db-securitygroup = dependency.eks.outputs.database-tools-db-securitygroup
+  notify_url                      = "https://staging.notification.cdssandbox.xyz/"
 }
 
 terraform {


### PR DESCRIPTION
# Summary | Résumé

Added a Notify URL in the Blazer runtime depending if it runs in staging or production. This will get used for the [linked_column feature](https://github.com/ankane/blazer#linked-columns) of Blazer.

# Test instructions | Instructions pour tester la modification

Deploy in staging environment and see if that works in Blazer with the special linked column called `service_id` (once Blazer is deployed as well).
