### PR TITLE
Task/add system status lambda

### DIFF
--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -38,6 +38,8 @@ env:
   TF_VAR_slack_channel_warning_topic: "notification-staging-ops"
   TF_VAR_slack_channel_critical_topic: "notification-staging-ops"
   TF_VAR_slack_channel_general_topic: "notification-staging-ops"
+  TF_VAR_system_status_api_key: ${{ secrets.STAGING_SYSTEM_STATUS_API_KEY }}
+  TF_VAR_system_status_github_key: ${{ secrets.STAGING_SYSTEM_STATUS_GITHUB_KEY }}
   TF_VAR_cloudwatch_opsgenie_alarm_webhook: ""
   TF_VAR_new_relic_license_key: ${{ secrets.STAGING_NEW_RELIC_LICENSE_KEY }}
   TF_VAR_perf_test_phone_number: ${{ secrets.PERF_TEST_PHONE_NUMBER }}
@@ -162,6 +164,11 @@ jobs:
       - name: Apply aws/sns_to_sqs_sms_callbacks
         run: |
           cd env/staging/sns_to_sqs_sms_callbacks
+          terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Apply aws/system_status
+        run: |
+          cd env/staging/system_status
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
       - name: Bump version and push tag

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -35,6 +35,8 @@ env:
   TF_VAR_slack_channel_warning_topic: "notification-staging-ops"
   TF_VAR_slack_channel_critical_topic: "notification-staging-ops"
   TF_VAR_slack_channel_general_topic: "notification-staging-ops"
+  TF_VAR_system_status_api_key: ${{ secrets.STAGING_SYSTEM_STATUS_API_KEY }}
+  TF_VAR_system_status_github_key: ${{ secrets.STAGING_SYSTEM_STATUS_GITHUB_KEY }}
   TF_VAR_new_relic_license_key: ${{ secrets.STAGING_NEW_RELIC_LICENSE_KEY }}
   TF_VAR_waf_secret: ${{secrets.STAGING_WAF_SECRET}}
   # Prevents repeated creation of the Slack lambdas if already existing.
@@ -112,6 +114,9 @@ jobs:
             database-tools:
               - 'aws/database-tools/**'
               - 'env/staging/database-tools/**'
+            system_status:
+              - 'aws/system_status/**'
+              - 'env/staging/system_status/**'
             quicksight:
               - 'aws/quicksight/**'
               - 'env/staging/quicksight/**'
@@ -305,5 +310,15 @@ jobs:
           directory: "env/staging/sns_to_sqs_sms_callbacks"
           comment-delete: "true"
           comment-title: "Staging: sns_to_sqs_sms_callbacks"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
+
+      - name: Terragrunt plan system_status
+        if: ${{ steps.filter.outputs.system_status == 'true' || steps.filter.outputs.common == 'true' }}
+        uses: cds-snc/terraform-plan@v3
+        with:
+          directory: "env/staging/system_status"
+          comment-delete: "true"
+          comment-title: "Staging: system_status"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"

--- a/aws/ecr/ecr.tf
+++ b/aws/ecr/ecr.tf
@@ -96,3 +96,15 @@ resource "aws_ecr_repository" "sns_to_sqs_sms_callbacks" {
     scan_on_push = true
   }
 }
+
+resource "aws_ecr_repository" "system_status" {
+  # The :latest tag is used in Staging
+
+  name                 = "notify/system_status"
+  image_tag_mutability = "MUTABLE" #tfsec:ignore:AWS078
+  force_delete         = var.force_delete_ecr
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}

--- a/aws/ecr/images.tf
+++ b/aws/ecr/images.tf
@@ -208,5 +208,25 @@ resource "null_resource" "push_sns_to_sqs_sms_callbacks_docker_image" {
 
 }
 
+#System status Build and Push
 
