### PR TITLE
fix: send client VPN connection logs to Sentinel

### DIFF
--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -175,6 +175,10 @@ output "sqs_send_email_high_queue_name" {
   value = var.sqs_send_email_high_queue_name
 }
 
+output "client_vpn_cloudwatch_log_group_name" {
+  value = module.vpn.client_vpn_cloudwatch_log_group_name
+}
+
 output "client_vpn_security_group_id" {
   value = module.vpn.client_vpn_security_group_id
 }

--- a/aws/common/vpn.tf
+++ b/aws/common/vpn.tf
@@ -3,7 +3,7 @@
 # access to the private subnets.
 #
 module "vpn" {
-  source = "github.com/cds-snc/terraform-modules//client_vpn?ref=v7.4.3"
+  source = "github.com/cds-snc/terraform-modules//client_vpn?ref=v9.0.3"
 
   endpoint_name   = "private-subnets"
   access_group_id = var.client_vpn_access_group_id

--- a/aws/eks/sentinel.tf
+++ b/aws/eks/sentinel.tf
@@ -30,12 +30,20 @@ resource "aws_cloudwatch_log_subscription_filter" "admin_api_request" {
   distribution    = "Random"
 }
 
-
 resource "aws_cloudwatch_log_subscription_filter" "blazer_logging" {
   count           = var.enable_sentinel_forwarding ? 1 : 0
   name            = "Blazer logging"
   log_group_name  = "blazer"
   filter_pattern  = "Audit "
+  destination_arn = module.sentinel_forwarder[0].lambda_arn
+  distribution    = "Random"
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "client_vpn_connections" {
+  count           = var.enable_sentinel_forwarding ? 1 : 0
+  name            = "Client VPN connections"
+  log_group_name  = var.client_vpn_cloudwatch_log_group_name
+  filter_pattern  = "[w1=\"*\"]" # All logs
   destination_arn = module.sentinel_forwarder[0].lambda_arn
   distribution    = "Random"
 }

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -240,6 +240,11 @@ variable "celery_queue_prefix" {
   description = "Celery queue prefix"
 }
 
+variable "client_vpn_cloudwatch_log_group_name" {
+  type        = string
+  description = "Client VPN CloudWatch log group name. This is used by the Sentinel forwarder to send logs to Sentinel."
+}
+
 variable "client_vpn_security_group_id" {
   type        = string
   description = "Client VPN security group ID"

--- a/env/dev/eks/terragrunt.hcl
+++ b/env/dev/eks/terragrunt.hcl
@@ -32,6 +32,7 @@ dependency "common" {
     notification_base_url_regex_arn           = ""
     private-links-vpc-endpoints-securitygroup = ""
     private-links-gateway-prefix-list-ids     = []
+    client_vpn_cloudwatch_log_group_name      = "/aws/vpc/client-vpn-endpoint-logs"
     client_vpn_security_group_id              = "sg-1234"
   }
 }
@@ -84,6 +85,7 @@ inputs = {
   private-links-vpc-endpoints-securitygroup = dependency.common.outputs.private-links-vpc-endpoints-securitygroup
   private-links-gateway-prefix-list-ids     = dependency.common.outputs.private-links-gateway-prefix-list-ids
   celery_queue_prefix                       = "eks-notification-canada-ca"
+  client_vpn_cloudwatch_log_group_name      = dependency.common.outputs.client_vpn_cloudwatch_log_group_name
   client_vpn_security_group_id              = dependency.common.outputs.client_vpn_security_group_id  
   
 }

--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -28,6 +28,7 @@ dependency "common" {
     sqs_send_sms_low_queue_name               = ""
     sqs_send_sms_medium_queue_name            = ""
     sqs_send_sms_high_queue_name              = ""
+    client_vpn_cloudwatch_log_group_name      = "/aws/vpc/client-vpn-endpoint-logs"
     client_vpn_security_group_id              = "sg-1234"
   }
 }
@@ -79,6 +80,7 @@ inputs = {
   sqs_send_sms_medium_queue_name            = dependency.common.outputs.sqs_send_sms_medium_queue_name
   sqs_send_sms_high_queue_name              = dependency.common.outputs.sqs_send_sms_high_queue_name
   celery_queue_prefix                       = "eks-notification-canada-ca"
+  client_vpn_cloudwatch_log_group_name      = dependency.common.outputs.client_vpn_cloudwatch_log_group_name
   client_vpn_security_group_id              = dependency.common.outputs.client_vpn_security_group_id  
 
 }

--- a/env/scratch/eks/terragrunt.hcl
+++ b/env/scratch/eks/terragrunt.hcl
@@ -32,6 +32,7 @@ dependency "common" {
     notification_base_url_regex_arn           = ""
     private-links-vpc-endpoints-securitygroup = ""
     private-links-gateway-prefix-list-ids     = []
+    client_vpn_cloudwatch_log_group_name      = "/aws/vpc/client-vpn-endpoint-logs"
     client_vpn_security_group_id              = "sg-1234"
   }
 }
@@ -83,6 +84,7 @@ inputs = {
   notification_base_url_regex_arn           = dependency.common.outputs.notification_base_url_regex_arn
   private-links-vpc-endpoints-securitygroup = dependency.common.outputs.private-links-vpc-endpoints-securitygroup
   private-links-gateway-prefix-list-ids     = dependency.common.outputs.private-links-gateway-prefix-list-ids
+  client_vpn_cloudwatch_log_group_name      = dependency.common.outputs.client_vpn_cloudwatch_log_group_name
   client_vpn_security_group_id              = dependency.common.outputs.client_vpn_security_group_id  
 }
 

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -38,6 +38,7 @@ dependency "common" {
     sqs_send_sms_low_queue_name               = ""
     sqs_send_sms_medium_queue_name            = ""
     sqs_send_sms_high_queue_name              = ""
+    client_vpn_cloudwatch_log_group_name      = "/aws/vpc/client-vpn-endpoint-logs"
     client_vpn_security_group_id              = "sg-1234"
   }
 }
@@ -96,6 +97,7 @@ inputs = {
   sqs_send_sms_medium_queue_name            = dependency.common.outputs.sqs_send_sms_medium_queue_name
   sqs_send_sms_high_queue_name              = dependency.common.outputs.sqs_send_sms_high_queue_name
   celery_queue_prefix                       = "eks-notification-canada-ca"
+  client_vpn_cloudwatch_log_group_name      = dependency.common.outputs.client_vpn_cloudwatch_log_group_name
   client_vpn_security_group_id              = dependency.common.outputs.client_vpn_security_group_id  
 }
 


### PR DESCRIPTION
# Summary
Update the Sentinel Forwarder subscriptions so that all client VPN connection logs are sent to Sentinel.

This updates the client VPN module to the latest `v9.0.3` version which includes the new CloudWatch log group name output.

# Related
- https://github.com/cds-snc/platform-core-services/issues/508
- cds-snc/terraform-modules#377