### PR TITLE
Setting desired node group size to 7 in staging

### DIFF
--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -51,7 +51,7 @@ include {
 }
 
 inputs = {
-  primary_worker_desired_size               = 3
+  primary_worker_desired_size               = 7
   primary_worker_instance_types             = ["r5.large"]
   secondary_worker_instance_types           = ["r5.large"]
   nodeUpgrade                               = false


### PR DESCRIPTION
# Summary | Résumé

Setting the node group size to 7 so that we can further test the non-karpenter performance improvement.

# Test instructions | Instructions pour tester la modification

Perf tests in staging