### PR TITLE
Add new sms queues to sms dashboard

### DIFF
--- a/aws/common/dashboards.tf
+++ b/aws/common/dashboards.tf
@@ -521,6 +521,12 @@ resource "aws_cloudwatch_dashboard" "sms" {
                     "${aws_cloudwatch_metric_alarm.sns-sms-success-rate-canadian-numbers-warning[0].arn}",
                     "${aws_cloudwatch_metric_alarm.sqs-sms-stuck-in-queue-warning[0].arn}",
                     "${aws_cloudwatch_metric_alarm.sqs-sms-stuck-in-queue-critical[0].arn}",
+                    "${aws_cloudwatch_metric_alarm.sqs-send-sms-high-queue-delay-warning[0].arn}",
+                    "${aws_cloudwatch_metric_alarm.sqs-send-sms-high-queue-delay-critical[0].arn}",
+                    "${aws_cloudwatch_metric_alarm.sqs-send-sms-medium-queue-delay-warning[0].arn}",
+                    "${aws_cloudwatch_metric_alarm.sqs-send-sms-medium-queue-delay-critical[0].arn}",
+                    "${aws_cloudwatch_metric_alarm.sqs-send-sms-low-queue-delay-warning[0].arn}",
+                    "${aws_cloudwatch_metric_alarm.sqs-send-sms-low-queue-delay-critical[0].arn}",
                     "${aws_cloudwatch_metric_alarm.sns-spending-critical[0].arn}",
                     "${aws_cloudwatch_metric_alarm.sns-spending-warning[0].arn}"
                 ]

