### PR TITLE
Enabling system status page in prod

### DIFF
--- a/env/dev/system_status_static_site/terragrunt.hcl
+++ b/env/dev/system_status_static_site/terragrunt.hcl
@@ -9,4 +9,5 @@ include {
 inputs = {
   env                                    = "dev"
   billing_tag_value                      = "notification-canada-ca-dev"
+  status_cert_created                    = true  
 }

--- a/env/production/system_status_static_site/terragrunt.hcl
+++ b/env/production/system_status_static_site/terragrunt.hcl
@@ -5,6 +5,7 @@ include {
 inputs = {
   env                                    = "production"
   billing_tag_value                      = "notification-canada-ca-production"
+  status_cert_created                    = true    
 }
 
 terraform {


### PR DESCRIPTION
# Summary | Résumé

This will enable the system status static site in production. We will need one more PR to cds/dns to create the A record for the cloudfront endpoint

# Test instructions | Instructions pour tester la modification

TF Apply works