### PR TITLE
Creating secondary node group for prod node migration

### DIFF
--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -34,11 +34,11 @@ include {
 }
 
 inputs = {
-  primary_worker_desired_size               = 5
+  primary_worker_desired_size               = 7
   primary_worker_instance_types             = ["m5.large"]
-  secondary_worker_instance_types           = ["m5.large"]
-  nodeUpgrade                               = false  
-  primary_worker_max_size                   = 7
+  secondary_worker_instance_types           = ["r5.large"]
+  nodeUpgrade                               = true  
+  primary_worker_max_size                   = 5
   primary_worker_min_size                   = 4
   vpc_id                                    = dependency.common.outputs.vpc_id
   vpc_private_subnets                       = dependency.common.outputs.vpc_private_subnets

--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -34,11 +34,11 @@ include {
 }
 
 inputs = {
-  primary_worker_desired_size               = 7
+  primary_worker_desired_size               = 5
   primary_worker_instance_types             = ["m5.large"]
   secondary_worker_instance_types           = ["r5.large"]
   nodeUpgrade                               = true  
-  primary_worker_max_size                   = 5
+  primary_worker_max_size                   = 7
   primary_worker_min_size                   = 4
   vpc_id                                    = dependency.common.outputs.vpc_id
   vpc_private_subnets                       = dependency.common.outputs.vpc_private_subnets


### PR DESCRIPTION
# Summary | Résumé

This is the first step at getting the new celery HPA tuning into prod for emails. We need to change the node type in production, which means we need to do a node migration. 

# Test instructions | Instructions pour tester la modification

[We are following the node migration guide here](https://github.com/cds-snc/notification-terraform/blob/main/docs/nodeUpgrade.md)

- Verify the terraform plan shows the creation of the secondary node group, with no changes to primary.
- Smoke test production after apply

