### PR TITLE
fix: Terraform module version references

### DIFF
--- a/aws/common/file_scanning.tf
+++ b/aws/common/file_scanning.tf
@@ -1,5 +1,5 @@
 module "s3_scan_objects" {
-  source = "github.com/cds-snc/terraform-modules?ref=v6.0.1//S3_scan_object"
+  source = "github.com/cds-snc/terraform-modules//S3_scan_object?ref=v6.0.1"
 
   s3_upload_bucket_name = "notification-canada-ca-${var.env}-document-download-scan-files"
   billing_tag_value     = var.billing_tag_value

--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -43,7 +43,7 @@ resource "aws_s3_bucket_public_access_block" "csv_bucket" {
 }
 
 module "csv_bucket_logs" {
-  source = "github.com/cds-snc/terraform-modules?ref=v5.1.8//S3_log_bucket"
+  source = "github.com/cds-snc/terraform-modules//S3_log_bucket?ref=v5.1.8"
 
   bucket_name       = "notification-canada-ca-${var.env}-csv-upload-logs"
   force_destroy     = var.force_destroy_s3
@@ -98,7 +98,7 @@ resource "aws_s3_bucket_public_access_block" "bulk_send" {
 }
 
 module "bulk_send_logs" {
-  source = "github.com/cds-snc/terraform-modules?ref=v5.1.8//S3_log_bucket"
+  source = "github.com/cds-snc/terraform-modules//S3_log_bucket?ref=v5.1.8"
 
   bucket_name       = "notification-canada-ca-${var.env}-bulk-send-logs"
   force_destroy     = var.force_destroy_s3
@@ -270,7 +270,7 @@ resource "aws_s3_bucket_public_access_block" "scan_files_document_bucket" {
 }
 
 module "document_download_logs" {
-  source = "github.com/cds-snc/terraform-modules?ref=v5.1.8//S3_log_bucket"
+  source = "github.com/cds-snc/terraform-modules//S3_log_bucket?ref=v5.1.8"
 
   bucket_name       = "notification-canada-ca-${var.env}-document-download-logs"
   force_destroy     = var.force_destroy_s3
@@ -402,7 +402,7 @@ resource "aws_s3_bucket_public_access_block" "athena_bucket" {
 }
 
 module "athena_logs_bucket" {
-  source = "github.com/cds-snc/terraform-modules?ref=v5.1.8//S3_log_bucket"
+  source = "github.com/cds-snc/terraform-modules//S3_log_bucket?ref=v5.1.8"
 
   bucket_name       = "notification-canada-ca-${var.env}-athena-logs"
   force_destroy     = var.force_destroy_s3
@@ -416,7 +416,7 @@ module "athena_logs_bucket" {
 }
 
 module "cbs_logs_bucket" {
-  source = "github.com/cds-snc/terraform-modules?ref=v5.1.8//S3_log_bucket"
+  source = "github.com/cds-snc/terraform-modules//S3_log_bucket?ref=v5.1.8"
   count  = var.create_cbs_bucket ? 1 : 0
 
   bucket_name                    = var.cbs_satellite_bucket_name

--- a/aws/eks/sentinel.tf
+++ b/aws/eks/sentinel.tf
@@ -8,7 +8,7 @@ locals {
 # and https://docs.google.com/document/d/16LLelZ7WEKrnbocrl0Az74JqkCv5DBZ9QILRBUFJQt8/edit#heading=h.z87ipkd84djw
 module "sentinel_forwarder" {
   count             = var.enable_sentinel_forwarding ? 1 : 0
-  source            = "github.com/cds-snc/terraform-modules?ref=v4.0.2//sentinel_forwarder"
+  source            = "github.com/cds-snc/terraform-modules//sentinel_forwarder?ref=v4.0.2"
   function_name     = "sentinel-cloud-watch-forwarder"
   billing_tag_value = "notification-canada-ca-${var.env}"
 

--- a/aws/heartbeat/lambda.tf
+++ b/aws/heartbeat/lambda.tf
@@ -1,5 +1,5 @@
 module "heartbeat" {
-  source                 = "github.com/cds-snc/terraform-modules?ref=v0.0.45//lambda"
+  source                 = "github.com/cds-snc/terraform-modules//lambda?ref=v0.0.45"
   name                   = "heartbeat"
   billing_tag_value      = var.billing_tag_value
   ecr_arn                = var.heartbeat_ecr_arn

--- a/aws/lambda-google-cidr/lambda.tf
+++ b/aws/lambda-google-cidr/lambda.tf
@@ -1,5 +1,5 @@
 module "lambda-google-cidr" {
-  source                 = "github.com/cds-snc/terraform-modules?ref=v4.0.1//lambda"
+  source                 = "github.com/cds-snc/terraform-modules//lambda?ref=v4.0.1"
   name                   = "google-cidr"
   billing_tag_value      = var.billing_tag_value
   ecr_arn                = var.google_cidr_ecr_arn

--- a/aws/performance-test/s3.tf
+++ b/aws/performance-test/s3.tf
@@ -1,5 +1,5 @@
 module "notify_performance_test_results" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v0.0.38//S3"
+  source            = "github.com/cds-snc/terraform-modules//S3?ref=v0.0.38"
   bucket_name       = "notify-performance-test-results-${var.env}"
   billing_tag_value = "notification-canada-ca-${var.env}"
 }

--- a/aws/ses_receiving_emails/lambda.tf
+++ b/aws/ses_receiving_emails/lambda.tf
@@ -4,7 +4,7 @@ module "ses_receiving_emails" {
     aws = aws.us-east-1
   }
 
-  source                 = "github.com/cds-snc/terraform-modules?ref=v4.0.3//lambda"
+  source                 = "github.com/cds-snc/terraform-modules//lambda?ref=v4.0.3"
   name                   = "ses_receiving_emails"
   billing_tag_value      = var.billing_tag_value
   ecr_arn                = var.ses_receiving_emails_ecr_arn

--- a/aws/ses_to_sqs_email_callbacks/lambda.tf
+++ b/aws/ses_to_sqs_email_callbacks/lambda.tf
@@ -1,5 +1,5 @@
 module "ses_to_sqs_email_callbacks" {
-  source                 = "github.com/cds-snc/terraform-modules?ref=v4.0.3//lambda"
+  source                 = "github.com/cds-snc/terraform-modules//lambda?ref=v4.0.3"
   name                   = "ses_to_sqs_email_callbacks"
   billing_tag_value      = var.billing_tag_value
   ecr_arn                = var.ses_to_sqs_email_callbacks_ecr_arn

--- a/aws/sns_to_sqs_sms_callbacks/lambda.tf
+++ b/aws/sns_to_sqs_sms_callbacks/lambda.tf
@@ -1,5 +1,5 @@
 module "sns_to_sqs_sms_callbacks" {
-  source                 = "github.com/cds-snc/terraform-modules?ref=v4.0.3//lambda"
+  source                 = "github.com/cds-snc/terraform-modules//lambda?ref=v4.0.3"
   name                   = "sns_to_sqs_sms_callbacks"
   billing_tag_value      = var.billing_tag_value
   ecr_arn                = var.sns_to_sqs_sms_callbacks_ecr_arn


### PR DESCRIPTION
# Summary
Update the Terraform module version references so they are in the [correct format](https://developer.hashicorp.com/terraform/language/modules/sources#modules-in-package-sub-directories): 

> If the source address has arguments, such as the ref argument supported for the version control sources, the sub-directory portion must be before those arguments.

This will allow Renovate dependency PRs to update the module versions without stripping the `//sub-directory` path.

# Note
There should be no TF plan changes.