### PR TITLE
Quicksight tweaks

### DIFF
--- a/aws/quicksight/data_source.tf
+++ b/aws/quicksight/data_source.tf
@@ -21,4 +21,15 @@ resource "aws_quicksight_data_source" "rds" {
     }
   }
   type = "POSTGRESQL"
+  permission {
+    actions = [
+      "quicksight:PassDataSource",
+      "quicksight:DescribeDataSourcePermissions",
+      "quicksight:UpdateDataSource",
+      "quicksight:UpdateDataSourcePermissions",
+      "quicksight:DescribeDataSource",
+      "quicksight:DeleteDataSource"
+    ]
+    principal = aws_quicksight_group.dataset_owner.arn
+  }
 }

--- a/aws/quicksight/data_source.tf
+++ b/aws/quicksight/data_source.tf
@@ -1,5 +1,5 @@
 resource "aws_quicksight_data_source" "rds" {
-  depends_on     = [aws_iam_role_policy_attachment.rds-qs-attach]
+  depends_on     = [aws_iam_role_policy_attachment.rds-qs-attach, aws_quicksight_account_subscription.subscription]
   data_source_id = var.database_name
   name           = "Quicksight RDS data source"
   ssl_properties {

--- a/aws/quicksight/user_group.tf
+++ b/aws/quicksight/user_group.tf
@@ -1,9 +1,11 @@
 resource "aws_quicksight_group" "dataset_owner" {
+  depends_on  = [aws_quicksight_account_subscription.subscription]
   group_name  = "quicksight-dataset-owners"
   description = "users with owner permissions to QuickSight data sets"
 }
 
 resource "aws_quicksight_group" "dataset_viewer" {
+  depends_on  = [aws_quicksight_account_subscription.subscription]
   group_name  = "quicksight-dataset-viewers"
   description = "users with viewer permissions to QuickSight data sets"
 }


### PR DESCRIPTION
# Summary | Résumé

- add dependancies on subscription creation
- add owner group permissions to use the data source (for manually creating joined tables, won't need this once everything is done in terraform / CloudFormation)

