### PR TITLE
Reducing EKS minimum node count to 3; Setting desired count to 4

### DIFF
--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -34,12 +34,12 @@ include {
 }
 
 inputs = {
-  primary_worker_desired_size               = 7
+  primary_worker_desired_size               = 4
   primary_worker_instance_types             = ["r5.large"]
   secondary_worker_instance_types           = ["r5.large"]
   nodeUpgrade                               = false  
   primary_worker_max_size                   = 7
-  primary_worker_min_size                   = 4
+  primary_worker_min_size                   = 3
   vpc_id                                    = dependency.common.outputs.vpc_id
   vpc_private_subnets                       = dependency.common.outputs.vpc_private_subnets
   vpc_public_subnets                        = dependency.common.outputs.vpc_public_subnets


### PR DESCRIPTION
# Summary | Résumé

Celery has been running stable in prod for a week on karpenter nodes. We can now reduce the primary nodes. This will reduce to 4, which is a conservative reduction. We will monitor the system and reduce to 3 nodes in the future.

# Test instructions | Instructions pour tester la modification

- TF Plan in prod shows node reduction
- Smoke Test
- Verify admin works

