### PR TITLE
upgrade primary staging nodes to r5a.large

### DIFF
--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -51,7 +51,7 @@ include {
 
 inputs = {
   primary_worker_desired_size               = 7
-  primary_worker_instance_types             = ["m6i.large"]
+  primary_worker_instance_types             = ["r5a.large"]
   secondary_worker_instance_types           = ["r5a.large"]
   nodeUpgrade                               = true
   primary_worker_max_size                   = 7


### PR DESCRIPTION
# Summary | Résumé

Goal: switch k8s nodes from m6i.large to r5a.large. (see [docs](https://github.com/cds-snc/notification-terraform/blob/main/docs/nodeUpgrade.md))

this step: upgrade primary to r5a.large