### PR TITLE
Adding karpenter tag to eks security group

### DIFF
--- a/aws/eks/securitygroups.tf
+++ b/aws/eks/securitygroups.tf
@@ -328,3 +328,10 @@ resource "aws_security_group_rule" "notification-worker-egress-endpoints-gateway
   security_group_id = aws_security_group.notification-canada-ca-worker.id
   prefix_list_ids   = var.private-links-gateway-prefix-list-ids
 }
+
+# Tag EKS Security Group for Karpenter
+resource "aws_ec2_tag" "eks_created_security_group_tag" {
+  resource_id = data.aws_security_group.eks-securitygroup-rds.id
+  key         = "karpenter.sh/discovery"
+  value       = var.eks_cluster_name
+}


### PR DESCRIPTION
# Summary | Résumé

Adding a tag to the EKS Security Group for Karpenter discovery. I must have added this manually in my scratch account


# Test instructions | Instructions pour tester la modification

TF Plan shows 1 to add
TF Apply completes
Smoke Test Staging