### PR TITLE
Changed the eval to 1 error in a 5 min period

### DIFF
--- a/aws/lambda-api/cloudwatch_alarms.tf
+++ b/aws/lambda-api/cloudwatch_alarms.tf
@@ -69,10 +69,10 @@ resource "aws_cloudwatch_metric_alarm" "failed-login-count-5-minute-warning" {
   alarm_name          = "failed-login-count-5-minute-warning"
   alarm_description   = "One user had a failed login count of more than 10 times in 5 minutes"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "5"
+  evaluation_periods  = "1"
   metric_name         = aws_cloudwatch_log_metric_filter.failed-login-count-more-than-10[0].name
   namespace           = aws_cloudwatch_log_metric_filter.failed-login-count-more-than-10[0].metric_transformation[0].namespace
-  period              = 60
+  period              = 300
   statistic           = "Sum"
   threshold           = 1
   treat_missing_data  = "notBreaching"


### PR DESCRIPTION
# Summary | Résumé

We want an alarm if a user is locked out after trying to login 10 times. This will only be a warning error