### PR TITLE
7 on demand nodes on prod

### DIFF
--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -34,7 +34,7 @@ include {
 }
 
 inputs = {
-  primary_worker_desired_size               = 4
+  primary_worker_desired_size               = 7
   primary_worker_instance_types             = ["r5.large"]
   secondary_worker_instance_types           = ["r5.large"]
   nodeUpgrade                               = false  


### PR DESCRIPTION
# Summary | Résumé

fluent bit problems with spot instances. moving celery back to on demand. This PR ups the number of nodes to accomodate.

