### PR TITLE
feat: RDS cluster update check workflow

### DIFF
--- a/.github/workflows/check_rds_cluster_update.yml
+++ b/.github/workflows/check_rds_cluster_update.yml
@@ -1,0 +1,52 @@
+name: Check for RDS Aurora Postgres version updates
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 13 * * 1" # 1pm Monday UTC
+
+env:
+  AWS_DEFAULT_REGION: ca-central-1
+  RDS_CLUSTER_NAME: notification-canada-ca-staging-cluster
+  RDS_ENGINE: aurora-postgresql
+
+permissions:
+  id-token: write
+
+jobs:
+  check-rds-cluster-update:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Configure AWS credentials using OIDC
+      uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
+      with:
+        role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+        role-session-name: RDSClusterUpdateCheck
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+    - name: Get RDS cluster current version
+      id: current
+      run: |
+        CLUSTER_VERSION="$(aws rds describe-db-clusters \
+          --db-cluster-identifier ${{ env.RDS_CLUSTER_NAME }} \
+          --query 'DBClusters[0].EngineVersion' \
+          --output text)"
+        echo "version=${CLUSTER_VERSION}" >> "$GITHUB_OUTPUT"
+
+    - name: Get RDS cluster available updates
+      id: available
+      run: |
+        AVAILABLE_VERSIONS="$(aws rds describe-db-engine-versions \
+          --engine ${{ env.RDS_ENGINE }} \
+          --query 'DBEngineVersions[*].ValidUpgradeTarget[*].{EngineVersion:EngineVersion}' \
+          --engine-version ${{ steps.current.outputs.version }} \
+          --output text \
+          --no-paginate)"
+        echo "versions=${AVAILABLE_VERSIONS}" >> "$GITHUB_OUTPUT"
+
+    - name: Post to slack
+      if: steps.available.outputs.versions != ''
+      #checkov:skip=CKV_GHA_3:This is an expected use of curl
+      run: |
+        json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":mr-data: RDS Aurora Postgres ${{ steps.current.outputs.version }} updates are available: <https://docs.aws.amazon.com/AmazonRDS/latest/AuroraPostgreSQLReleaseNotes/AuroraPostgreSQL.Updates.html|RDS Updates>\n```${{ steps.available.outputs.versions }}```"}}]}'
+        curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.NOTIFY_DEV_SLACK_WEBHOOK }}

--- a/.github/workflows/check_rds_cluster_update.yml
+++ b/.github/workflows/check_rds_cluster_update.yml
@@ -42,7 +42,17 @@ jobs:
           --engine-version ${{ steps.current.outputs.version }} \
           --output text \
           --no-paginate)"
-        echo "versions=${AVAILABLE_VERSIONS}" >> "$GITHUB_OUTPUT"
+
+        # Get the latest version for each major version
+        LATEST_MAJOR_VERSIONS="$(echo $AVAILABLE_VERSIONS | awk -F. 'BEGIN {ORS="\\n"}{
+              major[$1] = $2 > major[$1] ? $2 : major[$1]
+          }
+          END {
+              for (m in major) {
+                  print m"."major[m]
+              }
+          }' | sort -t. -k1,1n -k2,2n)"
+        echo "versions=${LATEST_MAJOR_VERSIONS}" >> "$GITHUB_OUTPUT"
 
     - name: Post to slack
       if: steps.available.outputs.versions != ''


### PR DESCRIPTION
# Summary
Add a workflow that checks for available RDS cluster version upgrades.  Like the EKS update workflows, this will post a message to Slack if there are updates available.

# Related
- https://github.com/cds-snc/notification-planning-core/issues/64
- https://github.com/cds-snc/platform-core-services/issues/482