### PR TITLE
Alarm to notify team if there was a failed login of more than 10 times

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -730,3 +730,17 @@ resource "aws_cloudwatch_metric_alarm" "documentation-evicted-pods" {
   ok_actions                = [var.sns_alert_warning_arn]
   insufficient_data_actions = [var.sns_alert_warning_arn]
 }
+
+resource "aws_cloudwatch_metric_alarm" "failed-login-count-5-minute-warning" {
+  alarm_name          = "failed-login-count-5-minute-warning"
+  alarm_description   = "One user had a failed login count of more than 10 times in 5 minutes"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "5"
+  metric_name         = aws_cloudwatch_log_metric_filter.failed-login-count-more-than-10[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.failed-login-count-more-than-10[0].metric_transformation[0].namespace
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [var.sns_alert_warning_arn]
+}

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -166,3 +166,16 @@ resource "aws_cloudwatch_log_metric_filter" "documentation-evicted-pods" {
     value     = "1"
   }
 }
+
+resource "aws_cloudwatch_log_metric_filter" "failed-login-count-more-than-10" {
+  count          = var.cloudwatch_enabled ? 1 : 0
+  name           = "failed-login-count-more-than-10"
+  pattern        = "Failed login: Incorrect password for"
+  log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs[0].name
+
+  metric_transformation {
+    name      = "failed-login-count"
+    namespace = "LogMetrics"
+    value     = "1"
+  }
+}


### PR DESCRIPTION
# Summary | Résumé

Once this is merged: https://github.com/cds-snc/notification-api/pull/1994
we want to ensure that a failed login is reported to our slack channel. We will only report it if a user has failed to login > 10 times.