### PR TITLE
fix: remove Salesforce errors from API error metric

### DIFF
--- a/aws/lambda-api/cloudwatch_logs.tf
+++ b/aws/lambda-api/cloudwatch_logs.tf
@@ -54,7 +54,7 @@ data "aws_iam_policy_document" "api_assume" {
 
 resource "aws_cloudwatch_log_metric_filter" "errors-lambda-api" {
   name           = "errors-lambda-api"
-  pattern        = "\"\\\"levelname\\\": \\\"ERROR\\\"\""
+  pattern        = "\"\\\"levelname\\\": \\\"ERROR\\\"\" -\"SF_ERR\""
   log_group_name = aws_cloudwatch_log_group.api_lambda_log_group.name
 
   metric_transformation {


### PR DESCRIPTION
# Summary
Update the Lambda API error metric to no longer trigger for Salesforce errors, which are identified by the `SF_ERR` token.

This will stop both alarms from triggering if a Salesforce error is detected.