### PR TITLE
fix: update Sentinel Forwarder log group ARNs

### DIFF
--- a/aws/eks/sentinel.tf
+++ b/aws/eks/sentinel.tf
@@ -20,8 +20,8 @@ module "sentinel_forwarder" {
 
   cloudwatch_log_arns = [
     local.application_log_group_arn,
-    local.client_vpn_log_group_arn,
-    local.blazer_log_group_arn
+    local.blazer_log_group_arn,
+    local.client_vpn_log_group_arn
   ]
 }
 

--- a/aws/eks/sentinel.tf
+++ b/aws/eks/sentinel.tf
@@ -1,5 +1,6 @@
 locals {
   application_log_group_arn = "arn:aws:logs:${var.region}:${var.account_id}:log-group:${local.eks_application_log_group}"
+  client_vpn_log_group_arn  = "arn:aws:logs:${var.region}:${var.account_id}:log-group:${var.client_vpn_cloudwatch_log_group_name}"
   blazer_log_group_arn      = "arn:aws:logs:${var.region}:${var.account_id}:log-group:blazer"
 }
 
@@ -17,7 +18,11 @@ module "sentinel_forwarder" {
   customer_id = var.sentinel_customer_id
   shared_key  = var.sentinel_shared_key
 
-  cloudwatch_log_arns = [local.application_log_group_arn, local.blazer_log_group_arn]
+  cloudwatch_log_arns = [
+    local.application_log_group_arn,
+    local.client_vpn_log_group_arn,
+    local.blazer_log_group_arn
+  ]
 }
 
 


### PR DESCRIPTION
# Summary
Add the client VPN's CloudWatch log group to the Sentinel Forwarder module.  This will grant the required permissions to add the CloudWatch subscription filter.

# Related
- https://github.com/cds-snc/platform-core-services/issues/508
- #1108 