### PR TITLE
Static site dns

### DIFF
--- a/aws/system_status_static_site/main.tf
+++ b/aws/system_status_static_site/main.tf
@@ -5,15 +5,16 @@ variable "billing_tag_value" {
 }
 
 module "system_status_static_site" {
-  source = "github.com/cds-snc/terraform-modules//simple_static_website?ref=v9.0.1"
+  source = "github.com/cds-snc/terraform-modules//simple_static_website?ref=v9.0.2"
 
   count = var.status_cert_created ? 1 : 0
 
-  acm_certificate_arn                = aws_acm_certificate.system_status_static_site_root_certificate
+  acm_certificate_arn                = aws_acm_certificate.system_status_static_site_root_certificate.arn
   domain_name_source                 = var.env == "production" ? "status.notification.canada.ca" : "status.${var.env}.notification.cdssandbox.xyz"
   billing_tag_value                  = var.billing_tag_value
   hosted_zone_id                     = var.route_53_zone_arn
   s3_bucket_name                     = "notification-canada-ca-${var.env}-system-status"
+  force_destroy_s3_bucket            = var.force_destroy_s3
   cloudfront_query_string_forwarding = true
 
   providers = {

--- a/aws/system_status_static_site/main.tf
+++ b/aws/system_status_static_site/main.tf
@@ -7,6 +7,9 @@ variable "billing_tag_value" {
 module "system_status_static_site" {
   source = "github.com/cds-snc/terraform-modules//simple_static_website?ref=v9.0.1"
 
+  count = var.status_cert_created ? 1 : 0
+
+  acm_certificate_arn                = aws_acm_certificate.system_status_static_site_root_certificate
   domain_name_source                 = var.env == "production" ? "status.notification.canada.ca" : "status.${var.env}.notification.cdssandbox.xyz"
   billing_tag_value                  = var.billing_tag_value
   hosted_zone_id                     = var.route_53_zone_arn
@@ -18,4 +21,41 @@ module "system_status_static_site" {
     aws.us-east-1 = aws.us-east-1
     aws.dns       = aws.dns
   }
+}
+
+
+resource "aws_acm_certificate" "system_status_static_site_root_certificate" {
+  # Cloudfront requires client certificate to be created in us-east-1
+
+  provider          = aws.us-east-1
+  domain_name       = var.env == "production" ? "status.notification.canada.ca" : "status.${var.env}.notification.cdssandbox.xyz"
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}
+
+# This can't happen in production because we don't own the DNS zone. A PR will have to be done to cds-snc/dns with the validation records obtained from the above.
+
+resource "aws_acm_certificate_validation" "system_status_static_site" {
+  count                   = var.env != "production" ? 1 : 0
+  provider                = aws.us-east-1
+  certificate_arn         = aws_acm_certificate.system_status_static_site_root_certificate.arn
+  validation_record_fqdns = [aws_route53_record.system_status_static_site[0].fqdn]
+}
+
+resource "aws_route53_record" "system_status_static_site" {
+  count           = var.env != "production" ? 1 : 0
+  provider        = aws.dns
+  allow_overwrite = true
+  name            = tolist(aws_acm_certificate.system_status_static_site_root_certificate.domain_validation_options)[0].resource_record_name
+  records         = [tolist(aws_acm_certificate.system_status_static_site_root_certificate.domain_validation_options)[0].resource_record_value]
+  type            = tolist(aws_acm_certificate.system_status_static_site_root_certificate.domain_validation_options)[0].resource_record_type
+  zone_id         = var.route_53_zone_arn
+  ttl             = 60
 }

--- a/aws/system_status_static_site/outputs.tf
+++ b/aws/system_status_static_site/outputs.tf
@@ -1,14 +1,14 @@
 output "system_status_static_site_bucket_name" {
-  value       = module.system_status_static_site.s3_bucket_arn
+  value       = var.status_cert_created ? module.system_status_static_site[0].s3_bucket_arn : ""
   description = "name of the s3 bucket for the system status static site"
 }
 
 output "system_status_static_site_bucket_id" {
-  value       = module.system_status_static_site.s3_bucket_id
+  value       = var.status_cert_created ? module.system_status_static_site[0].s3_bucket_id : ""
   description = "id of the s3 bucket for the system status static site"
 }
 
 output "system_status_static_site_bucket_region" {
-  value       = module.system_status_static_site.s3_bucket_region
+  value       = var.status_cert_created ? module.system_status_static_site[0].s3_bucket_region : ""
   description = "aws region of the s3 bucket for the system status static site"
 }

--- a/aws/system_status_static_site/variables.tf
+++ b/aws/system_status_static_site/variables.tf
@@ -10,4 +10,8 @@ variable "status_cert_created" {
   default     = false
 }
 
-
+variable "force_destroy_s3" {
+  type        = bool
+  description = "Force destroy the s3 bucket. Not advised for production."
+  default     = false
+}

--- a/aws/system_status_static_site/variables.tf
+++ b/aws/system_status_static_site/variables.tf
@@ -3,3 +3,11 @@ variable "route_53_zone_arn" {
   description = "Used by the scratch environment to reference cdssandbox in staging"
   default     = "/hostedzone/Z04028033PLSHVOO9ZJ1Z"
 }
+
+variable "status_cert_created" {
+  type        = bool
+  description = "This flag must be set to false on a new environment creation in production, so that we can generate the certificate first."
+  default     = false
+}
+
+

--- a/env/dev/system_status_static_site/.terraform.lock.hcl
+++ b/env/dev/system_status_static_site/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.31.0"
+  constraints = ">= 4.9.0, ~> 5.0"
+  hashes = [
+    "h1:2eauBmfftzGMpzFQn9aHSXiyaO3Ve5cnihmXcKGGpgU=",
+    "zh:0cdb9c2083bf0902442384f7309367791e4640581652dda456f2d6d7abf0de8d",
+    "zh:2fe4884cb9642f48a5889f8dff8f5f511418a18537a9dfa77ada3bcdad391e4e",
+    "zh:36d8bdd72fe61d816d0049c179f495bc6f1e54d8d7b07c45b62e5e1696882a89",
+    "zh:539dd156e3ec608818eb21191697b230117437a58587cbd02ce533202a4dd520",
+    "zh:6a53f4b57ac4eb3479fc0d8b6e301ca3a27efae4c55d9f8bd24071b12a03361c",
+    "zh:6faeb8ff6792ca7af1c025255755ad764667a300291cc10cea0c615479488c87",
+    "zh:7d9423149b323f6d0df5b90c4d9029e5455c670aea2a7eb6fef4684ba7eb2e0b",
+    "zh:8235badd8a5d0993421cacf5ead48fac73d3b5a25c8a68599706a404b1f70730",
+    "zh:860b4f60842b2879c5128b7e386c8b49adeda9287fed12c5cd74861bb659bbcd",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b021fceaf9382c8fe3c6eb608c24d01dce3d11ba7e65bb443d51ca9b90e9b237",
+    "zh:b38b0bfc1c69e714e80cf1c9ea06e687ee86aa9f45694be28eb07adcebbe0489",
+    "zh:c972d155f6c01af9690a72adfb99cfc24ef5ef311ca92ce46b9b13c5c153f572",
+    "zh:e0dd29920ec84fdb6026acff44dcc1fb1a24a0caa093fa04cdbc713d384c651d",
+    "zh:e3127ebd2cb0374cd1808f911e6bffe2f4ac4d84317061381242353f3a7bc27d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.6.0"
+  hashes = [
+    "h1:p6WG1IPHnqx1fnJVKNjv733FBaArIugqy58HRZnpPCk=",
+    "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
+    "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
+    "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",
+    "zh:30ffb297ffd1633175d6545d37c2217e2cef9545a6e03946e514c59c0859b77d",
+    "zh:454ce4b3dbc73e6775f2f6605d45cee6e16c3872a2e66a2c97993d6e5cbd7055",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:91df0a9fab329aff2ff4cf26797592eb7a3a90b4a0c04d64ce186654e0cc6e17",
+    "zh:aa57384b85622a9f7bfb5d4512ca88e61f22a9cea9f30febaa4c98c68ff0dc21",
+    "zh:c4a3e329ba786ffb6f2b694e1fd41d413a7010f3a53c20b432325a94fa71e839",
+    "zh:e2699bc9116447f96c53d55f2a00570f982e6f9935038c3810603572693712d0",
+    "zh:e747c0fd5d7684e5bfad8aa0ca441903f15ae7a98a737ff6aca24ba223207e2c",
+    "zh:f1ca75f417ce490368f047b63ec09fd003711ae48487fba90b4aba2ccf71920e",
+  ]
+}


### PR DESCRIPTION
# Summary | Résumé

This will configure the system status website to use a manually created certificate. This first PR should destroy the site and create a manual certificate. We will then need a followup release to re-create the site.

# Test instructions | Instructions pour tester la modification
Tested in dev

- [ ] TF Apply works, staging status certificate is created and validated