### PR TITLE
fix: file scanning target account

### DIFF
--- a/aws/common/file_scanning.tf
+++ b/aws/common/file_scanning.tf
@@ -1,6 +1,13 @@
+locals {
+  scan_files_account = var.env == "production" ? "806545929748" : "127893201980"
+}
+
 module "s3_scan_objects" {
   source = "github.com/cds-snc/terraform-modules//S3_scan_object?ref=v6.0.1"
 
-  s3_upload_bucket_name = "notification-canada-ca-${var.env}-document-download-scan-files"
-  billing_tag_value     = var.billing_tag_value
+  s3_upload_bucket_name   = "notification-canada-ca-${var.env}-document-download-scan-files"
+  s3_scan_object_role_arn = "arn:aws:iam::${local.scan_files_account}:role/s3-scan-object"
+  scan_files_role_arn     = "arn:aws:iam::${local.scan_files_account}:role/scan-files-api"
+
+  billing_tag_value = var.billing_tag_value
 }


### PR DESCRIPTION
# Summary
Update the `s3_scan_object` module configuration so that all non-production Notify accounts use the Scan Files Staging service.

This will stop pentesting and load testing in the Notify Staging environment from impacting the Scan Files Production service.

# ⚠️  Note
Once this merges in Staging, the [`sqs_event_accounts` input will need to be updated in Scan Files](https://github.com/cds-snc/scan-files/blob/dfc80acd4a5a85cac7b79505be091618aa0370a9/terragrunt/env/staging/s3_scan_object/terragrunt.hcl#L27).