### PR TITLE
excplicitly setting image mime type

### DIFF
--- a/aws/common/uploadS3Assets.tf
+++ b/aws/common/uploadS3Assets.tf
@@ -5,10 +5,10 @@
 
 resource "aws_s3_object" "assets" {
 
-  bucket   = aws_s3_bucket.asset_bucket.id
-  for_each = fileset("/var/tmp/notification-admin/app/assets/cloudfront", "**")
-  key      = each.value
-  source   = "/var/tmp/notification-admin/app/assets/cloudfront/${each.value}"
+  bucket       = aws_s3_bucket.asset_bucket.id
+  for_each     = fileset("/var/tmp/notification-admin/app/assets/cloudfront", "**")
+  key          = each.value
+  source       = "/var/tmp/notification-admin/app/assets/cloudfront/${each.value}"
   content_type = "image/svg+xml"
 
 }

--- a/aws/common/uploadS3Assets.tf
+++ b/aws/common/uploadS3Assets.tf
@@ -9,5 +9,6 @@ resource "aws_s3_object" "assets" {
   for_each = fileset("/var/tmp/notification-admin/app/assets/cloudfront", "**")
   key      = each.value
   source   = "/var/tmp/notification-admin/app/assets/cloudfront/${each.value}"
+  content_type = "image/svg+xml"
 
 }


### PR DESCRIPTION
# Summary | Résumé

We're running into image mime type issues, this should explicitly set mime type to images.

We will need to invalidate the cloudfront cache afterwards.

# Test instructions | Instructions pour tester la modification

Apply staging
Invalidate cloudfront cache
Navigate admin and verify images work in staging