### PR TITLE
Converted to base URL instead of individual URL definitions

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -17,9 +17,10 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: ca-central-1
+  TF_VAR_base_domain: ${{secrets.PRODUCTION_BASE_DOMAIN}}
+  TF_VAR_alt_base_domain: ${{secrets.PRODUCTION_ALT_BASE_DOMAIN}}  
   TF_VAR_dbtools_password: ${{ secrets.PRODUCTION_DBTOOLS_PASSWORD }}
   TF_VAR_heartbeat_api_key: ${{ secrets.PRODUCTION_HEARTBEAT_API_KEY }}
-  TF_VAR_heartbeat_base_url: ${{ secrets.PRODUCTION_HEARTBEAT_BASE_URL }}
   TF_VAR_heartbeat_template_id: ${{ secrets.PRODUCTION_HEARTBEAT_TEMPLATE_ID }}
   TF_VAR_rds_cluster_password: ${{ secrets.PRODUCTION_RDS_CLUSTER_PASSWORD }}
   TF_VAR_app_db_user_password: ${{ secrets.PRODUCTION_APP_DB_USER_PASSWORD }}
@@ -34,7 +35,6 @@ env:
   TF_VAR_slack_channel_critical_topic: "notification-ops"
   TF_VAR_slack_channel_general_topic: "notification-ops"
   TF_VAR_cloudwatch_opsgenie_alarm_webhook: ${{ secrets.PRODUCTION_CLOUDWATCH_OPSGENIE_ALARM_WEBHOOK }}
-  TF_VAR_document_download_api_host: ${{ secrets.PRODUCTION_DOCUMENT_DOWNLOAD_API_HOST }}
   TF_VAR_new_relic_license_key: ${{ secrets.PRODUCTION_NEW_RELIC_LICENSE_KEY }}
   TF_VAR_waf_secret: ${{secrets.PRODUCTION_WAF_SECRET}}
   # Prevents repeated creation of the Slack lambdas if already existing.

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -20,9 +20,10 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: ca-central-1
+  TF_VAR_base_domain: ${{secrets.STAGING_BASE_DOMAIN}}
+  TF_VAR_alt_base_domain: ${{secrets.STAGING_ALT_BASE_DOMAIN}}
   TF_VAR_dbtools_password: ${{ secrets.STAGING_DBTOOLS_PASSWORD }}
   TF_VAR_heartbeat_api_key: ${{ secrets.STAGING_HEARTBEAT_API_KEY }}
-  TF_VAR_heartbeat_base_url: ${{ secrets.STAGING_HEARTBEAT_BASE_URL }}
   TF_VAR_heartbeat_template_id: ${{ secrets.STAGING_HEARTBEAT_TEMPLATE_ID }}
   TF_VAR_rds_cluster_password: ${{ secrets.STAGING_RDS_CLUSTER_PASSWORD }}
   TF_VAR_app_db_user_password: ${{ secrets.STAGING_APP_DB_USER_PASSWORD }}
@@ -37,7 +38,6 @@ env:
   TF_VAR_slack_channel_critical_topic: "notification-staging-ops"
   TF_VAR_slack_channel_general_topic: "notification-staging-ops"
   TF_VAR_cloudwatch_opsgenie_alarm_webhook: ""
-  TF_VAR_document_download_api_host: ${{ secrets.STAGING_DOCUMENT_DOWNLOAD_API_HOST }}
   TF_VAR_new_relic_license_key: ${{ secrets.STAGING_NEW_RELIC_LICENSE_KEY }}
   TF_VAR_perf_test_phone_number: ${{ secrets.PERF_TEST_PHONE_NUMBER }}
   TF_VAR_perf_test_email: ${{ secrets.PERF_TEST_EMAIL }}

--- a/.github/workflows/terragrunt_plan_production.yml
+++ b/.github/workflows/terragrunt_plan_production.yml
@@ -12,9 +12,10 @@ env:
   AWS_REGION: ca-central-1
   TERRAFORM_VERSION: 0.14.4
   TERRAGRUNT_VERSION: 0.35.13
+  TF_VAR_base_domain: ${{secrets.PRODUCTION_BASE_DOMAIN}}
+  TF_VAR_alt_base_domain: ${{secrets.PRODUCTION_ALT_BASE_DOMAIN}}
   TF_VAR_dbtools_password: ${{ secrets.PRODUCTION_DBTOOLS_PASSWORD }}
   TF_VAR_heartbeat_api_key: ${{ secrets.PRODUCTION_HEARTBEAT_API_KEY }}
