### PR TITLE
Prod dns migration prep

### DIFF
--- a/aws/dns/notification.canada.ca.tf
+++ b/aws/dns/notification.canada.ca.tf
@@ -1,0 +1,131 @@
+resource "aws_route53_zone" "notification-canada-ca" {
+  count = var.env == "production" ? 1 : 0
+  name  = "notification.canada.ca"
+}
+
+resource "aws_route53_record" "notification-canada-ca-ACM-cname" {
+  count = var.env == "production" ? 1 : 0
+  zone_id = aws_route53_zone.notification-canada-ca[0].zone_id
+  name    = "_2115a5004ab7895234c60254e152046b.notification.canada.ca"
+  type    = "CNAME"
+  records = [
+    "_aaacd89cd470de0970c70c7ab1b7d4d5.wggjkglgrm.acm-validations.aws."
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "document-notification-canada-ca-ACM-cname" {
+  count = var.env == "production" ? 1 : 0
+  zone_id = aws_route53_zone.notification-canada-ca[0].zone_id
+  name    = "_db43d1cf891afd4671fb913d18ef0a0e.document.notification.canada.ca"
+  type    = "CNAME"
+  records = [
+    "_130ea19fa1fdd9e59b7632fbac0d7e00.wggjkglgrm.acm-validations.aws."
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "api-notification-canada-ca-ACM-cname" {
+  count = var.env == "production" ? 1 : 0
+  zone_id = aws_route53_zone.notification-canada-ca[0].zone_id
+  name    = "_902cdb1a2cb8214fc698261ee3085b64.api.notification.canada.ca."
+  type    = "CNAME"
+  records = [
+    "_ac309158c158035bfb929da1617e2b16.mqzgcdqkwq.acm-validations.aws."
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "assets-notification-canada-ca-ACM-cname" {
+  count = var.env == "production" ? 1 : 0
+  zone_id = aws_route53_zone.notification-canada-ca[0].zone_id
+  name    = "_4e30c74d7459e0d63bdcdaac7a57fdcf.assets.notification.canada.ca"
+  type    = "CNAME"
+  records = [
+    "_2da9b84f7e094fd64c8930cffe8d9842.wggjkglgrm.acm-validations.aws."
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "assets-notification-canada-ca-cname" {
+  count = var.env == "production" ? 1 : 0
+  zone_id = aws_route53_zone.notification-canada-ca[0].zone_id
+  name    = "assets.notification.canada.ca"
+  type    = "CNAME"
+  records = [
+    "d1spq0ojswv1dj.cloudfront.net"
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "notification-canada-ca-SPF" {
+  count = var.env == "production" ? 1 : 0  
+  zone_id = aws_route53_zone.notification-canada-ca[0].zone_id
+  name    = "notification.canada.ca"
+  type    = "TXT"
+  records = [
+    # Used for https://postmaster.google.com
+    "google-site-verification=KMFWVel40xicbDXojkXz_1B2gBlPFSqF69cVdH_dfn0",
+    "google-site-verification=WNq0Z6naWk2E9SfS9eYq6Y6ZHH29nmkgox3chj5I9iE",
+    "v=spf1 include:amazonses.com -all"
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "notification-canada-ca-DMARC" {
+  count = var.env == "production" ? 1 : 0
+  zone_id = aws_route53_zone.notification-canada-ca[0].zone_id
+  name    = "_dmarc.notification.canada.ca"
+  type    = "TXT"
+  records = [
+    "v=DMARC1; p=reject; sp=reject; pct=100; rua=mailto:dmarc@cyber.gc.ca"
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "amazonses-notification-canada-ca-TXT" {
+  count = var.env == "production" ? 1 : 0
+  zone_id = aws_route53_zone.notification-canada-ca[0].zone_id
+  name    = "_amazonses.notification.canada.ca"
+  type    = "TXT"
+  records = [
+    # ca-central-1
+    "Ohfl/Syh3ZT5U/7IKELTCXIRaqI42ZJiw0HiUQoCHww=",
+    # us-east-1 for inbound emails
+    "FHX+PBM3ip2HfDeSXs3WpEuQZydluvX9VpOdBKj0dgU="
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "amazonses-mail-from-notification-canada-ca-TXT" {
+  count = var.env == "production" ? 1 : 0
+  zone_id = aws_route53_zone.notification-canada-ca[0].zone_id
+  name    = "bounce.notification.canada.ca"
+  type    = "TXT"
+  records = [
+    "v=spf1 include:amazonses.com -all"
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "amazonses-mail-from-notification-canada-ca-MX" {
+  count = var.env == "production" ? 1 : 0
+  zone_id = aws_route53_zone.notification-canada-ca[0].zone_id
+  name    = "bounce.notification.canada.ca"
+  type    = "MX"
+  records = [
+    "10 feedback-smtp.ca-central-1.amazonses.com"
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "amazonses-inbound-notification-canada-ca-MX" {
+  count = var.env == "production" ? 1 : 0
+  zone_id = aws_route53_zone.notification-canada-ca[0].zone_id
+  name    = "notification.canada.ca"
+  type    = "MX"
+  records = [
+    "10 inbound-smtp.us-east-1.amazonaws.com"
+  ]
+  ttl = "300"
+}

--- a/aws/dns/notification.canada.ca.tf
+++ b/aws/dns/notification.canada.ca.tf
@@ -4,7 +4,7 @@ resource "aws_route53_zone" "notification-canada-ca" {
 }
 
 resource "aws_route53_record" "notification-canada-ca-ACM-cname" {
-  count = var.env == "production" ? 1 : 0
+  count   = var.env == "production" ? 1 : 0
   zone_id = aws_route53_zone.notification-canada-ca[0].zone_id
   name    = "_2115a5004ab7895234c60254e152046b.notification.canada.ca"
   type    = "CNAME"
@@ -15,7 +15,7 @@ resource "aws_route53_record" "notification-canada-ca-ACM-cname" {
 }
 
 resource "aws_route53_record" "document-notification-canada-ca-ACM-cname" {
-  count = var.env == "production" ? 1 : 0
+  count   = var.env == "production" ? 1 : 0
   zone_id = aws_route53_zone.notification-canada-ca[0].zone_id
   name    = "_db43d1cf891afd4671fb913d18ef0a0e.document.notification.canada.ca"
   type    = "CNAME"
@@ -26,7 +26,7 @@ resource "aws_route53_record" "document-notification-canada-ca-ACM-cname" {
 }
 
 resource "aws_route53_record" "api-notification-canada-ca-ACM-cname" {
-  count = var.env == "production" ? 1 : 0
+  count   = var.env == "production" ? 1 : 0
   zone_id = aws_route53_zone.notification-canada-ca[0].zone_id
   name    = "_902cdb1a2cb8214fc698261ee3085b64.api.notification.canada.ca."
   type    = "CNAME"
@@ -37,7 +37,7 @@ resource "aws_route53_record" "api-notification-canada-ca-ACM-cname" {
 }
 
 resource "aws_route53_record" "assets-notification-canada-ca-ACM-cname" {
-  count = var.env == "production" ? 1 : 0
+  count   = var.env == "production" ? 1 : 0
   zone_id = aws_route53_zone.notification-canada-ca[0].zone_id
   name    = "_4e30c74d7459e0d63bdcdaac7a57fdcf.assets.notification.canada.ca"
   type    = "CNAME"
@@ -48,7 +48,7 @@ resource "aws_route53_record" "assets-notification-canada-ca-ACM-cname" {
 }
 
 resource "aws_route53_record" "assets-notification-canada-ca-cname" {
-  count = var.env == "production" ? 1 : 0
+  count   = var.env == "production" ? 1 : 0
   zone_id = aws_route53_zone.notification-canada-ca[0].zone_id
   name    = "assets.notification.canada.ca"
   type    = "CNAME"
@@ -59,7 +59,7 @@ resource "aws_route53_record" "assets-notification-canada-ca-cname" {
 }
 
 resource "aws_route53_record" "notification-canada-ca-SPF" {
-  count = var.env == "production" ? 1 : 0  
+  count   = var.env == "production" ? 1 : 0
   zone_id = aws_route53_zone.notification-canada-ca[0].zone_id
   name    = "notification.canada.ca"
   type    = "TXT"
@@ -73,7 +73,7 @@ resource "aws_route53_record" "notification-canada-ca-SPF" {
 }
 
 resource "aws_route53_record" "notification-canada-ca-DMARC" {
-  count = var.env == "production" ? 1 : 0
+  count   = var.env == "production" ? 1 : 0
   zone_id = aws_route53_zone.notification-canada-ca[0].zone_id
   name    = "_dmarc.notification.canada.ca"
   type    = "TXT"
@@ -84,7 +84,7 @@ resource "aws_route53_record" "notification-canada-ca-DMARC" {
 }
 
 resource "aws_route53_record" "amazonses-notification-canada-ca-TXT" {
-  count = var.env == "production" ? 1 : 0
+  count   = var.env == "production" ? 1 : 0
   zone_id = aws_route53_zone.notification-canada-ca[0].zone_id
   name    = "_amazonses.notification.canada.ca"
   type    = "TXT"
@@ -98,7 +98,7 @@ resource "aws_route53_record" "amazonses-notification-canada-ca-TXT" {
 }
 
 resource "aws_route53_record" "amazonses-mail-from-notification-canada-ca-TXT" {
-  count = var.env == "production" ? 1 : 0
+  count   = var.env == "production" ? 1 : 0
   zone_id = aws_route53_zone.notification-canada-ca[0].zone_id
   name    = "bounce.notification.canada.ca"
   type    = "TXT"
@@ -109,7 +109,7 @@ resource "aws_route53_record" "amazonses-mail-from-notification-canada-ca-TXT" {
 }
 
 resource "aws_route53_record" "amazonses-mail-from-notification-canada-ca-MX" {
-  count = var.env == "production" ? 1 : 0
+  count   = var.env == "production" ? 1 : 0
   zone_id = aws_route53_zone.notification-canada-ca[0].zone_id
   name    = "bounce.notification.canada.ca"
   type    = "MX"
@@ -120,7 +120,7 @@ resource "aws_route53_record" "amazonses-mail-from-notification-canada-ca-MX" {
 }
 
 resource "aws_route53_record" "amazonses-inbound-notification-canada-ca-MX" {
-  count = var.env == "production" ? 1 : 0
+  count   = var.env == "production" ? 1 : 0
   zone_id = aws_route53_zone.notification-canada-ca[0].zone_id
   name    = "notification.canada.ca"
   type    = "MX"

--- a/aws/dns/outputs.tf
+++ b/aws/dns/outputs.tf
@@ -8,8 +8,12 @@ output "dkim_verification_token" {
   value       = aws_ses_domain_dkim.notification-canada-ca.dkim_tokens
 }
 
-output "route_53_zone_arn" {
+output "staging_route_53_zone_arn" {
   value = var.env == "staging" ? aws_route53_zone.notification-sandbox[0].zone_id : null
+}
+
+output "production_route_53_zone_arn" {
+  value = var.env == "production" ? aws_route53_zone.notification-canada-ca[0].zone_id : null
 }
 
 output "custom_sending_domains_dkim" {

--- a/aws/eks/dns.tf
+++ b/aws/eks/dns.tf
@@ -1,6 +1,6 @@
 resource "aws_route53_record" "notification-root" {
-  count    = var.env != "production" ? 1 : 0
-  provider = aws.staging
+
+  provider = aws.dns
   zone_id  = var.route_53_zone_arn
   name     = var.domain
   type     = "A"
@@ -8,13 +8,13 @@ resource "aws_route53_record" "notification-root" {
   alias {
     name                   = aws_alb.notification-canada-ca.dns_name
     zone_id                = aws_alb.notification-canada-ca.zone_id
-    evaluate_target_health = false
+    evaluate_target_health = true
   }
 }
 
 resource "aws_route53_record" "notificatio-root-WC" {
-  count    = var.env != "production" ? 1 : 0
-  provider = aws.staging
+
+  provider = aws.dns
   name     = "*.${var.domain}"
   zone_id  = var.route_53_zone_arn
   type     = "A"
@@ -28,8 +28,9 @@ resource "aws_route53_record" "notificatio-root-WC" {
 }
 
 resource "aws_route53_record" "notification-alt-root" {
+  #TODO: For production
   count    = var.env != "production" ? 1 : 0
-  provider = aws.staging
+  provider = aws.dns
   zone_id  = var.route_53_zone_arn
   name     = var.alt_domain
   type     = "A"
@@ -42,8 +43,9 @@ resource "aws_route53_record" "notification-alt-root" {
 }
 
 resource "aws_route53_record" "notification-alt-root-WC" {
+  #TODO: For production
   count    = var.env != "production" ? 1 : 0
-  provider = aws.staging
+  provider = aws.dns
   name     = "*.${var.alt_domain}"
   zone_id  = var.route_53_zone_arn
   type     = "A"
@@ -58,8 +60,7 @@ resource "aws_route53_record" "notification-alt-root-WC" {
 
 
 resource "aws_route53_record" "api-k8s-scratch-notification-CNAME" {
-  count    = var.env != "production" ? 1 : 0
-  provider = aws.staging
+  provider = aws.dns
   zone_id  = var.route_53_zone_arn
   name     = "api-k8s.${var.domain}"
   type     = "CNAME"
@@ -69,8 +70,7 @@ resource "aws_route53_record" "api-k8s-scratch-notification-CNAME" {
 
 resource "aws_route53_record" "api-weighted-0-scratch-notification-A" {
   # Send no API traffic to K8s
-  count          = var.env != "production" ? 1 : 0
-  provider       = aws.staging
+  provider       = aws.dns
   zone_id        = var.route_53_zone_arn
   name           = "api.${var.domain}"
   type           = "A"

--- a/aws/lambda-api/dns.tf
+++ b/aws/lambda-api/dns.tf
@@ -1,6 +1,6 @@
 resource "aws_route53_record" "api-lambda-notification-A" {
-  count    = var.env != "production" ? 1 : 0
-  provider = aws.staging
+
+  provider = aws.dns
 
   zone_id = var.route_53_zone_arn
   name    = "api-lambda.${var.domain}"
@@ -9,15 +9,14 @@ resource "aws_route53_record" "api-lambda-notification-A" {
   alias {
     name                   = aws_api_gateway_domain_name.api_lambda.regional_domain_name
     zone_id                = aws_api_gateway_domain_name.api_lambda.regional_zone_id
-    evaluate_target_health = false
+    evaluate_target_health = true
   }
 
 }
 
 resource "aws_route53_record" "api-weighted-100-notification-A" {
   # Send all API traffic to Lambda
-  count    = var.env != "production" ? 1 : 0
-  provider = aws.staging
+  provider = aws.dns
 
   zone_id        = var.route_53_zone_arn
   name           = "api.${var.domain}"
@@ -27,7 +26,7 @@ resource "aws_route53_record" "api-weighted-100-notification-A" {
   alias {
     name                   = aws_api_gateway_domain_name.api_lambda.regional_domain_name
     zone_id                = aws_api_gateway_domain_name.api_lambda.regional_zone_id
-    evaluate_target_health = false
+    evaluate_target_health = true
   }
 
   weighted_routing_policy {
@@ -36,6 +35,7 @@ resource "aws_route53_record" "api-weighted-100-notification-A" {
 }
 
 resource "aws_route53_record" "api-notification-alt-A" {
+  #TODO: Alt DNS for Prod
   count    = var.env != "production" ? 1 : 0
   provider = aws.staging
 

--- a/aws/ses_validation_dns_entries/sesValidationDnsEntries.tf
+++ b/aws/ses_validation_dns_entries/sesValidationDnsEntries.tf
@@ -1,6 +1,6 @@
 resource "aws_route53_record" "ses_custom_domain_dkim_record" {
   for_each        = { for cd in jsondecode(var.custom_sending_domains_dkim) : "${cd.domain}.${cd.token}" => cd }
-  provider        = aws.staging
+  provider        = aws.dns
   zone_id         = var.route53_zone_arn
   name            = "${each.value.token}._domainkey.${each.value.domain}"
   type            = "CNAME"
@@ -12,7 +12,7 @@ resource "aws_route53_record" "ses_custom_domain_dkim_record" {
 
 resource "aws_route53_record" "notification_canada_ca_dkim_record" {
   for_each        = { for s in jsondecode(var.notification_canada_ca_dkim) : "${s}" => s }
-  provider        = aws.staging
+  provider        = aws.dns
   zone_id         = var.route53_zone_arn
   name            = "${each.value}._domainkey.${var.domain}"
   type            = "CNAME"
@@ -24,7 +24,7 @@ resource "aws_route53_record" "notification_canada_ca_dkim_record" {
 
 resource "aws_route53_record" "ses_cic_trvapply_vrtdemande_dkim_record" {
   for_each        = { for cd in jsondecode(var.cic_trvapply_vrtdemande_dkim) : "${cd.domain}.${cd.token}" => cd }
-  provider        = aws.staging
+  provider        = aws.dns
   zone_id         = var.route53_zone_arn
   name            = "${each.value.token}._domainkey.${each.value.domain}"
   type            = "CNAME"

--- a/env/production/env_vars.hcl
+++ b/env/production/env_vars.hcl
@@ -3,5 +3,5 @@ inputs = {
   domain     = "notification.canada.ca"
   alt_domain = "notification.alpha.canada.ca"
   env        = "production"
-  staging_account_id = "239043911459"
+  dns_account_id = "296255494825"
 }

--- a/env/scratch/env_vars.hcl
+++ b/env/scratch/env_vars.hcl
@@ -4,5 +4,5 @@ inputs = {
   domain     = "scratch.notification.cdssandbox.xyz"
   alt_domain = "alpha.scratch.notification.cdssandbox.xyz"
   env        = "scratch"
-  staging_account_id = "239043911459"
+  dns_account_id = "239043911459"
 }

--- a/env/staging/env_vars.hcl
+++ b/env/staging/env_vars.hcl
@@ -3,5 +3,5 @@ inputs = {
   domain     = "staging.notification.cdssandbox.xyz"
   alt_domain = "staging.alpha.notification.cdssandbox.xyz"
   env        = "staging"
-  staging_account_id = "239043911459"
+  dns_account_id = "239043911459"
 }

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -7,7 +7,7 @@ inputs = {
   domain             = "${local.vars.inputs.domain}"
   alt_domain         = "${local.vars.inputs.alt_domain}"
   env                = "${local.vars.inputs.env}"
-  staging_account_id = "${local.vars.inputs.staging_account_id}"
+  dns_account_id     = "${local.vars.inputs.dns_account_id}"
   region             = "ca-central-1"
   # See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-logging-bucket-permissions
   elb_account_ids = {
@@ -48,14 +48,23 @@ provider "aws" {
 }
 
 provider "aws" {
+  alias  = "dns"
+  region = "ca-central-1"
+  assume_role {
+    role_arn = "arn:aws:iam::${local.vars.inputs.dns_account_id}:role/${local.vars.inputs.env}_dns_manager_role"
+  }
+}
+
+provider "aws" {
   alias  = "staging"
   region = "ca-central-1"
   assume_role {
-    role_arn = "arn:aws:iam::${local.vars.inputs.staging_account_id}:role/${local.vars.inputs.env}_dns_manager_role"
+    role_arn = "arn:aws:iam::${local.vars.inputs.dns_account_id}:role/${local.vars.inputs.env}_dns_manager_role"
   }
 }
 EOF
 }
+
 
 generate "common_variables" {
   path      = "common_variables.tf"


### PR DESCRIPTION
# Summary | Résumé

This contains a copy/paste of the cds DNS repository entry for notification.canada.ca where I then removed the values that are now dynamically generated as well as the individual document download and documentation entries, which are now caught by a wildcard A record to go to the K8s load balancer.

There are still several hard coded values in notification.canada.ca that need to be migrated eventually but are currently manual in other environments as well.

I have renamed the staging provider in AWS to dns since we will use the same provider entry with a different account id for production. 

I have also updated the DNS records for staging and scratch api endpoints to be monitored by the DNS zone for health as this is the configuration for production.

**Note that creating these resources in production will not make them live. We still require SSC to do the DNS switch**

# Test instructions | Instructions pour tester la modification

- Terragrunt apply in production works
- A manual comparison of the existing production route 53 zone with the newly created resources will need to be done in order to validate that the values are as expeceted.
