### PR TITLE
chore: fix deprecated workflow set-output commands

### DIFF
--- a/.github/workflows/check_eks_ami_update.yml
+++ b/.github/workflows/check_eks_ami_update.yml
@@ -30,7 +30,8 @@ jobs:
         LATEST_AMI="$(aws ssm get-parameter \
           --name /aws/service/eks/optimized-ami/$CLUSTER_VERSION/amazon-linux-2/recommended/release_version \
           --query 'Parameter.Value' --output text)"
-        echo "::set-output name=ami::${LATEST_AMI}"
+        echo "ami=${LATEST_AMI}" >> "$GITHUB_OUTPUT"
+
 
     - name: Get Staging cluster node group AMI image release version
       id: current
@@ -39,7 +40,8 @@ jobs:
           --cluster-name ${{ env.EKS_CLUSTER_NAME }} \
           --nodegroup-name ${{ env.EKS_CLUSTER_NODE_GROUP_NAME }} \
           --query 'nodegroup.releaseVersion' --output text)"
-        echo "::set-output name=ami::${CURRENT_AMI}"
+        echo "ami=${CURRENT_AMI}" >> "$GITHUB_OUTPUT"
+
 
     - name: Post to slack
       if: steps.latest.outputs.ami != steps.current.outputs.ami

--- a/.github/workflows/check_eks_cluster_update.yml
+++ b/.github/workflows/check_eks_cluster_update.yml
@@ -27,7 +27,8 @@ jobs:
           | jq -r ".addons[] | .addonVersions[] | .compatibilities[] | .clusterVersion" \
           | sort -r \
           | head -1)"
-        echo "::set-output name=version::${LATEST_VERSION}"
+        echo "version=${LATEST_VERSION}" >> "$GITHUB_OUTPUT"
+
 
     - name: Get Staging cluster version
       id: current
@@ -35,7 +36,8 @@ jobs:
         CLUSTER_VERSION="$(aws eks describe-cluster \
           --name ${{ env.EKS_CLUSTER_NAME }} \
           --query 'cluster.version' --output text)"
-        echo "::set-output name=version::${CLUSTER_VERSION}"
+        echo "version=${CLUSTER_VERSION}" >> "$GITHUB_OUTPUT"
+
 
     - name: Post to slack
       if: steps.latest.outputs.version != steps.current.outputs.version


### PR DESCRIPTION
# Summary
Update the deprecated `set-output` GitHub workflow
commands to use the [new syntax](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter).
