### PR TITLE
create staging secondary r5.large

### DIFF
--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -52,8 +52,8 @@ include {
 inputs = {
   primary_worker_desired_size               = 7
   primary_worker_instance_types             = ["r5a.large"]
-  secondary_worker_instance_types           = ["r5a.large"]
-  nodeUpgrade                               = false
+  secondary_worker_instance_types           = ["r5.large"]
+  nodeUpgrade                               = true
   primary_worker_max_size                   = 7
   primary_worker_min_size                   = 4
   vpc_id                                    = dependency.common.outputs.vpc_id


### PR DESCRIPTION
# Summary | Résumé

r5a.large not available in all our azs:

```
aws ec2 describe-instance-type-offerings --location-type availability-zone --filters="Name=instance-type,Values=r5a.large" --region ca-central-1 --output table

----------------------------------------------------------
|              DescribeInstanceTypeOfferings             |
+--------------------------------------------------------+
||                 InstanceTypeOfferings                ||
|+--------------+-----------------+---------------------+|
|| InstanceType |    Location     |    LocationType     ||
|+--------------+-----------------+---------------------+|
||  r5a.large   |  ca-central-1a  |  availability-zone  ||
||  r5a.large   |  ca-central-1b  |  availability-zone  ||
|+--------------+-----------------+---------------------+|
```

But r5.large is
```
----------------------------------------------------------
|              DescribeInstanceTypeOfferings             |
+--------------------------------------------------------+
||                 InstanceTypeOfferings                ||
|+--------------+-----------------+---------------------+|
|| InstanceType |    Location     |    LocationType     ||
|+--------------+-----------------+---------------------+|
||  r5.large    |  ca-central-1b  |  availability-zone  ||
||  r5.large    |  ca-central-1d  |  availability-zone  ||
||  r5.large    |  ca-central-1a  |  availability-zone  ||
|+--------------+-----------------+---------------------+|
```
