### PR TITLE
Setting staging node group size to 3

### DIFF
--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -51,7 +51,7 @@ include {
 }
 
 inputs = {
-  primary_worker_desired_size               = 7
+  primary_worker_desired_size               = 3
   primary_worker_instance_types             = ["r5.large"]
   secondary_worker_instance_types           = ["r5.large"]
   nodeUpgrade                               = false


### PR DESCRIPTION
# Summary | Résumé

Resetting Staging to 3 nodes in EKS for karpenter

# Test instructions | Instructions pour tester la modification

Verify staging nodes reduce to 3
Verify that all deployments are able to be deployed
