### PR TITLE
Setting desired size of k8s nodegroup to 3

### DIFF
--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -51,12 +51,12 @@ include {
 }
 
 inputs = {
-  primary_worker_desired_size               = 7
+  primary_worker_desired_size               = 3
   primary_worker_instance_types             = ["r5.large"]
   secondary_worker_instance_types           = ["r5.large"]
   nodeUpgrade                               = false
   primary_worker_max_size                   = 7
-  primary_worker_min_size                   = 4
+  primary_worker_min_size                   = 3
   vpc_id                                    = dependency.common.outputs.vpc_id
   vpc_private_subnets                       = dependency.common.outputs.vpc_private_subnets
   vpc_public_subnets                        = dependency.common.outputs.vpc_public_subnets


### PR DESCRIPTION
# Summary | Résumé

Going aggressive to start - setting desired node count for primary node group to 3. Lets see how the system copes. May need to increase to 4.

# Test instructions | Instructions pour tester la modification

- Apply in staging
- Run Perf Tests
