### PR TITLE
fix: RDS cluster update workflow version display

### DIFF
--- a/.github/workflows/check_rds_cluster_update.yml
+++ b/.github/workflows/check_rds_cluster_update.yml
@@ -27,15 +27,6 @@ jobs:
         role-session-name: RDSClusterUpdateCheck
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
-    - name: Get RDS cluster current version
-      id: current
-      run: |
-        CLUSTER_VERSION="$(aws rds describe-db-clusters \
-          --db-cluster-identifier ${{ env.RDS_CLUSTER_NAME }} \
-          --query 'DBClusters[0].EngineVersion' \
-          --output text)"
-        echo "version=${CLUSTER_VERSION}" >> "$GITHUB_OUTPUT"
-
     - name: Get RDS cluster available updates
       id: available
       run: |
@@ -46,5 +37,5 @@ jobs:
       if: steps.available.outputs.versions != ''
       #checkov:skip=CKV_GHA_3:This is an expected use of curl
       run: |
-        json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":mr-data: RDS Aurora Postgres ${{ steps.current.outputs.version }} updates are available: <https://docs.aws.amazon.com/AmazonRDS/latest/AuroraPostgreSQLReleaseNotes/AuroraPostgreSQL.Updates.html|RDS Updates>\n```${{ steps.available.outputs.versions }}```"}}]}'
+        json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":mr-data: RDS Aurora Postgres updates are available: <https://docs.aws.amazon.com/AmazonRDS/latest/AuroraPostgreSQLReleaseNotes/AuroraPostgreSQL.Updates.html|RDS Updates>\n```${{ steps.available.outputs.versions }}```"}}]}'
         curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.NOTIFY_DEV_SLACK_WEBHOOK }}

--- a/.github/workflows/check_rds_cluster_update.yml
+++ b/.github/workflows/check_rds_cluster_update.yml
@@ -7,15 +7,18 @@ on:
 env:
   AWS_DEFAULT_REGION: ca-central-1
   RDS_CLUSTER_NAME: notification-canada-ca-staging-cluster
-  RDS_ENGINE: aurora-postgresql
 
 permissions:
+  contents: read
   id-token: write
 
 jobs:
   check-rds-cluster-update:
     runs-on: ubuntu-latest
     steps:
+
+    - name: Checkout
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
     - name: Configure AWS credentials using OIDC
       uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
@@ -36,22 +39,7 @@ jobs:
     - name: Get RDS cluster available updates
       id: available
       run: |
-        AVAILABLE_VERSIONS="$(aws rds describe-db-engine-versions \
-          --engine ${{ env.RDS_ENGINE }} \
-          --query 'DBEngineVersions[*].ValidUpgradeTarget[*].{EngineVersion:EngineVersion}' \
-          --engine-version ${{ steps.current.outputs.version }} \
-          --output text \
-          --no-paginate)"
-
-        # Get the latest version for each major version
-        LATEST_MAJOR_VERSIONS="$(echo $AVAILABLE_VERSIONS | awk -F. 'BEGIN {ORS="\\n"}{
-              major[$1] = $2 > major[$1] ? $2 : major[$1]
-          }
-          END {
-              for (m in major) {
-                  print m"."major[m]
-              }
-          }' | sort -t. -k1,1n -k2,2n)"
+        LATEST_MAJOR_VERSIONS="$(./scripts/get_rds_cluster_updates.sh ${{ env.RDS_CLUSTER_NAME }})"
         echo "versions=${LATEST_MAJOR_VERSIONS}" >> "$GITHUB_OUTPUT"
 
     - name: Post to slack

--- a/scripts/get_rds_cluster_updates.sh
+++ b/scripts/get_rds_cluster_updates.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+#
+# Given an RDS cluster name, return the the most recent
+# minor version of each major release that is available.
+#
+# Example:
+#   $ ./get_rds_cluster_updates.sh my-rds-cluster
+#   11.20, 12.15, 13.9, 14.8, 15.3
+#
+
+RDS_CLUSTER_NAME="$1"
+
+CLUSTER="$(aws rds describe-db-clusters \
+    --db-cluster-identifier "$RDS_CLUSTER_NAME" \
+    --query 'DBClusters[0]')"
+
+CLUSTER_VERSION="$(echo "$CLUSTER" | jq -r .EngineVersion)"
+CLUSTER_ENGINE="$(echo "$CLUSTER" | jq -r .Engine)"
+
+AVAILABLE_VERSIONS="$(aws rds describe-db-engine-versions \
+    --engine "$CLUSTER_ENGINE" \
+    --query 'DBEngineVersions[*].ValidUpgradeTarget[*].{EngineVersion:EngineVersion}' \
+    --engine-version "$CLUSTER_VERSION" \
+    --no-paginate)"
+
+echo "$AVAILABLE_VERSIONS" | jq -r '.[0] 
+    | group_by(.EngineVersion | split(".") | .[0]) 
+    | map(max_by(.EngineVersion | split(".") | .[1])) 
+    | map(.EngineVersion) 
+    | join(", ")'


### PR DESCRIPTION
# Summary
Fix the display of the available major RDS cluster versions available for the target cluster:

![image](https://github.com/cds-snc/notification-terraform/assets/2110107/8109f87c-36b0-4d19-9694-adf7b1274a74)

Update the workflow to use a standalone script for easier testing.

# Related
- https://github.com/cds-snc/platform-core-services/issues/482
- https://github.com/cds-snc/notification-planning-core/issues/64