-  TF_VAR_heartbeat_base_url: ${{ secrets.PRODUCTION_HEARTBEAT_BASE_URL }}
   TF_VAR_heartbeat_template_id: ${{ secrets.PRODUCTION_HEARTBEAT_TEMPLATE_ID }}
   TF_VAR_rds_cluster_password: ${{ secrets.PRODUCTION_RDS_CLUSTER_PASSWORD }}
   TF_VAR_app_db_user_password: ${{ secrets.PRODUCTION_APP_DB_USER_PASSWORD }}
@@ -29,7 +30,6 @@ env:
   TF_VAR_slack_channel_warning_topic: notification-ops
   TF_VAR_slack_channel_critical_topic: notification-ops
   TF_VAR_slack_channel_general_topic: notification-ops
-  TF_VAR_document_download_api_host: ${{ secrets.PRODUCTION_DOCUMENT_DOWNLOAD_API_HOST }}
   TF_VAR_new_relic_license_key: ${{ secrets.PRODUCTION_NEW_RELIC_LICENSE_KEY }}
   TF_VAR_waf_secret: ${{secrets.PRODUCTION_WAF_SECRET}}
   # Prevents repeated creation of the Slack lambdas if already existing.

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -16,9 +16,10 @@ env:
   AWS_REGION: ca-central-1
   TERRAFORM_VERSION: 0.14.4
   TERRAGRUNT_VERSION: 0.35.13
+  TF_VAR_base_domain: ${{secrets.STAGING_BASE_DOMAIN}}
+  TF_VAR_alt_base_domain: ${{secrets.STAGING_ALT_BASE_DOMAIN}}
   TF_VAR_dbtools_password: ${{ secrets.STAGING_DBTOOLS_PASSWORD }}
   TF_VAR_heartbeat_api_key: ${{ secrets.STAGING_HEARTBEAT_API_KEY }}
-  TF_VAR_heartbeat_base_url: ${{ secrets.STAGING_HEARTBEAT_BASE_URL }}
   TF_VAR_heartbeat_template_id: ${{ secrets.STAGING_HEARTBEAT_TEMPLATE_ID }}
   TF_VAR_rds_cluster_password: ${{ secrets.STAGING_RDS_CLUSTER_PASSWORD }}
   TF_VAR_app_db_user_password: ${{ secrets.STAGING_APP_DB_USER_PASSWORD }}
@@ -33,7 +34,6 @@ env:
   TF_VAR_slack_channel_warning_topic: "notification-staging-ops"
   TF_VAR_slack_channel_critical_topic: "notification-staging-ops"
   TF_VAR_slack_channel_general_topic: "notification-staging-ops"
-  TF_VAR_document_download_api_host: ${{ secrets.STAGING_DOCUMENT_DOWNLOAD_API_HOST }}
   TF_VAR_new_relic_license_key: ${{ secrets.STAGING_NEW_RELIC_LICENSE_KEY }}
   TF_VAR_waf_secret: ${{secrets.STAGING_WAF_SECRET}}
   # Prevents repeated creation of the Slack lambdas if already existing.

--- a/aws/heartbeat/lambda.tf
+++ b/aws/heartbeat/lambda.tf
@@ -10,7 +10,7 @@ module "heartbeat" {
 
   environment_variables = {
     heartbeat_api_key     = var.heartbeat_api_key
-    heartbeat_base_url    = var.heartbeat_base_url
+    heartbeat_base_url    = "['https://api-lambda.${var.base_domain}', 'https://api-k8s.${var.base_domain}']"
     heartbeat_template_id = var.heartbeat_template_id
   }
 }

--- a/aws/heartbeat/variables.tf
+++ b/aws/heartbeat/variables.tf
@@ -9,7 +9,7 @@ variable "heartbeat_api_key" {
   description = "Identifies the heartbeat api key."
 }
 
