### PR TITLE
fix: centralize workflow failure notifications

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -150,10 +150,3 @@ jobs:
         run: |
           cd env/production/lambda-google-cidr
           terragrunt apply --terragrunt-non-interactive -auto-approve
-
-      - name: Slack message on failure
-        if: ${{ failure() }}
-        #checkov:skip=CKV_GHA_3:This is an expected use of curl
-        run: |
-          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Terraform apply failed: <https://github.com/cds-snc/notification-terraform/actions/runs/${GITHUB_RUN_ID}|Merge to main (Production)>"}}]}'
-          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.NOTIFY_DEV_SLACK_WEBHOOK }}

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -170,10 +170,3 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           release_branches: main
-
-      - name: Slack message on failure
-        if: ${{ failure() }}
-        #checkov:skip=CKV_GHA_3:This is an expected use of curl
-        run: |
-          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Terraform apply failed: <https://github.com/cds-snc/notification-terraform/actions/runs/${GITHUB_RUN_ID}|Merge to main (Staging)>"}}]}'
-          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.NOTIFY_DEV_SLACK_WEBHOOK }}

--- a/.github/workflows/workflow_failure.yml
+++ b/.github/workflows/workflow_failure.yml
@@ -1,0 +1,19 @@
+name: Workflow failure
+
+on:
+  workflow_run:
+    workflows:
+      - "Merge to main (Production)"
+      - "Merge to main (Staging)"
+    types:
+      - completed
+
+jobs:
+  on-failure:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure'
+    steps:
+      - name: Notify Slack
+        run: |
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: GitHub workflow failed: <${{ github.event.workflow_run.html_url }}|${{ github.event.workflow.name }}>"}}]}'
+          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.NOTIFY_DEV_SLACK_WEBHOOK }}

--- a/.github/workflows/workflow_failure.yml
+++ b/.github/workflows/workflow_failure.yml
@@ -15,5 +15,5 @@ jobs:
     steps:
       - name: Notify Slack
         run: |
-          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: GitHub workflow failed: <${{ github.event.workflow_run.html_url }}|${{ github.event.workflow.name }}>"}}]}'
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Terraform workflow failed: <${{ github.event.workflow_run.html_url }}|${{ github.event.workflow.name }}>"}}]}'
           curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.NOTIFY_DEV_SLACK_WEBHOOK }}


### PR DESCRIPTION
# Summary
Add a workflow that is triggered when named workflow runs are completed.  If these workflows have a status of `failure` a message will be posted to Slack with a link to the failed run.