### PR TITLE
Reducing prod to 4 primary nodes again

### DIFF
--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -40,7 +40,7 @@ include {
 }
 
 inputs = {
-  primary_worker_desired_size               = 7
+  primary_worker_desired_size               = 4
   primary_worker_instance_types             = ["r5.large"]
   secondary_worker_instance_types           = ["r5.large"]
   nodeUpgrade                               = false  


### PR DESCRIPTION
# Summary | Résumé

Setting on demand node count back to 4 since we're stable with karpenter.

# Test instructions | Instructions pour tester la modification

Smoke test production after apply