### PR TITLE
Removing the limit on celery errors for notify system overview

### DIFF
--- a/aws/eks/dashboards.tf
+++ b/aws/eks/dashboards.tf
@@ -49,7 +49,7 @@ resource "aws_cloudwatch_dashboard" "notify_system" {
             "x": 8,
             "type": "log",
             "properties": {
-                "query": "SOURCE '/aws/containerinsights/${aws_eks_cluster.notification-canada-ca-eks-cluster.name}/application' | fields @timestamp as Time, kubernetes.pod_name as PodName, log\n| filter kubernetes.container_name like /^celery/\n| filter @message like /ERROR\\/.*Worker/\n| sort @timestamp desc\n| limit 20\n",
+                "query": "SOURCE '/aws/containerinsights/${aws_eks_cluster.notification-canada-ca-eks-cluster.name}/application' | fields @timestamp as Time, kubernetes.pod_name as PodName, log\n| filter kubernetes.container_name like /^celery/\n| filter @message like /ERROR\\/.*Worker/\n| sort @timestamp desc\n",
                 "region": "${var.region}",
                 "stacked": false,
                 "title": "Celery Errors",


### PR DESCRIPTION
# Summary | Résumé

Removing the limit 20 on the celery error query so that we can see all of the error messages for a given time period.

# Test instructions | Instructions pour tester la modification

Tested deployment works in dev

- Staging apply
- Pick a long time window in the notify-system-overview dashboard and make sure you see more than 20 errors.