-variable "heartbeat_base_url" {
+variable "base_domain" {
   sensitive   = true
   type        = string
   description = "Identifies the base url to trigger the heartbeat function with. This is a string in the secrets and parsed in the lambda"

--- a/aws/lambda-api/api_gateway.tf
+++ b/aws/lambda-api/api_gateway.tf
@@ -115,7 +115,7 @@ resource "aws_api_gateway_stage" "api" {
 
 resource "aws_api_gateway_domain_name" "api" {
   regional_certificate_arn = var.certificate_arn
-  domain_name              = var.api_domain_name
+  domain_name              = "api.${var.base_domain}"
   security_policy          = "TLS_1_2"
 
   endpoint_configuration {
@@ -125,7 +125,7 @@ resource "aws_api_gateway_domain_name" "api" {
 
 resource "aws_api_gateway_domain_name" "api_lambda" {
   regional_certificate_arn = var.certificate_arn
-  domain_name              = var.api_lambda_domain_name
+  domain_name              = "api-lambda.${var.base_domain}"
   security_policy          = "TLS_1_2"
 
   endpoint_configuration {
@@ -135,7 +135,7 @@ resource "aws_api_gateway_domain_name" "api_lambda" {
 
 resource "aws_api_gateway_domain_name" "alt_api_lambda" {
   regional_certificate_arn = var.certificate_alt_arn
-  domain_name              = var.api_lambda_alt_domain_name
+  domain_name              = "api.${var.alt_base_domain}"
   security_policy          = "TLS_1_2"
 
   endpoint_configuration {

--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -26,9 +26,9 @@ resource "aws_lambda_function" "api" {
   }
   environment {
     variables = {
-      ADMIN_BASE_URL                 = var.admin_base_url
-      API_HOST_NAME                  = "https://${var.api_domain_name}"
-      DOCUMENT_DOWNLOAD_API_HOST     = var.document_download_api_host
+      ADMIN_BASE_URL                 = "https://${var.base_domain}"
+      API_HOST_NAME                  = "https://api.${var.base_domain}"
+      DOCUMENT_DOWNLOAD_API_HOST     = "https://api.document.${var.base_domain}"
       SQLALCHEMY_DATABASE_URI        = "postgresql://app_db_user:${var.app_db_user_password}@${var.database_read_write_proxy_endpoint}/NotificationCanadaCa${var.env}"
       SQLALCHEMY_DATABASE_READER_URI = "postgresql://app_db_user:${var.app_db_user_password}@${var.database_read_only_proxy_endpoint}/NotificationCanadaCa${var.env}"
       NOTIFICATION_QUEUE_PREFIX      = var.notification_queue_prefix

--- a/aws/lambda-api/variables.tf
+++ b/aws/lambda-api/variables.tf
@@ -1,16 +1,4 @@
-variable "admin_base_url" {
-  type = string
-}
-
-variable "api_domain_name" {
-  type = string
-}
-
-variable "api_lambda_domain_name" {
-  type = string
-}
-
-variable "api_lambda_alt_domain_name" {
+variable "alt_base_domain" {
   type = string
 }
 
@@ -51,7 +39,7 @@ variable "firehose_waf_logs_iam_role_arn" {
   type = string
 }
 
-variable "document_download_api_host" {
+variable "base_domain" {
   type = string
 }
 

--- a/env/production/lambda-api/terragrunt.hcl
+++ b/env/production/lambda-api/terragrunt.hcl
@@ -69,10 +69,6 @@ include {
 
 inputs = {
   env                                       = "production"
-  admin_base_url                            = "https://notification.canada.ca"
-  api_domain_name                           = "api.notification.canada.ca"
-  api_lambda_domain_name                    = "api-lambda.notification.canada.ca"
-  api_lambda_alt_domain_name                = "api.notification.alpha.canada.ca"
   api_image_tag                             = "release"
   eks_cluster_securitygroup                 = dependency.eks.outputs.eks-cluster-securitygroup
   vpc_private_subnets                       = dependency.common.outputs.vpc_private_subnets

--- a/env/scratch/dns/terragrunt.hcl
+++ b/env/scratch/dns/terragrunt.hcl
@@ -32,7 +32,7 @@ include {
 
 inputs = {
   notification_canada_ca_ses_callback_arn = dependency.common.outputs.notification_canada_ca_ses_callback_arn
-  ses_custom_sending_domains              = ["custom-sending-domain.staging.notification.cdssandbox.xyz"]
+  ses_custom_sending_domains              = ["custom-sending-domain.scratch.notification.cdssandbox.xyz"]
   lambda_ses_receiving_emails_image_arn   = dependency.ses_receiving_emails.outputs.lambda_ses_receiving_emails_image_arn
 }
 

--- a/env/scratch/heartbeat/terragrunt.hcl
+++ b/env/scratch/heartbeat/terragrunt.hcl
@@ -22,7 +22,7 @@ include {
 }
 
 inputs = {
-  billing_tag_value      = "notification-canada-ca-staging"
+  billing_tag_value      = "notification-canada-ca-scratch"
   schedule_expression    = "rate(1 minute)"
   sns_alert_warning_arn  = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn = dependency.common.outputs.sns_alert_critical_arn

--- a/env/scratch/lambda-api/terragrunt.hcl
+++ b/env/scratch/lambda-api/terragrunt.hcl
@@ -57,10 +57,6 @@ include {
 
 inputs = {
   env                                    = "scratch"
-  admin_base_url                         = "https://scratch.notification.cdssandbox.xyz"
-  api_domain_name                        = "api.scratch.notification.cdssandbox.xyz"
-  api_lambda_domain_name                 = "api-lambda.scratch.notification.cdssandbox.xyz"
-  api_lambda_alt_domain_name             = "api.alpha.scratch.notification.cdssandbox.xyz"
   api_image_tag                          = "latest"
   vpc_private_subnets                    = dependency.common.outputs.vpc_private_subnets
   redis_enabled                          = "1"

--- a/env/scratch/lambda-google-cidr/terragrunt.hcl
+++ b/env/scratch/lambda-google-cidr/terragrunt.hcl
@@ -28,7 +28,7 @@ include {
 }
 
 inputs = {
-  billing_tag_value                  = "notification-canada-ca-staging"
+  billing_tag_value                  = "notification-canada-ca-scratch"
   google_cidr_schedule_expression    = "rate(1 day)"
   google_cidr_prefix_list_id         = dependency.eks.outputs.google_cidr_prefix_list_id
   google_cidr_ecr_repository_url     = dependency.ecr.outputs.google_cidr_ecr_repository_url

--- a/env/scratch/performance-test/terragrunt.hcl
+++ b/env/scratch/performance-test/terragrunt.hcl
@@ -51,9 +51,9 @@ inputs = {
   aws_pinpoint_region       = "ca-central-1"
 
   billing_tag_key                             = "CostCenter"
-  billing_tag_value                           = "notification-canada-ca-staging"
+  billing_tag_value                           = "notification-canada-ca-scratch"
   schedule_expression                         = "cron(0 0 * * ? *)"
-  perf_test_aws_s3_bucket                     = "notify-performance-test-results-staging"
+  perf_test_aws_s3_bucket                     = "notify-performance-test-results-scratch"
   perf_test_csv_directory_path                = "/tmp/notify_performance_test"
   perf_test_sms_template_id                   = "d5fea9f3-f69d-481e-9186-b7f4eaa5cf63"
   perf_test_bulk_email_template_id            = "fa759679-30f2-4666-94e2-bd4921329c46"

--- a/env/scratch/ses_to_sqs_email_callbacks/terragrunt.hcl
+++ b/env/scratch/ses_to_sqs_email_callbacks/terragrunt.hcl
@@ -30,7 +30,7 @@ include {
 }
 
 inputs = {
-  billing_tag_value                                   = "notification-canada-ca-staging"
+  billing_tag_value                                   = "notification-canada-ca-scratch"
   notification_canada_ca_ses_callback_arn             = dependency.common.outputs.notification_canada_ca_ses_callback_arn
   sns_alert_warning_arn                               = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                              = dependency.common.outputs.sns_alert_critical_arn

--- a/env/scratch/sns_to_sqs_sms_callbacks/terragrunt.hcl
+++ b/env/scratch/sns_to_sqs_sms_callbacks/terragrunt.hcl
@@ -33,7 +33,7 @@ include {
 }
 
 inputs = {
-  billing_tag_value                             = "notification-canada-ca-staging"
+  billing_tag_value                             = "notification-canada-ca-scratch"
   sns_deliveries_ca_central_arn                 = dependency.common.outputs.sns_deliveries_ca_central_arn
   sns_deliveries_ca_central_name                = dependency.common.outputs.sns_deliveries_ca_central_name
   sns_deliveries_failures_ca_central_arn        = dependency.common.outputs.sns_deliveries_failures_ca_central_arn

--- a/env/staging/lambda-api/terragrunt.hcl
+++ b/env/staging/lambda-api/terragrunt.hcl
@@ -57,10 +57,6 @@ include {
 
 inputs = {
   env                                    = "staging"
-  admin_base_url                         = "https://staging.notification.cdssandbox.xyz"
-  api_domain_name                        = "api.staging.notification.cdssandbox.xyz"
-  api_lambda_domain_name                 = "api-lambda.staging.notification.cdssandbox.xyz"
-  api_lambda_alt_domain_name             = "api.staging.notification.alpha.cdssandbox.xyz"
   api_image_tag                          = "latest"
   vpc_private_subnets                    = dependency.common.outputs.vpc_private_subnets
   redis_enabled                          = "1"


### PR DESCRIPTION
# Summary | Résumé

Instead of having to define individual URLs for all of the different endpoints, I have created a base_domain (and alt_base_domain) variable that can be set once to the root domain. From there, TF will automatically create the appropriate URLs.

# Test instructions | Instructions pour tester la modification

Tested in scratch.
Test in staging, TF Plan should show minimal changes (since the domains are the same).  There will be a recreate on api gateway due to a weird trigger based on the file contents, and not the actual values that are sent.
