### PR TITLE
create secondary r5a.large

### DIFF
--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -52,8 +52,8 @@ include {
 inputs = {
   primary_worker_desired_size               = 7
   primary_worker_instance_types             = ["m6i.large"]
-  secondary_worker_instance_types           = ["m6i.large"]
-  nodeUpgrade                               = false
+  secondary_worker_instance_types           = ["r5a.large"]
+  nodeUpgrade                               = true
   primary_worker_max_size                   = 7
   primary_worker_min_size                   = 4
   vpc_id                                    = dependency.common.outputs.vpc_id


### PR DESCRIPTION
# Summary | Résumé

Goal: switch k8s nodes from m6i.large to r5a.large. (see [docs](https://github.com/cds-snc/notification-terraform/blob/main/docs/nodeUpgrade.md))

this step: create secondary r5a.large

