### PR TITLE
Enabling the system status static site

### DIFF
--- a/env/staging/system_status_static_site/terragrunt.hcl
+++ b/env/staging/system_status_static_site/terragrunt.hcl
@@ -9,4 +9,5 @@ include {
 inputs = {
   env                                    = "staging"
   billing_tag_value                      = "notification-canada-ca-staging"
+  status_cert_created                    = true
 }


### PR DESCRIPTION
# Summary | Résumé

This will enable the system status static website in staging only

# Test instructions | Instructions pour tester la modification

TF Apply - verify that the system status page is working.