### PR TITLE
Code for System Status Static Website

### DIFF
--- a/aws/system_status_static_site/main.tf
+++ b/aws/system_status_static_site/main.tf
@@ -1,0 +1,20 @@
+variable "billing_tag_value" {
+  type        = string
+  description = "The value of the billing tag"
+
+}
+
+module "system_status_static_site" {
+  source = "github.com/cds-snc/terraform-modules//simple_static_website?ref=v8.0.0"
+
+  domain_name_source = var.env == "prd" ? "status.notification.canada.ca" : "status.${var.env}.notification.cdssandbox.xyz"
+  billing_tag_value  = var.billing_tag_value
+  hosted_zone_id     = var.route_53_zone_arn
+  s3_bucket_name     = "notification-canada-ca-${var.env}-system-status"
+
+  providers = {
+    aws           = aws
+    aws.us-east-1 = aws.us-east-1
+    aws.dns       = aws.dns
+  }
+}

--- a/aws/system_status_static_site/outputs.tf
+++ b/aws/system_status_static_site/outputs.tf
@@ -1,0 +1,14 @@
+output "system_status_static_site_bucket_name" {
+  value       = module.system_status_static_site.s3_bucket_arn
+  description = "name of the s3 bucket for the system status static site"
+}
+
+output "system_status_static_site_bucket_id" {
+  value       = module.system_status_static_site.s3_bucket_id
+  description = "id of the s3 bucket for the system status static site"
+}
+
+output "system_status_static_site_bucket_region" {
+  value       = module.system_status_static_site.s3_bucket_region
+  description = "aws region of the s3 bucket for the system status static site"
+}

--- a/aws/system_status_static_site/variables.tf
+++ b/aws/system_status_static_site/variables.tf
@@ -1,0 +1,5 @@
+variable "route_53_zone_arn" {
+  type        = string
+  description = "Used by the scratch environment to reference cdssandbox in staging"
+  default     = "/hostedzone/Z04028033PLSHVOO9ZJ1Z"
+}

--- a/env/dev/system_status_static_site/terragrunt.hcl
+++ b/env/dev/system_status_static_site/terragrunt.hcl
@@ -1,0 +1,12 @@
+terraform {
+  source = "../../../aws//system_status_static_site"
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  env                                    = "dev"
+  billing_tag_value                      = "notification-canada-ca-dev"
+}


### PR DESCRIPTION
# Summary | Résumé

Code for system status static website.

I tested this on dev. We have a status.dev.notification.cdssandbox.xyz -> but there is still a permission issue somewhere