### PR TITLE
Revert "add new GAC sending domains"

### DIFF
--- a/env/production/dns/terragrunt.hcl
+++ b/env/production/dns/terragrunt.hcl
@@ -36,6 +36,6 @@ include {
 
 inputs = {
   notification_canada_ca_ses_callback_arn = dependency.common.outputs.notification_canada_ca_ses_callback_arn
-  ses_custom_sending_domains              = ["notification.gov.bc.ca", "notify.novascotia.ca", "international.gc.ca", "core-ocre.gc.ca"]
+  ses_custom_sending_domains              = ["notification.gov.bc.ca", "notify.novascotia.ca"]
   lambda_ses_receiving_emails_image_arn   = dependency.ses_receiving_emails.outputs.lambda_ses_receiving_emails_image_arn
 }


### PR DESCRIPTION
Reverts cds-snc/notification-terraform#789

No longer needed by client (see https://cds-snc.freshdesk.com/a/tickets/15122)