### PR TITLE
Secondary target groups bindings

### DIFF
--- a/aws/eks/alb.tf
+++ b/aws/eks/alb.tf
@@ -39,12 +39,8 @@ resource "aws_alb_listener" "notification-canada-ca" {
   ssl_policy = "ELBSecurityPolicy-FS-1-2-Res-2019-08"
 
   default_action {
-    type = "forward"
-    forward {
-      target_group {
-        arn = aws_alb_target_group.admin_secondary.arn
-      }
-    }
+    type             = "forward"
+    target_group_arn = aws_alb_target_group.admin_secondary.arn
   }
 }
 
@@ -136,12 +132,8 @@ resource "aws_lb_listener_rule" "document-api-host-route" {
   priority     = 100
 
   action {
-    type = "forward"
-    forward {
-      target_group {
-        arn = aws_alb_target_group.doc_api_secondary.arn
-      }
-    }
+    type             = "forward"
+    target_group_arn = aws_alb_target_group.doc_api_secondary.arn
   }
 
   condition {
@@ -196,12 +188,8 @@ resource "aws_lb_listener_rule" "document-host-route" {
   priority     = 200
 
   action {
-    type = "forward"
-    forward {
-      target_group {
-        arn = aws_alb_target_group.document_secondary.arn
-      }
-    }
+    type             = "forward"
+    target_group_arn = aws_alb_target_group.doc_api_secondary.arn
   }
 
   condition {
@@ -231,12 +219,8 @@ resource "aws_lb_listener_rule" "api-host-route" {
   priority     = 300
 
   action {
-    type = "forward"
-    forward {
-      target_group {
-        arn = aws_alb_target_group.api_secondary.arn
-      }
-    }
+    type             = "forward"
+    target_group_arn = aws_alb_target_group.api_secondary.arn
   }
 
   condition {
@@ -334,12 +318,8 @@ resource "aws_lb_listener_rule" "documentation-host-route" {
   priority     = 60
 
   action {
-    type = "forward"
-    forward {
-      target_group {
-        arn = aws_alb_target_group.document_secondary.arn
-      }
-    }
+    type             = "forward"
+    target_group_arn = aws_alb_target_group.document_secondary.arn
   }
 
   condition {

--- a/aws/eks/alb.tf
+++ b/aws/eks/alb.tf
@@ -39,8 +39,15 @@ resource "aws_alb_listener" "notification-canada-ca" {
   ssl_policy = "ELBSecurityPolicy-FS-1-2-Res-2019-08"
 
   default_action {
-    type             = "forward"
-    target_group_arn = aws_alb_target_group.notification-canada-ca-admin.arn
+    type = "forward"
+    forward {
+      target_group {
+        arn = aws_alb_target_group.notification-canada-ca-admin.arn
+      }
+      target_group {
+        arn = aws_alb_target_group.admin_secondary.arn
+      }
+    }
   }
 }
 
@@ -132,8 +139,15 @@ resource "aws_lb_listener_rule" "document-api-host-route" {
   priority     = 100
 
   action {
-    type             = "forward"
-    target_group_arn = aws_alb_target_group.notification-canada-ca-document-api.arn
+    type = "forward"
+    forward {
+      target_group {
+        arn = aws_alb_target_group.notification-canada-ca-document-api.arn
+      }
+      target_group {
+        arn = aws_alb_target_group.doc_api_secondary.arn
+      }
+    }
   }
 
   condition {
@@ -188,8 +202,15 @@ resource "aws_lb_listener_rule" "document-host-route" {
   priority     = 200
 
   action {
-    type             = "forward"
-    target_group_arn = aws_alb_target_group.notification-canada-ca-document-api.arn
+    type = "forward"
+    forward {
+      target_group {
+        arn = aws_alb_target_group.notification-canada-ca-document-api.arn
+      }
+      target_group {
+        arn = aws_alb_target_group.document_secondary.arn
+      }
+    }
   }
 
   condition {
@@ -219,8 +240,15 @@ resource "aws_lb_listener_rule" "api-host-route" {
   priority     = 300
 
   action {
-    type             = "forward"
-    target_group_arn = aws_alb_target_group.notification-canada-ca-api.arn
+    type = "forward"
+    forward {
+      target_group {
+        arn = aws_alb_target_group.notification-canada-ca-api.arn
+      }
+      target_group {
+        arn = aws_alb_target_group.api_secondary.arn
+      }
+    }
   }
 
   condition {
@@ -318,8 +346,15 @@ resource "aws_lb_listener_rule" "documentation-host-route" {
   priority     = 60
 
   action {
-    type             = "forward"
-    target_group_arn = aws_alb_target_group.notification-canada-ca-documentation.arn
+    type = "forward"
+    forward {
+      target_group {
+        arn = aws_alb_target_group.notification-canada-ca-documentation.arn
+      }
+      target_group {
+        arn = aws_alb_target_group.document_secondary.arn
+      }
+    }
   }
 
   condition {

--- a/aws/eks/alb.tf
+++ b/aws/eks/alb.tf
@@ -42,9 +42,6 @@ resource "aws_alb_listener" "notification-canada-ca" {
     type = "forward"
     forward {
       target_group {
-        arn = aws_alb_target_group.notification-canada-ca-admin.arn
-      }
-      target_group {
         arn = aws_alb_target_group.admin_secondary.arn
       }
     }
@@ -142,9 +139,6 @@ resource "aws_lb_listener_rule" "document-api-host-route" {
     type = "forward"
     forward {
       target_group {
-        arn = aws_alb_target_group.notification-canada-ca-document-api.arn
-      }
-      target_group {
         arn = aws_alb_target_group.doc_api_secondary.arn
       }
     }
@@ -205,9 +199,6 @@ resource "aws_lb_listener_rule" "document-host-route" {
     type = "forward"
     forward {
       target_group {
-        arn = aws_alb_target_group.notification-canada-ca-document-api.arn
-      }
-      target_group {
         arn = aws_alb_target_group.document_secondary.arn
       }
     }
@@ -242,9 +233,6 @@ resource "aws_lb_listener_rule" "api-host-route" {
   action {
     type = "forward"
     forward {
-      target_group {
-        arn = aws_alb_target_group.notification-canada-ca-api.arn
-      }
       target_group {
         arn = aws_alb_target_group.api_secondary.arn
       }
@@ -348,9 +336,6 @@ resource "aws_lb_listener_rule" "documentation-host-route" {
   action {
     type = "forward"
     forward {
-      target_group {
-        arn = aws_alb_target_group.notification-canada-ca-documentation.arn
-      }
       target_group {
         arn = aws_alb_target_group.document_secondary.arn
       }


### PR DESCRIPTION
# Summary | Résumé
Step 2 of EKS Load Balancer privatization

This will bind the secondary target groups to the EKS ALB, and remove the primary target groups.

# Test instructions | Instructions pour tester la modification

- Run a smoke test in staging while this is applying to validate that there are no 502s or other errors
