### PR TITLE
All log retention syncronized across log groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ override.tf.json
 
 # VSCode editor's files
 .vscode
+
+# aider AI
+.aider*
+.DS_Store

--- a/aws/common/cloudwatch_log.tf
+++ b/aws/common/cloudwatch_log.tf
@@ -4,6 +4,7 @@
 resource "aws_cloudwatch_log_group" "sns_deliveries" {
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "sns/${var.region}/${var.account_id}/DirectPublishToPhoneNumber"
+  retention_in_days = var.env == "production" ? 0 : 365
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
@@ -13,6 +14,7 @@ resource "aws_cloudwatch_log_group" "sns_deliveries" {
 resource "aws_cloudwatch_log_group" "sns_deliveries_failures" {
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "sns/${var.region}/${var.account_id}/DirectPublishToPhoneNumber/Failure"
+  retention_in_days = var.env == "production" ? 0 : 365
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
@@ -24,6 +26,7 @@ resource "aws_cloudwatch_log_group" "sns_deliveries_us_west_2" {
 
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "sns/us-west-2/${var.account_id}/DirectPublishToPhoneNumber"
+  retention_in_days = var.env == "production" ? 0 : 365
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
@@ -35,6 +38,7 @@ resource "aws_cloudwatch_log_group" "sns_deliveries_failures_us_west_2" {
 
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "sns/us-west-2/${var.account_id}/DirectPublishToPhoneNumber/Failure"
+  retention_in_days = var.env == "production" ? 0 : 365
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
@@ -44,8 +48,7 @@ resource "aws_cloudwatch_log_group" "sns_deliveries_failures_us_west_2" {
 resource "aws_cloudwatch_log_group" "route53_resolver_query_log" {
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "route53/${var.region}/${var.account_id}/DNS/logs"
-
-  retention_in_days = 14
+  retention_in_days = var.env == "production" ? 0 : 365
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"

--- a/aws/common/cloudwatch_log.tf
+++ b/aws/common/cloudwatch_log.tf
@@ -2,8 +2,8 @@
 # AWS CloudWatch Log Groups
 ###
 resource "aws_cloudwatch_log_group" "sns_deliveries" {
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "sns/${var.region}/${var.account_id}/DirectPublishToPhoneNumber"
+  count             = var.cloudwatch_enabled ? 1 : 0
+  name              = "sns/${var.region}/${var.account_id}/DirectPublishToPhoneNumber"
   retention_in_days = var.env == "production" ? 0 : 365
 
   tags = {
@@ -12,8 +12,8 @@ resource "aws_cloudwatch_log_group" "sns_deliveries" {
 }
 
 resource "aws_cloudwatch_log_group" "sns_deliveries_failures" {
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "sns/${var.region}/${var.account_id}/DirectPublishToPhoneNumber/Failure"
+  count             = var.cloudwatch_enabled ? 1 : 0
+  name              = "sns/${var.region}/${var.account_id}/DirectPublishToPhoneNumber/Failure"
   retention_in_days = var.env == "production" ? 0 : 365
 
   tags = {
@@ -24,8 +24,8 @@ resource "aws_cloudwatch_log_group" "sns_deliveries_failures" {
 resource "aws_cloudwatch_log_group" "sns_deliveries_us_west_2" {
   provider = aws.us-west-2
 
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "sns/us-west-2/${var.account_id}/DirectPublishToPhoneNumber"
+  count             = var.cloudwatch_enabled ? 1 : 0
+  name              = "sns/us-west-2/${var.account_id}/DirectPublishToPhoneNumber"
   retention_in_days = var.env == "production" ? 0 : 365
 
   tags = {
@@ -36,8 +36,8 @@ resource "aws_cloudwatch_log_group" "sns_deliveries_us_west_2" {
 resource "aws_cloudwatch_log_group" "sns_deliveries_failures_us_west_2" {
   provider = aws.us-west-2
 
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "sns/us-west-2/${var.account_id}/DirectPublishToPhoneNumber/Failure"
+  count             = var.cloudwatch_enabled ? 1 : 0
+  name              = "sns/us-west-2/${var.account_id}/DirectPublishToPhoneNumber/Failure"
   retention_in_days = var.env == "production" ? 0 : 365
 
   tags = {
@@ -46,8 +46,8 @@ resource "aws_cloudwatch_log_group" "sns_deliveries_failures_us_west_2" {
 }
 
 resource "aws_cloudwatch_log_group" "route53_resolver_query_log" {
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "route53/${var.region}/${var.account_id}/DNS/logs"
+  count             = var.cloudwatch_enabled ? 1 : 0
+  name              = "route53/${var.region}/${var.account_id}/DNS/logs"
   retention_in_days = var.env == "production" ? 0 : 365
 
   tags = {

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -5,19 +5,19 @@
 resource "aws_cloudwatch_log_group" "notification-canada-ca-eks-cluster-logs" {
   count             = var.cloudwatch_enabled ? 1 : 0
   name              = "/aws/eks/${var.eks_cluster_name}/cluster"
-  retention_in_days = 14
+  retention_in_days = var.env == "production" ? 0 : 365
 }
 
 resource "aws_cloudwatch_log_group" "notification-canada-ca-eks-application-logs" {
   count             = var.cloudwatch_enabled ? 1 : 0
   name              = "/aws/containerinsights/${var.eks_cluster_name}/application"
-  retention_in_days = var.env == "production" ? 0 : 30
+  retention_in_days = var.env == "production" ? 0 : 365
 }
 
 resource "aws_cloudwatch_log_group" "notification-canada-ca-eks-prometheus-logs" {
   count             = var.cloudwatch_enabled ? 1 : 0
   name              = "/aws/containerinsights/${var.eks_cluster_name}/prometheus"
-  retention_in_days = 0
+  retention_in_days = var.env == "production" ? 0 : 365
 }
 
 

--- a/aws/elasticache/cloudwatch_log.tf
+++ b/aws/elasticache/cloudwatch_log.tf
@@ -1,9 +1,9 @@
 resource "aws_cloudwatch_log_group" "notification-canada-ca-elasticache-slow-logs" {
   name              = "/aws/elasticache/notify-${var.env}-cluster-cache-az/slow-logs"
-  retention_in_days = 90
+  retention_in_days = var.env == "production" ? 0 : 365
 }
 
 resource "aws_cloudwatch_log_group" "notification-canada-ca-elasticache-engine-logs" {
   name              = "/aws/elasticache/notify-${var.env}-cluster-cache-az/engine-logs"
-  retention_in_days = 90
+  retention_in_days = var.env == "production" ? 0 : 365
 }

--- a/aws/heartbeat/cloudwatch_logs.tf
+++ b/aws/heartbeat/cloudwatch_logs.tf
@@ -5,7 +5,7 @@
 resource "aws_cloudwatch_log_group" "heartbeat_log_group" {
   count             = var.cloudwatch_enabled ? 1 : 0
   name              = "heartbeat_log_group"
-  retention_in_days = 90
+  retention_in_days = var.env == "production" ? 0 : 365
   tags = {
     CostCenter  = "notification-canada-ca-${var.env}"
     Environment = var.env

--- a/aws/lambda-api/cloudwatch_logs.tf
+++ b/aws/lambda-api/cloudwatch_logs.tf
@@ -4,7 +4,7 @@
 
 resource "aws_cloudwatch_log_group" "api_gateway_log_group" {
   name              = "api_gateway_log_group"
-  retention_in_days = 0
+  retention_in_days = var.env == "production" ? 0 : 365
   tags = {
     CostCenter  = "notification-canada-ca-${var.env}"
     Environment = var.env
@@ -15,7 +15,7 @@ resource "aws_cloudwatch_log_group" "api_gateway_log_group" {
 resource "aws_cloudwatch_log_group" "api_lambda_log_group" {
   count             = var.cloudwatch_enabled ? 1 : 0
   name              = "/aws/lambda/${aws_lambda_function.api.function_name}"
-  retention_in_days = 0
+  retention_in_days = var.env == "production" ? 0 : 365
   tags = {
     CostCenter  = "notification-canada-ca-${var.env}"
     Environment = var.env

--- a/aws/performance-test/cloudwatch_logs.tf
+++ b/aws/performance-test/cloudwatch_logs.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_group" "perf_test_ecs_logs" {
   count             = var.cloudwatch_enabled ? 1 : 0
   name              = aws_ecs_cluster.perf_test.name
-  retention_in_days = 14
+  retention_in_days = var.env == "production" ? 0 : 365
 }

--- a/aws/ses_to_sqs_email_callbacks/cloudwatch_logs.tf
+++ b/aws/ses_to_sqs_email_callbacks/cloudwatch_logs.tf
@@ -5,7 +5,7 @@
 resource "aws_cloudwatch_log_group" "ses_to_sqs_email_callbacks_log_group" {
   count             = var.cloudwatch_enabled ? 1 : 0
   name              = "ses_to_sqs_email_callbacks_log_group"
-  retention_in_days = 90
+  retention_in_days = var.env == "production" ? 0 : 365
   tags = {
     CostCenter  = "notification-canada-ca-${var.env}"
     Environment = var.env

--- a/aws/sns_to_sqs_sms_callbacks/cloudwatch_logs.tf
+++ b/aws/sns_to_sqs_sms_callbacks/cloudwatch_logs.tf
@@ -5,7 +5,7 @@
 resource "aws_cloudwatch_log_group" "sns_to_sqs_sms_callbacks_log_group" {
   count             = var.cloudwatch_enabled ? 1 : 0
   name              = "sns_to_sqs_sms_callbacks_log_group"
-  retention_in_days = 90
+  retention_in_days = var.env == "production" ? 0 : 365
   tags = {
     CostCenter  = "notification-canada-ca-${var.env}"
     Environment = var.env


### PR DESCRIPTION
# Summary | Résumé

Setting log retention across all log groups. Prod will retain indefinitely, other envs, 1 year.

# Test instructions | Instructions pour tester la modification

Tested apply in dev
Test in staging
Smoke test in staging
Verify log retention periods in AWS console.