### PR TITLE
add quicksight user group and fix a data type

### DIFF
--- a/aws/quicksight/datasets.tf
+++ b/aws/quicksight/datasets.tf
@@ -20,7 +20,7 @@ resource "aws_quicksight_data_set" "notifications" {
       }
       input_columns {
         name = "template_version"
-        type = "STRING"
+        type = "INTEGER"
       }
       input_columns {
         name = "service_id"
@@ -51,5 +51,15 @@ resource "aws_quicksight_data_set" "notifications" {
         type = "DATETIME"
       }
     }
+  }
+  permissions {
+    actions = [
+      "quicksight:DescribeDataSet",
+      "quicksight:DescribeDataSetPermissions",
+      "quicksight:PassDataSet",
+      "quicksight:DescribeIngestion",
+      "quicksight:ListIngestions",
+    ]
+    principal = aws_quicksight_group.dataset_full.arn
   }
 }

--- a/aws/quicksight/user_group.tf
+++ b/aws/quicksight/user_group.tf
@@ -1,0 +1,4 @@
+resource "aws_quicksight_group" "dataset_full" {
+  group_name  = "quicksight-dataset-full-access"
+  description = "users with full access to Quicksight data sets"
+}


### PR DESCRIPTION
# Summary | Résumé

- the notifications data set has a wrong data type for template_version
- by default nobody has access to the dataset (!) - we create a quicksight user group that has access to it. We should be able to manually add folks to this group.
