### PR TITLE
Parameterizing database name to account for some issues in scratch

### DIFF
--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -73,7 +73,7 @@ resource "aws_rds_cluster" "notification-canada-ca" {
   cluster_identifier           = "notification-canada-ca-${var.env}-cluster"
   engine                       = "aurora-postgresql"
   engine_version               = 11.9
-  database_name                = "NotificationCanadaCa${var.env}"
+  database_name                = var.rds_database_name
   final_snapshot_identifier    = "server-${random_string.random.result}"
   master_username              = "postgres"
   master_password              = var.rds_cluster_password

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -38,3 +38,9 @@ variable "enable_delete_protection" {
   description = "Sets whether or not to enable delete protection."
   default     = true
 }
+
+variable "rds_database_name" {
+  type = string
+  description = "Set the name of the database"
+
+}

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -40,7 +40,7 @@ variable "enable_delete_protection" {
 }
 
 variable "rds_database_name" {
-  type = string
+  type        = string
   description = "Set the name of the database"
 
 }

--- a/env/production/rds/terragrunt.hcl
+++ b/env/production/rds/terragrunt.hcl
@@ -25,4 +25,5 @@ inputs = {
   rds_instance_type         = "db.r6g.large"
   vpc_private_subnets       = dependency.common.outputs.vpc_private_subnets
   sns_alert_general_arn     = dependency.common.outputs.sns_alert_general_arn
+  rds_database_name         = "NotificationCanadaCaproduction"
 }

--- a/env/scratch/rds/terragrunt.hcl
+++ b/env/scratch/rds/terragrunt.hcl
@@ -41,6 +41,7 @@ inputs = {
   rds_instance_type         = "db.t3.medium"
   vpc_private_subnets       = dependency.common.outputs.vpc_private_subnets
   sns_alert_general_arn     = dependency.common.outputs.sns_alert_general_arn
+  rds_database_name         = "notificationcanadacascratch"
 }
 
 terraform {

--- a/env/staging/rds/terragrunt.hcl
+++ b/env/staging/rds/terragrunt.hcl
@@ -41,6 +41,7 @@ inputs = {
   rds_instance_type         = "db.r6g.large"
   vpc_private_subnets       = dependency.common.outputs.vpc_private_subnets
   sns_alert_general_arn     = dependency.common.outputs.sns_alert_general_arn
+  rds_database_name = "NotificationCanadaCastaging"
 }
 
 terraform {


### PR DESCRIPTION
# Summary | Résumé

This is just a quick PR to parameterize the database name, something I require when working on scratch account. There should be no effect on staging or production.

# Test instructions | Instructions pour tester la modification

TF Plan on staging and prod should be empty for RDS.