--- a/aws/common/dashboards.tf
+++ b/aws/common/dashboards.tf
@@ -554,7 +554,7 @@ resource "aws_cloudwatch_dashboard" "sms" {
             "height": 6,
             "width": 9,
             "y": 11,
-            "x": 9,
+            "x": 0,
             "type": "metric",
             "properties": {
                 "metrics": [
@@ -571,7 +571,7 @@ resource "aws_cloudwatch_dashboard" "sms" {
         {
             "height": 6,
             "width": 9,
-            "y": 37,
+            "y": 45,
             "x": 0,
             "type": "metric",
             "properties": {
@@ -605,7 +605,7 @@ resource "aws_cloudwatch_dashboard" "sms" {
         {
             "height": 6,
             "width": 9,
-            "y": 37,
+            "y": 45,
             "x": 9,
             "type": "metric",
             "properties": {
@@ -623,8 +623,8 @@ resource "aws_cloudwatch_dashboard" "sms" {
         {
             "height": 6,
             "width": 9,
-            "y": 17,
-            "x": 0,
+            "y": 11,
+            "x": 9,
             "type": "metric",
             "properties": {
                 "metrics": [
@@ -655,7 +655,7 @@ resource "aws_cloudwatch_dashboard" "sms" {
         {
             "height": 6,
             "width": 9,
-            "y": 31,
+            "y": 39,
             "x": 9,
             "type": "metric",
             "properties": {
@@ -683,7 +683,7 @@ resource "aws_cloudwatch_dashboard" "sms" {
         {
             "height": 2,
             "width": 24,
-            "y": 29,
+            "y": 37,
             "x": 0,
             "type": "text",
             "properties": {
@@ -693,7 +693,7 @@ resource "aws_cloudwatch_dashboard" "sms" {
         {
             "height": 6,
             "width": 9,
-            "y": 31,
+            "y": 39,
             "x": 0,
             "type": "metric",
             "properties": {
@@ -722,8 +722,8 @@ resource "aws_cloudwatch_dashboard" "sms" {
         {
             "height": 6,
             "width": 9,
-            "y": 23,
-            "x": 0,
+            "y": 17,
+            "x": 9,
             "type": "metric",
             "properties": {
                 "metrics": [
@@ -740,7 +740,7 @@ resource "aws_cloudwatch_dashboard" "sms" {
         {
             "height": 9,
             "width": 6,
-            "y": 31,
+            "y": 39,
             "x": 18,
             "type": "text",
             "properties": {
@@ -748,61 +748,9 @@ resource "aws_cloudwatch_dashboard" "sms" {
             }
         },
         {
-            "height": 6,
-            "width": 9,
-            "y": 17,
-            "x": 9,
-            "type": "metric",
-            "properties": {
-                "metrics": [
-                    [ "AWS/SQS", "ApproximateNumberOfMessagesVisible", "QueueName", "eks-notification-canada-casend-sms-tasks" ]
-                ],
-                "view": "timeSeries",
-                "stacked": false,
-                "region": "${var.region}",
-                "stat": "Average",
-                "period": 60,
-                "title": "Number of messages visible in send-sms-tasks"
-            }
-        },
-        {
-            "height": 6,
-            "width": 9,
-            "y": 11,
-            "x": 0,
-            "type": "metric",
-            "properties": {
-                "metrics": [
-                    [ "AWS/SQS", "ApproximateAgeOfOldestMessage", "QueueName", "eks-notification-canada-casend-sms-tasks" ]
-                ],
-                "view": "timeSeries",
-                "stacked": false,
-                "region": "${var.region}",
-                "title": "Approximate age of oldest message in send-sms-tasks",
-                "stat": "Average",
-                "period": 60,
-                "annotations": {
-                    "horizontal": [
-                        {
-                            "color": "#ff7f0e",
-                            "label": "Above 3mn",
-                            "value": 180,
-                            "fill": "above"
-                        },
-                        {
-                            "color": "#d62728",
-                            "label": "Above 5mn",
-                            "value": 300,
-                            "fill": "above"
-                        }
-                    ]
-                }
-            }
-        },
-        {
             "height": 3,
             "width": 24,
-            "y": 46,
+            "y": 54,
             "x": 0,
             "type": "log",
             "properties": {
@@ -816,7 +764,7 @@ resource "aws_cloudwatch_dashboard" "sms" {
         {
             "height": 3,
             "width": 24,
-            "y": 43,
+            "y": 51,
             "x": 0,
             "type": "log",
             "properties": {
@@ -874,7 +822,7 @@ resource "aws_cloudwatch_dashboard" "sms" {
         {
             "height": 6,
             "width": 24,
-            "y": 55,
+            "y": 63,
             "x": 0,
             "type": "log",
             "properties": {
@@ -887,7 +835,7 @@ resource "aws_cloudwatch_dashboard" "sms" {
         {
             "height": 6,
             "width": 24,
-            "y": 49,
+            "y": 57,
             "x": 0,
             "type": "log",
             "properties": {
@@ -896,6 +844,177 @@ resource "aws_cloudwatch_dashboard" "sms" {
                 "stacked": false,
                 "view": "timeSeries",
                 "title": "dwellTimeMsUntilDeviceAck"
+            }
+        },
+        {
+            "height": 6,
+            "width": 8,
+            "y": 25,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/SQS", "ApproximateAgeOfOldestMessage", "QueueName", "eks-notification-canada-casend-sms-high", { "region": "${var.region}" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${var.region}",
+                "title": "Approximate age of oldest message in send-sms-high",
+                "stat": "Average",
+                "period": 60,
+                "annotations": {
+                    "horizontal": [
+                        {
+                            "color": "#ff7f0e",
+                            "label": "Above 10 sec",
+                            "value": 10,
+                            "fill": "above"
+                        },
+                        {
+                            "color": "#d62728",
+                            "label": "Above 60 sec",
+                            "value": 60,
+                            "fill": "above"
+                        }
+                    ]
+                },
+                "yAxis": {
+                    "left": {
+                        "showUnits": true
+                    }
+                }
+            }
+        },
+        {
+            "height": 6,
+            "width": 8,
+            "y": 25,
+            "x": 8,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/SQS", "ApproximateAgeOfOldestMessage", "QueueName", "eks-notification-canada-casend-sms-medium", { "region": "${var.region}" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${var.region}",
+                "title": "Approximate age of oldest message in send-sms-medium",
+                "stat": "Average",
+                "period": 60,
+                "annotations": {
+                    "horizontal": [
+                        {
+                            "color": "#ff7f0e",
+                            "label": "Above 10 min",
+                            "value": 600,
+                            "fill": "above"
+                        },
+                        {
+                            "color": "#d62728",
+                            "label": "Above 15 min",
+                            "value": 900,
+                            "fill": "above"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "height": 6,
+            "width": 8,
+            "y": 25,
+            "x": 16,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/SQS", "ApproximateAgeOfOldestMessage", "QueueName", "eks-notification-canada-casend-sms-low", { "region": "${var.region}" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${var.region}",
+                "title": "Approximate age of oldest message in send-sms-low",
+                "stat": "Average",
+                "period": 60,
+                "annotations": {
+                    "horizontal": [
+                        {
+                            "color": "#ff7f0e",
+                            "label": "Above 10 min",
+                            "value": 600,
+                            "fill": "above"
+                        },
+                        {
+                            "color": "#d62728",
+                            "label": "Above 3 hours",
+                            "value": 10800,
+                            "fill": "above"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "height": 2,
+            "width": 24,
+            "y": 23,
+            "x": 0,
+            "type": "text",
+            "properties": {
+                "markdown": "\n# Delivery queues\n"
+            }
+        },
+        {
+            "height": 6,
+            "width": 8,
+            "y": 31,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/SQS", "ApproximateNumberOfMessagesVisible", "QueueName", "eks-notification-canada-casend-sms-high", { "region": "${var.region}" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${var.region}",
+                "stat": "Average",
+                "period": 60,
+                "title": "Number of messages visible in send-sms-high"
+            }
+        },
+        {
+            "height": 6,
+            "width": 8,
+            "y": 31,
+            "x": 16,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/SQS", "ApproximateNumberOfMessagesVisible", "QueueName", "eks-notification-canada-casend-sms-low", { "region": "${var.region}" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${var.region}",
+                "stat": "Average",
+                "period": 60,
+                "title": "Number of messages visible in send-sms-low"
+            }
+        },
+        {
+            "height": 6,
+            "width": 8,
+            "y": 31,
+            "x": 8,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/SQS", "ApproximateNumberOfMessagesVisible", "QueueName", "eks-notification-canada-casend-sms-medium", { "region": "${var.region}" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${var.region}",
+                "stat": "Average",
+                "period": 60,
+                "title": "Number of messages visible in send-sms-medium"
             }
         }
     ]


### PR DESCRIPTION
# Summary | Résumé

re https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/185

Add the new sms queues to the SMS dashboard.

# Test instructions | Instructions pour tester la modification

[Old SMS dashboard
](https://ca-central-1.console.aws.amazon.com/cloudwatch/home?region=ca-central-1#dashboards/dashboard/SMS)

[Review (SMS_V2) dashboard
](https://ca-central-1.console.aws.amazon.com/cloudwatch/home?region=ca-central-1#dashboards/dashboard/SMS_V2
)
