### PR TITLE
Adding service linked role

### DIFF
--- a/aws/common/iam.tf
+++ b/aws/common/iam.tf
@@ -184,3 +184,8 @@ data "aws_iam_policy_document" "firehose_waf_logs" {
     ]
   }
 }
+
+# This is required for Karpenter. Older accounts do not have this enabled by default
+resource "aws_iam_service_linked_role" "spotInstances" {
+  aws_service_name = "spot.amazonaws.com"
+}


### PR DESCRIPTION
# Summary | Résumé

Adding service linked role which is required by Karpenter.

# Test instructions | Instructions pour tester la modification

Tested in scratch
* Note I will have to manually import this in staging before merging the PR since I created it outside of TF