### PR TITLE
Setting TTL on prod acm validation to 60 in notification.canada.ca

### DIFF
--- a/aws/dns/notification.canada.ca.tf
+++ b/aws/dns/notification.canada.ca.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "notification-canada-ca-ACM-cname" {
   records = [
     "_aaacd89cd470de0970c70c7ab1b7d4d5.wggjkglgrm.acm-validations.aws."
   ]
-  ttl = "300"
+  ttl = "60"
 }
 
 resource "aws_route53_record" "document-notification-canada-ca-ACM-cname" {
@@ -22,7 +22,7 @@ resource "aws_route53_record" "document-notification-canada-ca-ACM-cname" {
   records = [
     "_130ea19fa1fdd9e59b7632fbac0d7e00.wggjkglgrm.acm-validations.aws."
   ]
-  ttl = "300"
+  ttl = "60"
 }
 
 resource "aws_route53_record" "api-notification-canada-ca-ACM-cname" {
@@ -33,7 +33,7 @@ resource "aws_route53_record" "api-notification-canada-ca-ACM-cname" {
   records = [
     "_ac309158c158035bfb929da1617e2b16.mqzgcdqkwq.acm-validations.aws."
   ]
-  ttl = "300"
+  ttl = "60"
 }
 
 resource "aws_route53_record" "assets-notification-canada-ca-ACM-cname" {


### PR DESCRIPTION
# Summary | Résumé

There is currently some overlap on automation vs static DNS entries for ACM validation in production. This is causing the TTL on ACM validation records for notification.canada.ca to bounce back and forth. I've syncronized them to be 60 seconds for now (which corresponds to what the automation does).

# Test instructions | Instructions pour tester la modification

Terragrunt plan in production should show no changes