### PR TITLE
Try setting up a separate DB reader instance for blazer

### DIFF
--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -10,6 +10,10 @@ output "vpc_private_subnets" {
   value = aws_subnet.notification-canada-ca-private.*.id
 }
 
+output "vpc_private_subnets_separate_reader_db" {
+  value = aws_subnet.notification-canada-ca-private-separate-db-reader.id
+}
+
 output "vpc_public_subnets" {
   value = aws_subnet.notification-canada-ca-public.*.id
 }

--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -11,7 +11,7 @@ output "vpc_private_subnets" {
 }
 
 output "vpc_private_subnets_separate_reader_db" {
-  value = aws_subnet.notification-canada-ca-private-separate-db-reader.id
+  value = aws_subnet.notification-canada-ca-private-separate-db-reader.*.id
 }
 
 output "vpc_public_subnets" {

--- a/aws/common/vpc.tf
+++ b/aws/common/vpc.tf
@@ -87,6 +87,19 @@ resource "aws_subnet" "notification-canada-ca-private" {
   }
 }
 
+resource "aws_subnet" "notification-canada-ca-private-separate-db-reader" {
+  vpc_id            = aws_vpc.notification-canada-ca.id
+  cidr_block        = "10.0.16.0/24"
+  availability_zone = element(data.aws_availability_zones.available.names, 0)
+
+  tags = {
+    Name       = "Private Subnet for database-tools (DB Reader)"
+    CostCenter = "notification-canada-ca-${var.env}"
+    Access     = "private"
+  }
+}
+
+
 resource "aws_subnet" "notification-canada-ca-public" {
   count = 3
 

--- a/aws/common/vpc.tf
+++ b/aws/common/vpc.tf
@@ -163,6 +163,26 @@ resource "aws_route_table_association" "notification-canada-ca-private" {
   route_table_id = aws_route_table.notification-canada-ca-private_subnet.*.id[count.index]
 }
 
+# Route table for Subnet for database-tools (DB Reader)
+resource "aws_route_table" "notification-canada-ca-private-db-reader_subnet" {
+  vpc_id = aws_vpc.notification-canada-ca.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.notification-canada-ca[0].id
+  }
+
+  tags = {
+    Name       = "Private Subnet Route Table for DB reader"
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}
+
+resource "aws_route_table_association" "notification-canada-ca-private-db-reader" {
+  subnet_id      = aws_subnet.notification-canada-ca-private-separate-db-reader.id
+  route_table_id = aws_route_table.notification-canada-ca-private-db-reader_subnet.id
+}
+
 ###
 # AWS Network ACL
 ###

--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -15,7 +15,7 @@ resource "aws_db_subnet_group" "notification-canada-ca" {
 
 resource "aws_db_subnet_group" "notification-canada-ca-reader-db" {
   name       = "notification-canada-ca-separate-reader-db${var.env}"
-  subnet_ids = [var.vpc_private_subnets_separate_reader_db]
+  subnet_ids = var.vpc_private_subnets_separate_reader_db
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
@@ -64,7 +64,7 @@ resource "aws_rds_cluster_instance" "notification-canada-ca-separate-reader-db" 
 
 resource "aws_rds_cluster_parameter_group" "default" {
   name        = "rds-cluster-pg"
-  family      = "aurora-postgresql11"
+  family      = "aurora-postgresql15"
   description = "RDS customized cluster parameter group"
 
   parameter {

--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -54,8 +54,10 @@ resource "aws_rds_cluster_instance" "notification-canada-ca-separate-reader-db" 
   # tfsec:ignore:AWS053 - Encryption for RDS Perfomance Insights should be enabled.
   # Cannot set a custom KMS key after performance insights has been enabled
   # https://github.com/hashicorp/terraform-provider-aws/issues/3015#issuecomment-520667166
+  # checkov:skip= CKV_AWS_354:AWS KMS Is good enough for us
   preferred_maintenance_window = "wed:04:00-wed:04:30"
-  auto_minor_version_upgrade   = false
+  auto_minor_version_upgrade   = true
+  monitoring_interval          = 60
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"

--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -15,7 +15,7 @@ resource "aws_db_subnet_group" "notification-canada-ca" {
 
 resource "aws_db_subnet_group" "notification-canada-ca-reader-db" {
   name       = "notification-canada-ca-separate-reader-db${var.env}"
-  subnet_ids = var.vpc_private_subnets_separate_reader_db
+  subnet_ids = [var.vpc_private_subnets_separate_reader_db]
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"

--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -43,15 +43,13 @@ resource "aws_rds_cluster_instance" "notification-canada-ca-instances" {
 }
 
 resource "aws_rds_cluster_instance" "notification-canada-ca-separate-reader-db" {
-  count                        = 1
-  identifier                   = "notification-canada-ca-${var.env}-separate-reader-db-${count.index}"
+  identifier                   = "notification-canada-ca-${var.env}-separate-reader-db-0"
   cluster_identifier           = aws_rds_cluster.notification-canada-ca.id
   instance_class               = var.rds_instance_type
   db_subnet_group_name         = aws_db_subnet_group.notification-canada-ca-reader-db.name
   engine                       = aws_rds_cluster.notification-canada-ca.engine
   engine_version               = aws_rds_cluster.notification-canada-ca.engine_version
   performance_insights_enabled = true
-  # tfsec:ignore:AWS053 - Encryption for RDS Perfomance Insights should be enabled.
   # Cannot set a custom KMS key after performance insights has been enabled
   # https://github.com/hashicorp/terraform-provider-aws/issues/3015#issuecomment-520667166
   # checkov:skip= CKV_AWS_354:AWS KMS Is good enough for us

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -30,7 +30,7 @@ variable "vpc_private_subnets" {
 }
 
 variable "vpc_private_subnets_separate_reader_db" {
-  type        = string
+  type        = list(any)
   description = "Subnet so blazer can run on a reader instance of the DB that isn't used by the app layer"
 }
 

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -29,6 +29,11 @@ variable "vpc_private_subnets" {
   type = list(any)
 }
 
+variable "vpc_private_subnets_separate_reader_db" {
+  type        = string
+  description = "Subnet so blazer can run on a reader instance of the DB that isn't used by the app layer"
+}
+
 variable "sns_alert_general_arn" {
   type = string
 }

--- a/env/dev/rds/terragrunt.hcl
+++ b/env/dev/rds/terragrunt.hcl
@@ -16,7 +16,7 @@ dependency "common" {
       "subnet-08de34a9e1a7458dc",
       "subnet-0af8b8402f1d605ff",
     ]
-    vpc_private_subnets_separate_reader_db = "subnet-0af8b8402f1d60523"
+    vpc_private_subnets_separate_reader_db = ["subnet-0af8b8402f1d60523"]
     sns_alert_general_arn = ""
   }
 }
@@ -39,7 +39,7 @@ include {
 inputs = {
   eks_cluster_securitygroup               = dependency.eks.outputs.eks-cluster-securitygroup
   kms_arn                                 = dependency.common.outputs.kms_arn
-  rds_instance_count                      = 1
+  rds_instance_count                      = 3
   rds_instance_type                       = "db.t3.medium"
   vpc_private_subnets                     = dependency.common.outputs.vpc_private_subnets
   vpc_private_subnets_separate_reader_db  = dependency.common.outputs.vpc_private_subnets_separate_reader_db

--- a/env/dev/rds/terragrunt.hcl
+++ b/env/dev/rds/terragrunt.hcl
@@ -7,7 +7,8 @@ dependency "common" {
 
   # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
   # module hasn't been applied yet.
-  mock_outputs_allowed_terraform_commands = ["validate"]
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state = true
   mock_outputs = {
     kms_arn = ""
     vpc_private_subnets = [
@@ -15,6 +16,7 @@ dependency "common" {
       "subnet-08de34a9e1a7458dc",
       "subnet-0af8b8402f1d605ff",
     ]
+    vpc_private_subnets_separate_reader_db = "subnet-0af8b8402f1d60523"
     sns_alert_general_arn = ""
   }
 }
@@ -35,13 +37,14 @@ include {
 }
 
 inputs = {
-  eks_cluster_securitygroup = dependency.eks.outputs.eks-cluster-securitygroup
-  kms_arn                   = dependency.common.outputs.kms_arn
-  rds_instance_count        = 3
-  rds_instance_type         = "db.t3.medium"
-  vpc_private_subnets       = dependency.common.outputs.vpc_private_subnets
-  sns_alert_general_arn     = dependency.common.outputs.sns_alert_general_arn
-  rds_database_name         = "notificationcanadacadev"
+  eks_cluster_securitygroup               = dependency.eks.outputs.eks-cluster-securitygroup
+  kms_arn                                 = dependency.common.outputs.kms_arn
+  rds_instance_count                      = 1
+  rds_instance_type                       = "db.t3.medium"
+  vpc_private_subnets                     = dependency.common.outputs.vpc_private_subnets
+  vpc_private_subnets_separate_reader_db  = dependency.common.outputs.vpc_private_subnets_separate_reader_db
+  sns_alert_general_arn                   = dependency.common.outputs.sns_alert_general_arn
+  rds_database_name                       = "notificationcanadacadev"
 }
 
 terraform {

--- a/env/production/rds/terragrunt.hcl
+++ b/env/production/rds/terragrunt.hcl
@@ -8,10 +8,31 @@ dependencies {
 
 dependency "common" {
   config_path = "../common"
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    kms_arn = ""
+    vpc_private_subnets = [
+      "subnet-001e585d12cce4d1e",
+      "subnet-08de34a9e1a7458dc",
+      "subnet-0af8b8402f1d605ff",
+    ]
+    vpc_private_subnets_separate_reader_db = ["subnet-0af8b8402f1d60523"]
+    sns_alert_general_arn = ""
+  }
+  mock_outputs_merge_with_state = true
 }
 
 dependency "eks" {
   config_path = "../eks"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["validate"]
+  mock_outputs = {
+    eks-cluster-securitygroup = "sg-0e2c3ef6c5c75b74c"
+  }
 }
 
 include {
@@ -19,11 +40,12 @@ include {
 }
 
 inputs = {
-  eks_cluster_securitygroup = dependency.eks.outputs.eks-cluster-securitygroup
-  kms_arn                   = dependency.common.outputs.kms_arn
-  rds_instance_count        = 3
-  rds_instance_type         = "db.r6g.large"
-  vpc_private_subnets       = dependency.common.outputs.vpc_private_subnets
-  sns_alert_general_arn     = dependency.common.outputs.sns_alert_general_arn
-  rds_database_name         = "NotificationCanadaCaproduction"
+  eks_cluster_securitygroup               = dependency.eks.outputs.eks-cluster-securitygroup
+  kms_arn                                 = dependency.common.outputs.kms_arn
+  rds_instance_count                      = 3
+  rds_instance_type                       = "db.r6g.large"
+  vpc_private_subnets                     = dependency.common.outputs.vpc_private_subnets
+  vpc_private_subnets_separate_reader_db  = dependency.common.outputs.vpc_private_subnets_separate_reader_db
+  sns_alert_general_arn                   = dependency.common.outputs.sns_alert_general_arn
+  rds_database_name                       = "NotificationCanadaCaproduction"
 }

--- a/env/scratch/rds/terragrunt.hcl
+++ b/env/scratch/rds/terragrunt.hcl
@@ -7,7 +7,8 @@ dependency "common" {
 
   # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
   # module hasn't been applied yet.
-  mock_outputs_allowed_terraform_commands = ["validate"]
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state = true
   mock_outputs = {
     kms_arn = ""
     vpc_private_subnets = [
@@ -15,6 +16,7 @@ dependency "common" {
       "subnet-08de34a9e1a7458dc",
       "subnet-0af8b8402f1d605ff",
     ]
+    vpc_private_subnets_separate_reader_db = "subnet-0af8b8402f1d60523"
     sns_alert_general_arn = ""
   }
 }
@@ -35,13 +37,14 @@ include {
 }
 
 inputs = {
-  eks_cluster_securitygroup = dependency.eks.outputs.eks-cluster-securitygroup
-  kms_arn                   = dependency.common.outputs.kms_arn
-  rds_instance_count        = 1
-  rds_instance_type         = "db.t3.medium"
-  vpc_private_subnets       = dependency.common.outputs.vpc_private_subnets
-  sns_alert_general_arn     = dependency.common.outputs.sns_alert_general_arn
-  rds_database_name         = "notificationcanadacascratch"
+  eks_cluster_securitygroup              = dependency.eks.outputs.eks-cluster-securitygroup
+  kms_arn                                = dependency.common.outputs.kms_arn
+  rds_instance_count                     = 1
+  rds_instance_type                      = "db.t3.medium"
+  vpc_private_subnets                    = dependency.common.outputs.vpc_private_subnets
+  vpc_private_subnets_separate_reader_db = dependency.common.outputs.vpc_private_subnets_separate_reader_db
+  sns_alert_general_arn                  = dependency.common.outputs.sns_alert_general_arn
+  rds_database_name                      = "notificationcanadacascratch"
 }
 
 terraform {

--- a/env/staging/rds/terragrunt.hcl
+++ b/env/staging/rds/terragrunt.hcl
@@ -15,7 +15,7 @@ dependency "common" {
       "subnet-08de34a9e1a7458dc",
       "subnet-0af8b8402f1d605ff",
     ]
-    vpc_private_subnets_separate_reader_db = "subnet-0af8b8402f1d60523"
+    vpc_private_subnets_separate_reader_db = ["subnet-0af8b8402f1d60523"]
     sns_alert_general_arn = ""
   }
   mock_outputs_merge_with_state = true

--- a/env/staging/rds/terragrunt.hcl
+++ b/env/staging/rds/terragrunt.hcl
@@ -7,7 +7,7 @@ dependency "common" {
 
   # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
   # module hasn't been applied yet.
-  mock_outputs_allowed_terraform_commands = ["validate"]
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs = {
     kms_arn = ""
     vpc_private_subnets = [
@@ -15,8 +15,10 @@ dependency "common" {
       "subnet-08de34a9e1a7458dc",
       "subnet-0af8b8402f1d605ff",
     ]
+    vpc_private_subnets_separate_reader_db = "subnet-0af8b8402f1d60523"
     sns_alert_general_arn = ""
   }
+  mock_outputs_merge_with_state = true
 }
 
 dependency "eks" {
@@ -35,13 +37,14 @@ include {
 }
 
 inputs = {
-  eks_cluster_securitygroup = dependency.eks.outputs.eks-cluster-securitygroup
-  kms_arn                   = dependency.common.outputs.kms_arn
-  rds_instance_count        = 3
-  rds_instance_type         = "db.r6g.large"
-  vpc_private_subnets       = dependency.common.outputs.vpc_private_subnets
-  sns_alert_general_arn     = dependency.common.outputs.sns_alert_general_arn
-  rds_database_name = "NotificationCanadaCastaging"
+  eks_cluster_securitygroup              = dependency.eks.outputs.eks-cluster-securitygroup
+  kms_arn                                = dependency.common.outputs.kms_arn
+  rds_instance_count                     = 3
+  rds_instance_type                      = "db.r6g.large"
+  vpc_private_subnets                    = dependency.common.outputs.vpc_private_subnets
+  vpc_private_subnets_separate_reader_db = dependency.common.outputs.vpc_private_subnets_separate_reader_db
+  sns_alert_general_arn                  = dependency.common.outputs.sns_alert_general_arn
+  rds_database_name                      = "NotificationCanadaCastaging"
 }
 
 terraform {


### PR DESCRIPTION
# Summary | Résumé

We need a new reader instance for blazer, that is part of the notification DB, but won't be used by the application layer.
