### PR TITLE
Cloudfront s3

### DIFF
--- a/aws/common/uploadS3Assets.tf
+++ b/aws/common/uploadS3Assets.tf
@@ -1,0 +1,7 @@
+resource "aws_s3_object" "assets" {
+
+    bucket = aws_s3_bucket.asset_bucket.id
+    for_each = fileset("/var/tmp/notification-admin/app/assets/cloudfront","**")
+    key = each.value
+    source = "/var/tmp/notification-admin/app/assets/cloudfront/${each.value}"
+}

--- a/env/dev/common/terragrunt.hcl
+++ b/env/dev/common/terragrunt.hcl
@@ -3,7 +3,7 @@ terraform {
 
   before_hook "get-admin" {
     commands     = ["apply", "plan"]
-    execute      = ["git", "clone","-b", "asset-update2", "https://github.com/cds-snc/notification-admin.git", "/var/tmp/notification-admin"]
+    execute      = ["git", "clone", "https://github.com/cds-snc/notification-admin.git", "/var/tmp/notification-admin"]
     run_on_error = true
 
   }

--- a/env/dev/common/terragrunt.hcl
+++ b/env/dev/common/terragrunt.hcl
@@ -1,5 +1,19 @@
 terraform {
   source = "../../../aws//common"
+
+  before_hook "get-admin" {
+    commands     = ["apply", "plan"]
+    execute      = ["git", "clone","-b", "asset-update2", "https://github.com/cds-snc/notification-admin.git", "/var/tmp/notification-admin"]
+    run_on_error = true
+
+  }
+
+  after_hook "cleanup-admin" {
+    commands     = ["apply", "plan"]
+    execute      = ["rm", "-rfd", "/var/tmp/notification-admin"]
+    run_on_error = true
+  }  
+
 }
 
 include {

--- a/env/dev/quicksight/.terraform.lock.hcl
+++ b/env/dev/quicksight/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.23.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:OfNN1dWusOJXQFmQjEXwgVBBG1uUAZ6+Ecc0F0+ukPg=",
+    "zh:024a188ad3c979a9ec0d7d898aaa90a3867a8839edc8d3543ea6155e6e010064",
+    "zh:05b73a04c58534a7527718ef55040577d5c573ea704e16a813e7d1b18a7f4c26",
+    "zh:13932cdee2fa90f40ebaa783f033752864eb6899129e055511359f8d1ada3710",
+    "zh:3500f5febc7878b4426ef89a16c0096eefd4dd0c5b0d9ba00f9ed54387df5d09",
+    "zh:394a48dea7dfb0ae40e506ccdeb5387829dbb8ab00fb64f41c347a1de092aa00",
+    "zh:51a57f258b3bce2c167b39b6ecf486f72f523da05d4c92adc6b697abe1c5ff1f",
+    "zh:7290488a96d8d10119b431eb08a37407c0812283042a21b69bcc2454eabc08ad",
+    "zh:7545389dbbba624c0ffa72fa376b359b27f484aba02139d37ee5323b589e0939",
+    "zh:92266ac6070809e0c874511ae93097c8b1eddce4c0213e487c5439e89b6ad64d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c3841bd650d6ba471c7159bcdfa35200e5e49c2ea11032c481a33cf7875879d",
+    "zh:bd103c46a16e7f9357e08d6427c316ccc56d203452130eed8e36ede3afa3322c",
+    "zh:cab0a16e320c6ca285a3a51f40c8f46dbaa0712856594819b415b4d8b3e63910",
+    "zh:e8adedcda4d6ff47dcae9c9bb884da26ca448fb6f7436be95ad6a341e4d8094a",
+    "zh:fc23701a3723f50878f440dcdf8768ea96d60a0d7c351aa6dfb912ad832c8384",
+  ]
+}

--- a/env/production/common/terragrunt.hcl
+++ b/env/production/common/terragrunt.hcl
@@ -2,6 +2,19 @@
 #
 terraform {
   source = "git::https://github.com/cds-snc/notification-terraform//aws/common?ref=v${get_env("INFRASTRUCTURE_VERSION")}"
+  
+  before_hook "get-admin" {
+    commands     = ["apply", "plan"]
+    execute      = ["git", "clone","-b", "asset-update", "https://github.com/cds-snc/notification-admin.git", "/var/tmp/notification-admin"]
+    run_on_error = true
+
+  }
+
+  after_hook "cleanup-admin" {
+    commands     = ["apply", "plan"]
+    execute      = ["rm", "-rfd", "/var/tmp/notification-admin"]
+    run_on_error = true
+  }    
 }
 
 include {

--- a/env/staging/common/terragrunt.hcl
+++ b/env/staging/common/terragrunt.hcl
@@ -1,5 +1,18 @@
 terraform {
   source = "../../../aws//common"
+
+  before_hook "get-admin" {
+    commands     = ["apply", "plan"]
+    execute      = ["git", "clone","-b", "asset-update", "https://github.com/cds-snc/notification-admin.git", "/var/tmp/notification-admin"]
+    run_on_error = true
+
+  }
+
+  after_hook "cleanup-admin" {
+    commands     = ["apply", "plan"]
+    execute      = ["rm", "-rfd", "/var/tmp/notification-admin"]
+    run_on_error = true
+  }  
 }
 
 include {

--- a/env/staging/common/terragrunt.hcl
+++ b/env/staging/common/terragrunt.hcl
@@ -3,7 +3,7 @@ terraform {
 
   before_hook "get-admin" {
     commands     = ["apply", "plan"]
-    execute      = ["git", "clone","-b", "asset-update", "https://github.com/cds-snc/notification-admin.git", "/var/tmp/notification-admin"]
+    execute      = ["git", "clone", "https://github.com/cds-snc/notification-admin.git", "/var/tmp/notification-admin"]
     run_on_error = true
 
   }


### PR DESCRIPTION
# Summary | Résumé

Adding a hack to get the cloudfront assets for admin into the S3 bucket programmatically.

I tested in dev that it will overwrite existing files automatically and thus we shouldn't have any conflicts with existing resources in staging and prod.

# Test instructions | Instructions pour tester la modification

Terragrunt deploy
Ensure that admin is still working as expected