### PR TITLE
fix: remove RDS version constraint on update check

### DIFF
--- a/scripts/get_rds_cluster_updates.sh
+++ b/scripts/get_rds_cluster_updates.sh
@@ -22,7 +22,6 @@ CLUSTER_ENGINE="$(echo "$CLUSTER" | jq -r .Engine)"
 AVAILABLE_VERSIONS="$(aws rds describe-db-engine-versions \
     --engine "$CLUSTER_ENGINE" \
     --query 'DBEngineVersions[*].ValidUpgradeTarget[*].{EngineVersion:EngineVersion}' \
-    --engine-version "$CLUSTER_VERSION" \
     --no-paginate)"
 
 echo "$AVAILABLE_VERSIONS" | jq -r '.[0] 


### PR DESCRIPTION
# Summary
Update the RDS update check script to remove the `engine-version` parameter as this was causing an empty array of versions to be returned.

Output of the script will be the same with the highest available Postgres version available:
```
11.21, 12.9, 13.9, 14.9, 15.4
```