### PR TITLE
Revert "chore(deps): update terraform terraform-aws-modules/notify-slack/aws to v6"

### DIFF
--- a/aws/common/slack.tf
+++ b/aws/common/slack.tf
@@ -1,7 +1,7 @@
 # Doc: https://registry.terraform.io/modules/terraform-aws-modules/notify-slack/aws/
 module "notify_slack_warning" {
   source  = "terraform-aws-modules/notify-slack/aws"
-  version = "~> 6.0.0"
+  version = "~> 4.24.0"
 
   create_sns_topic = false
   sns_topic_name   = aws_sns_topic.notification-canada-ca-alert-warning.name
@@ -19,7 +19,7 @@ module "notify_slack_warning" {
 
 module "notify_slack_ok" {
   source  = "terraform-aws-modules/notify-slack/aws"
-  version = "~> 6.0.0"
+  version = "~> 4.24.0"
 
   create_sns_topic = false
   sns_topic_name   = aws_sns_topic.notification-canada-ca-alert-ok.name
@@ -37,7 +37,7 @@ module "notify_slack_ok" {
 
 module "notify_slack_critical" {
   source  = "terraform-aws-modules/notify-slack/aws"
-  version = "~> 6.0.0"
+  version = "~> 4.24.0"
 
   create_sns_topic = false
   sns_topic_name   = aws_sns_topic.notification-canada-ca-alert-critical.name
@@ -56,7 +56,7 @@ module "notify_slack_critical" {
 # Shared generic slack webhook & topic.
 module "notify_slack_general" {
   source  = "terraform-aws-modules/notify-slack/aws"
-  version = "~> 6.0.0"
+  version = "~> 4.24.0"
 
   create_sns_topic = false
   sns_topic_name   = aws_sns_topic.notification-canada-ca-alert-general.name


### PR DESCRIPTION
Reverts cds-snc/notification-terraform#896

😞 [apply failed](https://gcdigital.slack.com/archives/CV38DBNVA/p1693508097016519)

there's a related bug report: https://github.com/hashicorp/terraform-provider-aws/issues/31642 

Will redo once it's sorted out.