### PR TITLE
chore: remove legacy TLS ALB listener

### DIFF
--- a/aws/eks/alb.tf
+++ b/aws/eks/alb.tf
@@ -66,27 +66,6 @@ resource "aws_lb_listener" "notification-canada-ca-80" {
   }
 }
 
-# An HTTPS listener with an old SSL policy
-# for some clients that cannot upgrade to TLSv1.2
-resource "aws_lb_listener" "notification-canada-ca-legacy-tls" {
-  load_balancer_arn = aws_alb.notification-canada-ca.id
-  port              = 4444
-  protocol          = "HTTPS"
-  certificate_arn   = aws_acm_certificate.notification-canada-ca.arn
-  #tfsec:ignore:AWS010 Outdated SSL policy
-  ssl_policy = "ELBSecurityPolicy-2016-08"
-
-  default_action {
-    type = "fixed-response"
-
-    fixed_response {
-      content_type = "text/plain"
-      message_body = "Forbidden"
-      status_code  = "403"
-    }
-  }
-}
-
 ###
 # Document API Specific routing
 ###

--- a/aws/eks/securitygroups.tf
+++ b/aws/eks/securitygroups.tf
@@ -21,13 +21,6 @@ resource "aws_security_group" "notification-canada-ca-alb" {
     cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:AWS008
   }
 
-  ingress {
-    protocol    = "tcp"
-    from_port   = 4444
-    to_port     = 4444
-    cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:AWS008
-  }
-
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
   }


### PR DESCRIPTION
# Summary
Remove the port 4444 legacy TLS load balancer listener and its associated security group ingress rule.

This listener was set to return a `403 Forbidden` to all requests back in November 2021, so the risk of removing it is low.

The reason for the removal is that it is being flagged as a Security Hub finding for `0.0.0.0/0` ingress on an unexpected port.

# Related
- #262 
- #321
- https://github.com/cds-snc/platform-core-services/issues/471