### PR TITLE
Reducing prod to 4 nodes to allow scaling to do its thing again

### DIFF
--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -40,12 +40,12 @@ include {
 }
 
 inputs = {
-  primary_worker_desired_size               = 8
+  primary_worker_desired_size               = 4
   primary_worker_instance_types             = ["r5.large"]
   secondary_worker_instance_types           = ["r5.large"]
   nodeUpgrade                               = false  
   primary_worker_max_size                   = 8
-  primary_worker_min_size                   = 8
+  primary_worker_min_size                   = 3
   vpc_id                                    = dependency.common.outputs.vpc_id
   vpc_private_subnets                       = dependency.common.outputs.vpc_private_subnets
   vpc_public_subnets                        = dependency.common.outputs.vpc_public_subnets


### PR DESCRIPTION
# Summary | Résumé

Reduce prod to 4 primary nodes so that we delegate most celery instances to spot nodes.

# Test instructions | Instructions pour tester la modification

Smoke test in production
Verify logging
Verify no errors in notification-ops
Verify 4 on demand nodes 
```
kubectl describe nodes | grep ON_DEMAND
```
Verify there are spot nodes
```
kubectl describe nodes | grep spot
```
Use K9s to validate that all deployments are able to spin up to their desired count