### PR TITLE
Setting DNS certs for status static site

### DIFF
--- a/aws/system_status_static_site/main.tf
+++ b/aws/system_status_static_site/main.tf
@@ -7,6 +7,9 @@ variable "billing_tag_value" {
 module "system_status_static_site" {
   source = "github.com/cds-snc/terraform-modules//simple_static_website?ref=v9.0.1"
 
+  count = var.status_cert_created ? 1 : 0
+
+  acm_certificate_arn                = aws_acm_certificate.system_status_static_site_root_certificate
   domain_name_source                 = var.env == "production" ? "status.notification.canada.ca" : "status.${var.env}.notification.cdssandbox.xyz"
   billing_tag_value                  = var.billing_tag_value
   hosted_zone_id                     = var.route_53_zone_arn
@@ -18,4 +21,41 @@ module "system_status_static_site" {
     aws.us-east-1 = aws.us-east-1
     aws.dns       = aws.dns
   }
+}
+
+
+resource "aws_acm_certificate" "system_status_static_site_root_certificate" {
+  # Cloudfront requires client certificate to be created in us-east-1
+
+  provider          = aws.us-east-1
+  domain_name       = var.env == "production" ? "status.notification.canada.ca" : "status.${var.env}.notification.cdssandbox.xyz"
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}
+
+# This can't happen in production because we don't own the DNS zone. A PR will have to be done to cds-snc/dns with the validation records obtained from the above.
+
+resource "aws_acm_certificate_validation" "system_status_static_site" {
+  count                   = var.env != "production" ? 1 : 0
+  provider                = aws.us-east-1
+  certificate_arn         = aws_acm_certificate.system_status_static_site_root_certificate.arn
+  validation_record_fqdns = [aws_route53_record.system_status_static_site[0].fqdn]
+}
+
+resource "aws_route53_record" "system_status_static_site" {
+  count           = var.env != "production" ? 1 : 0
+  provider        = aws.dns
+  allow_overwrite = true
+  name            = tolist(aws_acm_certificate.system_status_static_site_root_certificate.domain_validation_options)[0].resource_record_name
+  records         = [tolist(aws_acm_certificate.system_status_static_site_root_certificate.domain_validation_options)[0].resource_record_value]
+  type            = tolist(aws_acm_certificate.system_status_static_site_root_certificate.domain_validation_options)[0].resource_record_type
+  zone_id         = var.route_53_zone_arn
+  ttl             = 60
 }

--- a/aws/system_status_static_site/variables.tf
+++ b/aws/system_status_static_site/variables.tf
@@ -3,3 +3,11 @@ variable "route_53_zone_arn" {
   description = "Used by the scratch environment to reference cdssandbox in staging"
   default     = "/hostedzone/Z04028033PLSHVOO9ZJ1Z"
 }
+
+variable "status_cert_created" {
+  type        = bool
+  description = "This flag must be set to false on a new environment creation in production, so that we can generate the certificate first."
+  default     = false
+}
+
+


### PR DESCRIPTION
# Summary | Résumé

This will create the certificate for the static status site. If in a lower state environment, certificate validation is done automatically. If in a higher environment, this is done manually through a pr to cds-snc/dns

# Test instructions | Instructions pour tester la modification

In staging, the cert should be created and automatically validated.