### PR TITLE
bump staging sns spend limit to 100

### DIFF
--- a/env/staging/common/terragrunt.hcl
+++ b/env/staging/common/terragrunt.hcl
@@ -7,7 +7,7 @@ include {
 }
 
 inputs = {
-  sns_monthly_spend_limit                                            = 50
+  sns_monthly_spend_limit                                            = 100
   sns_monthly_spend_limit_us_west_2                                  = 30
   alarm_warning_document_download_bucket_size_gb                     = 0.5
   alarm_warning_inflight_processed_created_delta_threshold           = 100


### PR DESCRIPTION
# Summary | Résumé

[Staging sns spend getting close to the current limit of $50 / month](https://gcdigital.slack.com/archives/C012W5K734Y/p1698268274798659). [We already got AWS to bump up the limit to 100 from their side a while ago](https://support.console.aws.amazon.com/support/home?region=ca-central-1#/case/?displayId=12375587721&language=en), so we just need to change it in our account settings.