+resource "null_resource" "build_system_status_docker_image" {
+  count = var.bootstrap ? 1 : 0
+  depends_on = [
+    null_resource.lambda_repo_clone
+  ]
 
+  provisioner "local-exec" {
+    command = "docker build -t ${aws_ecr_repository.system_status.repository_url}:bootstrap -f /var/tmp/notification-lambdas/system_status/Dockerfile /var/tmp/notification-lambdas/"
+  }
+}
+
+resource "null_resource" "push_system_status_docker_image" {
+  count      = var.bootstrap ? 1 : 0
+  depends_on = [null_resource.build_system_status_docker_image]
+
+  provisioner "local-exec" {
+    command = "docker push ${aws_ecr_repository.system_status.repository_url}:bootstrap"
+  }
+
+}

--- a/aws/ecr/outputs.tf
+++ b/aws/ecr/outputs.tf
@@ -62,3 +62,11 @@ output "performance_test_ecr_repository_url" {
   description = "Repository URL of performance-test ECR"
   value       = var.env == "production" ? "" : aws_ecr_repository.performance-test[0].repository_url
 }
+output "system_status_ecr_arn" {
+  description = "arn of system_status ECR"
+  value       = aws_ecr_repository.system_status.arn
+}
+output "system_status_ecr_repository_url" {
+  description = "Repository URL of system_status ECR"
+  value       = aws_ecr_repository.system_status.repository_url
+}

