### PR TITLE
Setting disk size to 80gb

### DIFF
--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -59,6 +59,8 @@ resource "aws_eks_node_group" "notification-canada-ca-eks-node-group" {
   release_version = var.eks_node_ami_version
   instance_types  = var.primary_worker_instance_types
 
+  disk_size = 80
+
   scaling_config {
     desired_size = var.primary_worker_desired_size
     max_size     = var.primary_worker_max_size
@@ -93,6 +95,8 @@ resource "aws_eks_node_group" "notification-canada-ca-eks-secondary-node-group" 
 
   release_version = var.eks_node_ami_version
   instance_types  = var.secondary_worker_instance_types
+
+  disk_size = 80
 
   scaling_config {
     # Since we are just using this node group as an interim group while we upgrade primary, 


### PR DESCRIPTION
# Summary | Résumé

Setting disk size of EKS nodes to 80gb to remove disk pressure issues. To ensure no downtime, manual steps must be taken in production:

1. Manually resize disks in AWS Console:
  a. Navigate to node in AWS
  b. Select the volume
  c. Choose "Modify Volume"
  d. Change size from 20gb to 80gb
  e. Save
1. kubectl cordon the node
1. kubectl drain the node
1. Restart the node in AWS Console
1. Uncordon the node when it is in ready, scheduling disabled state
1. Repeat for all nodes
1. Terragrunt refresh-only to update terragrunt

