### PR TITLE
Revert "scan object to reference s3 bucket by ID (#823)"

### DIFF
--- a/aws/common/file_scanning.tf
+++ b/aws/common/file_scanning.tf
@@ -1,6 +1,6 @@
 module "s3_scan_objects" {
   source = "github.com/cds-snc/terraform-modules//S3_scan_object?ref=v6.0.1"
 
-  s3_upload_bucket_name = aws_s3_bucket.scan_files_document_bucket.id
+  s3_upload_bucket_name = "notification-canada-ca-${var.env}-document-download-scan-files"
   billing_tag_value     = var.billing_tag_value
 }

--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -219,7 +219,7 @@ resource "aws_s3_bucket" "document_bucket" {
 }
 
 resource "aws_s3_bucket" "scan_files_document_bucket" {
-  bucket        = "notification-canada-ca-${var.env}-dd-scan-files"
+  bucket        = "notification-canada-ca-${var.env}-document-download-scan-files"
   acl           = "private"
   force_destroy = var.force_destroy_s3
 


### PR DESCRIPTION
# Summary | Résumé

This raises the document attachment to fail in staging as we need extra changes, and the CI pipeline is already blocked by other changes. So we are reverting that one to reduce the bottleneck and reducing risk. We will get back to it later.

# Test instructions | Instructions pour tester la modification

Send a notification with a file attachment in staging once deployed and check if the scan files functionality is working as expected through the CW logs.
