### PR TITLE
Cloudwatch alarms for evicted pods in k8s

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -614,3 +614,83 @@ resource "aws_cloudwatch_metric_alarm" "document-download-api-replicas-unavailab
     }
   }
 }
+
+resource "aws_cloudwatch_metric_alarm" "api-evicted-pods" {
+  alarm_name                = "evicted-api-pods-detected"
+  alarm_description         = "One or more Kubernetes API Pods is reporting as Evicted"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = aws_cloudwatch_log_metric_filter.api-evicted-pods.name
+  namespace                 = aws_cloudwatch_log_metric_filter.api-evicted-pods.metric_transformation[0].namespace
+  period                    = "60"
+  statistic                 = "Sum"
+  threshold                 = 1
+  treat_missing_data        = "notBreaching"
+  alarm_actions             = [var.sns_alert_warning_arn]
+  ok_actions                = [var.sns_alert_warning_arn]
+  insufficient_data_actions = [var.sns_alert_warning_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "celery-evicted-pods" {
+  alarm_name                = "evicted-celery-pods-detected"
+  alarm_description         = "One or more Kubernetes Celery Pods is reporting as Evicted"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = aws_cloudwatch_log_metric_filter.celery-evicted-pods.name
+  namespace                 = aws_cloudwatch_log_metric_filter.celery-evicted-pods.metric_transformation[0].namespace
+  period                    = "60"
+  statistic                 = "Sum"
+  threshold                 = 1
+  treat_missing_data        = "notBreaching"
+  alarm_actions             = [var.sns_alert_warning_arn]
+  ok_actions                = [var.sns_alert_warning_arn]
+  insufficient_data_actions = [var.sns_alert_warning_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "admin-evicted-pods" {
+  alarm_name                = "evicted-admin-pods-detected"
+  alarm_description         = "One or more Kubernetes Admin Pods is reporting as Evicted"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = aws_cloudwatch_log_metric_filter.admin-evicted-pods.name
+  namespace                 = aws_cloudwatch_log_metric_filter.admin-evicted-pods.metric_transformation[0].namespace
+  period                    = "60"
+  statistic                 = "Sum"
+  threshold                 = 1
+  treat_missing_data        = "notBreaching"
+  alarm_actions             = [var.sns_alert_warning_arn]
+  ok_actions                = [var.sns_alert_warning_arn]
+  insufficient_data_actions = [var.sns_alert_warning_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "document-download-evicted-pods" {
+  alarm_name                = "evicted-document-download-pods-detected"
+  alarm_description         = "One or more Kubernetes Document Download Pods is reporting as Evicted"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = aws_cloudwatch_log_metric_filter.document-download-evicted-pods.name
+  namespace                 = aws_cloudwatch_log_metric_filter.document-download-evicted-pods.metric_transformation[0].namespace
+  period                    = "60"
+  statistic                 = "Sum"
+  threshold                 = 1
+  treat_missing_data        = "notBreaching"
+  alarm_actions             = [var.sns_alert_warning_arn]
+  ok_actions                = [var.sns_alert_warning_arn]
+  insufficient_data_actions = [var.sns_alert_warning_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "documentation-evicted-pods" {
+  alarm_name                = "evicted-documentation-pods-detected"
+  alarm_description         = "One or more Kubernetes Documentation Pods is reporting as Evicted"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = aws_cloudwatch_log_metric_filter.documentation-evicted-pods.name
+  namespace                 = aws_cloudwatch_log_metric_filter.documentation-evicted-pods.metric_transformation[0].namespace
+  period                    = "60"
+  statistic                 = "Sum"
+  threshold                 = 1
+  treat_missing_data        = "notBreaching"
+  alarm_actions             = [var.sns_alert_warning_arn]
+  ok_actions                = [var.sns_alert_warning_arn]
+  insufficient_data_actions = [var.sns_alert_warning_arn]
+}

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -12,6 +12,11 @@ resource "aws_cloudwatch_log_group" "notification-canada-ca-eks-application-logs
   retention_in_days = var.env == "production" ? 0 : 30
 }
 
+resource "aws_cloudwatch_log_group" "notification-canada-ca-eks-prometheus-logs" {
+  name              = "/aws/containerinsights/${var.eks_cluster_name}/prometheus"
+  retention_in_days = 0
+}
+
 
 ###
 # AWS EKS Cloudwatch log metric filters
@@ -83,6 +88,66 @@ resource "aws_cloudwatch_log_metric_filter" "bounce-rate-warning" {
 
   metric_transformation {
     name      = "bounce-rate-warning"
+    namespace = "LogMetrics"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "api-evicted-pods" {
+  name           = "api-evicted-pods"
+  pattern        = "{ ($.reason = \"Evicted\") && ($.kube_pod_status_reason = 1) && ($.pod = \"api-*\") }"
+  log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-prometheus-logs.name
+
+  metric_transformation {
+    name      = "api-evicted-pods"
+    namespace = "LogMetrics"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "celery-evicted-pods" {
+  name           = "celery-evicted-pods"
+  pattern        = "{ ($.reason = \"Evicted\") && ($.kube_pod_status_reason = 1) && ($.pod = \"celery-*\") }"
+  log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-prometheus-logs.name
+
+  metric_transformation {
+    name      = "celery-evicted-pods"
+    namespace = "LogMetrics"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "admin-evicted-pods" {
+  name           = "admin-evicted-pods"
+  pattern        = "{ ($.reason = \"Evicted\") && ($.kube_pod_status_reason = 1) && ($.pod = \"admin-*\") }"
+  log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-prometheus-logs.name
+
+  metric_transformation {
+    name      = "admin-evicted-pods"
+    namespace = "LogMetrics"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "document-download-evicted-pods" {
+  name           = "document-download-evicted-pods"
+  pattern        = "{ ($.reason = \"Evicted\") && ($.kube_pod_status_reason = 1) && ($.pod = \"document-download-*\") }"
+  log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-prometheus-logs.name
+
+  metric_transformation {
+    name      = "document-download-evicted-pods"
+    namespace = "LogMetrics"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "documentation-evicted-pods" {
+  name           = "documentation-evicted-pods"
+  pattern        = "{ ($.reason = \"Evicted\") && ($.kube_pod_status_reason = 1) && ($.pod = \"documentation-*\") }"
+  log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-prometheus-logs.name
+
+  metric_transformation {
+    name      = "documentation-evicted-pods"
     namespace = "LogMetrics"
     value     = "1"
   }


### PR DESCRIPTION
# Summary | Résumé

Adding alarms that will trigger when any of the notify apps show evicted pods.

**NOTE: A manual import of the prometheus cloudwatch log group will be required for staging and prod.**

# Test instructions | Instructions pour tester la modification

Tested in scratch.

Unfortunately there doesn't seem to be an easy way to test this exactly. I verified that the queries return the correct data in staging on June 16th. I also tested the inverse query (kube_pod_status_reason = 0) to validate that the alarm trips. 