### PR TITLE
set prod to 5 on demand nodes

### DIFF
--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -40,7 +40,7 @@ include {
 }
 
 inputs = {
-  primary_worker_desired_size               = 4
+  primary_worker_desired_size               = 5
   primary_worker_instance_types             = ["r5.large"]
   secondary_worker_instance_types           = ["r5.large"]
   nodeUpgrade                               = false  


### PR DESCRIPTION
# Summary | Résumé

Upping prod to 5 nodes to accomodate all the primary celeries!

# Test instructions | Instructions pour tester la modification

Prod should show 5 on demand nodes when complete.