### PR TITLE
fix: update RDS version script with engine-version

### DIFF
--- a/scripts/get_rds_cluster_updates.sh
+++ b/scripts/get_rds_cluster_updates.sh
@@ -21,6 +21,7 @@ CLUSTER_ENGINE="$(echo "$CLUSTER" | jq -r .Engine)"
 
 AVAILABLE_VERSIONS="$(aws rds describe-db-engine-versions \
     --engine "$CLUSTER_ENGINE" \
+    --engine-version "$CLUSTER_VERSION" \
     --query 'DBEngineVersions[*].ValidUpgradeTarget[*].{EngineVersion:EngineVersion}' \
     --no-paginate)"
 


### PR DESCRIPTION
# Summary
Update the script that checks for available RDS cluster version updates to include the cluster's current engine version.

This will prevent versions that are lower than the clusters current engine version from being displayed.