### PR TITLE
Setting desired node count in prod to 4

### DIFF
--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -34,12 +34,12 @@ include {
 }
 
 inputs = {
-  primary_worker_desired_size               = 7
+  primary_worker_desired_size               = 4
   primary_worker_instance_types             = ["r5.large"]
   secondary_worker_instance_types           = ["r5.large"]
   nodeUpgrade                               = false  
   primary_worker_max_size                   = 7
-  primary_worker_min_size                   = 4
+  primary_worker_min_size                   = 3
   vpc_id                                    = dependency.common.outputs.vpc_id
   vpc_private_subnets                       = dependency.common.outputs.vpc_private_subnets
   vpc_public_subnets                        = dependency.common.outputs.vpc_public_subnets


### PR DESCRIPTION
# Summary | Résumé

Celery is now running on karpenter nodes in production. Reducing the node count for the on demand nodes to 4. This is a conservative reduction, if this behaves well, we will further reduce to 3 nodes like we have in staging.

# Test instructions | Instructions pour tester la modification

- Smoke test prod
- Verify all pods are deployed
- Verify resource usage on nodes