--- a/aws/system_status/cloudwatch_alarms.tf
+++ b/aws/system_status/cloudwatch_alarms.tf
@@ -1,0 +1,36 @@
+# Note to maintainers:
+# Updating alarms? Update the Google Sheet also!
+# https://docs.google.com/spreadsheets/d/1gkrL3Trxw0xEkX724C1bwpfeRsTlK2X60wtCjF6MFRA/edit
+#
+
+resource "aws_cloudwatch_metric_alarm" "logs-1-500-error-1-minute-warning-system_status-api" {
+  count               = var.cloudwatch_enabled ? 1 : 0
+  alarm_name          = "logs-1-500-error-1-minute-warning-system_status-api"
+  alarm_description   = "One 500 error in 1 minute for system_status api"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.system_status-500-errors-api[0].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.system_status-500-errors-api[0].metric_transformation[0].namespace
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [var.sns_alert_warning_arn]
+  ok_actions          = [var.sns_alert_warning_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "logs-10-500-error-5-minutes-critical-system_status-api" {
+  count               = var.cloudwatch_enabled ? 1 : 0
+  alarm_name          = "logs-10-500-error-5-minutes-critical-system_status-api"
+  alarm_description   = "Ten 500 errors in 5 minutes for system_status api"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.system_status-500-errors-api[0].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.system_status-500-errors-api[0].metric_transformation[0].namespace
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = 10
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [var.sns_alert_critical_arn]
+  ok_actions          = [var.sns_alert_critical_arn]
+}

--- a/aws/system_status/cloudwatch_logs.tf
+++ b/aws/system_status/cloudwatch_logs.tf
@@ -1,0 +1,27 @@
+#
+# System Status CloudWatch logging
+#
+
+resource "aws_cloudwatch_log_group" "system_status_log_group" {
+  count             = var.cloudwatch_enabled ? 1 : 0
+  name              = "system_status_log_group"
+  retention_in_days = var.log_retention_period_days
+  tags = {
+    CostCenter  = "notification-canada-ca-${var.env}"
+    Environment = var.env
+    Application = "lambda"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "system_status-500-errors-api" {
+  count          = var.cloudwatch_enabled ? 1 : 0
+  name           = "system_status-500-errors-api"
+  pattern        = "\"\\\"levelname\\\": \\\"ERROR\\\"\""
+  log_group_name = "/aws/lambda/${module.system_status.function_name}"
+
+  metric_transformation {
+    name      = "500-errors-system_status-api"
+    namespace = "LogMetrics"
+    value     = "1"
+  }
+}

--- a/aws/system_status/lambda.tf
+++ b/aws/system_status/lambda.tf
@@ -1,0 +1,44 @@
+module "system_status" {
+  source                 = "github.com/cds-snc/terraform-modules//lambda?ref=v0.0.49"
+  name                   = "system_status"
+  billing_tag_value      = var.billing_tag_value
+  ecr_arn                = var.system_status_ecr_arn
+  enable_lambda_insights = true
+  image_uri              = "${var.system_status_ecr_repository_url}:${var.system_status_docker_tag}"
+  timeout                = 60
+  memory                 = 1024
+
+  environment_variables = {
+    system_status_api_key    = var.system_status_api_key
+    system_status_github_key = var.system_status_github_key
+  }
+}
+
+resource "aws_lambda_function_event_invoke_config" "system_status_invoke_config" {
+  function_name                = module.system_status.function_name
+  maximum_event_age_in_seconds = 120
+  maximum_retry_attempts       = 0
+}
+
+resource "aws_cloudwatch_event_target" "system_status" {
+  count = var.cloudwatch_enabled ? 1 : 0
+  arn   = module.system_status.function_arn
+  rule  = aws_cloudwatch_event_rule.system_status_testing[0].id
+}
+
+resource "aws_cloudwatch_event_rule" "system_status_testing" {
+  count               = var.cloudwatch_enabled ? 1 : 0
+  name                = "system_status_testing"
+  description         = "system_status_testing event rule"
+  schedule_expression = var.schedule_expression
+  depends_on          = [module.system_status]
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch" {
+  count         = var.cloudwatch_enabled ? 1 : 0
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = module.system_status.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.system_status_testing[0].arn
+}

--- a/aws/system_status/variables.tf
+++ b/aws/system_status/variables.tf
@@ -1,0 +1,45 @@
+variable "billing_tag_value" {
+  type        = string
+  description = "Identifies the billing code."
+}
+
+variable "system_status_api_key" {
+  sensitive   = true
+  type        = string
+  description = "Identifies the system_status api key."
+}
+
+variable "system_status_github_key" {
+  sensitive   = true
+  type        = string
+  description = "Key to git commit to the system status repo"
+}
+
+variable "schedule_expression" {
+  type        = string
+  description = "This aws cloudwatch event rule scheule expression that specifies when the scheduler runs."
+}
+
+variable "sns_alert_warning_arn" {
+  type = string
+}
+
+variable "sns_alert_critical_arn" {
+  type = string
+}
+
+variable "system_status_ecr_arn" {
+  type        = string
+  description = "Inherited from ecr dependency"
+}
+
+variable "system_status_ecr_repository_url" {
+  type        = string
+  description = "Inherited from ecr dependency"
+}
+
+variable "system_status_docker_tag" {
+  type        = string
+  description = "Set this to specify the image version"
+  default     = "bootstrap"
+}

--- a/env/dev/system_status/terragrunt.hcl
+++ b/env/dev/system_status/terragrunt.hcl
@@ -1,0 +1,43 @@
+terraform {
+  source = "../../../aws//system_status"
+}
+
+dependencies {
+  paths = ["../common", "../ecr"]
+}
+
+dependency "common" {
+  config_path = "../common"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs = {
+    sns_alert_warning_arn             = ""
+    sns_alert_critical_arn            = ""
+  }
+}
+
+dependency "ecr" {
+  config_path = "../ecr"
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    system_status_ecr_repository_url = ""
+    system_status_ecr_arn = ""
+  }
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  billing_tag_value                 = "notification-canada-ca-dev"
+  schedule_expression               = "rate(1 minute)"
+  sns_alert_warning_arn             = dependency.common.outputs.sns_alert_warning_arn
+  sns_alert_critical_arn            = dependency.common.outputs.sns_alert_critical_arn
+  system_status_ecr_repository_url  = dependency.ecr.outputs.system_status_ecr_repository_url
+  system_status_ecr_arn             = dependency.ecr.outputs.system_status_ecr_arn
+}

--- a/env/production/system_status/terragrunt.hcl
+++ b/env/production/system_status/terragrunt.hcl
@@ -1,0 +1,43 @@
+dependencies {
+  paths = ["../common", "../ecr"]
+}
+
+dependency "common" {
+  config_path = "../common"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs = {
+    sns_alert_warning_arn  = ""
+    sns_alert_critical_arn = ""
+  }
+}
+
+dependency "ecr" {
+  config_path = "../ecr"
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    system_status_ecr_repository_url = ""
+    system_status_ecr_arn = ""
+  }
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  billing_tag_value                 = "notification-canada-ca-production"
+  schedule_expression               = "rate(1 minute)"
+  sns_alert_warning_arn             = dependency.common.outputs.sns_alert_warning_arn
+  sns_alert_critical_arn            = dependency.common.outputs.sns_alert_critical_arn
+  system_status_ecr_repository_url  = dependency.ecr.outputs.system_status_ecr_repository_url
+  system_status_ecr_arn             = dependency.ecr.outputs.heartbeat_ecr_arn  
+}
+
+terraform {
+  source = "git::https://github.com/cds-snc/notification-terraform//aws/system_status?ref=v${get_env("INFRASTRUCTURE_VERSION")}"
+}

--- a/env/scratch/system_status/terragrunt.hcl
+++ b/env/scratch/system_status/terragrunt.hcl
@@ -1,0 +1,43 @@
+terraform {
+  source = "../../../aws//system_status"
+}
+
+dependencies {
+  paths = ["../common", "../ecr"]
+}
+
+dependency "common" {
+  config_path = "../common"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs = {
+    sns_alert_warning_arn             = ""
+    sns_alert_critical_arn            = ""
+  }
+}
+
+dependency "ecr" {
+  config_path = "../ecr"
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    system_status_ecr_repository_url = ""
+    system_status_ecr_arn = ""
+  }
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  billing_tag_value                 = "notification-canada-ca-scratch"
+  schedule_expression               = "rate(1 minute)"
+  sns_alert_warning_arn             = dependency.common.outputs.sns_alert_warning_arn
+  sns_alert_critical_arn            = dependency.common.outputs.sns_alert_critical_arn
+  system_status_ecr_repository_url  = dependency.ecr.outputs.system_status_ecr_repository_url
+  system_status_ecr_arn             = dependency.ecr.outputs.system_status_ecr_arn
+}

--- a/env/staging/system_status/terragrunt.hcl
+++ b/env/staging/system_status/terragrunt.hcl
@@ -1,0 +1,43 @@
+terraform {
+  source = "../../../aws//system_status"
+}
+
+dependencies {
+  paths = ["../common", "../ecr"]
+}
+
+dependency "common" {
+  config_path = "../common"
+
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs = {
+    sns_alert_warning_arn             = ""
+    sns_alert_critical_arn            = ""
+  }
+}
+
+dependency "ecr" {
+  config_path = "../ecr"
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    system_status_ecr_repository_url = ""
+    system_status_ecr_arn = ""
+  }
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  billing_tag_value                 = "notification-canada-ca-staging"
+  schedule_expression               = "rate(1 minute)"
+  sns_alert_warning_arn             = dependency.common.outputs.sns_alert_warning_arn
+  sns_alert_critical_arn            = dependency.common.outputs.sns_alert_critical_arn
+  system_status_ecr_repository_url  = dependency.ecr.outputs.system_status_ecr_repository_url
+  system_status_ecr_arn             = dependency.ecr.outputs.system_status_ecr_arn
+}


### PR DESCRIPTION
# Summary | Résumé

Basic scaffolding for System Status Lambda.

We make a docker image -> We want the docker image to pull from notifications-lambda -> we will use that image to run a LAMBDA function.