### PR TITLE
feat: add alarm and log metric for queues not being active

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -907,3 +907,35 @@ resource "aws_cloudwatch_metric_alarm" "karpenter-replicas-unavailable" {
     }
   }
 }
+
+resource "aws_cloudwatch_metric_alarm" "queues-not-active-1-minute-warning" {
+  count               = var.cloudwatch_enabled ? 1 : 0
+  alarm_name          = "queues-not-active-1-minute-warning"
+  alarm_description   = "Queues have not been active for one minute"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.queues-are-active[0].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.queues-are-active[0].metric_transformation[0].namespace
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = 1
+  treat_missing_data  = "breaching"
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "queues-not-active-5-minutes-critical" {
+  count                     = var.cloudwatch_enabled ? 1 : 0
+  alarm_name                = "queues-not-active-5-minutes-critical"
+  alarm_description         = "Queues have not been active for 5 minutes"
+  comparison_operator       = "LessThanThreshold"
+  evaluation_periods        = "1"
+  metric_name               = aws_cloudwatch_log_metric_filter.queues-are-active[0].metric_transformation[0].name
+  namespace                 = aws_cloudwatch_log_metric_filter.queues-are-active[0].metric_transformation[0].namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = 1
+  treat_missing_data        = "breaching"
+  alarm_actions             = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
+  insufficient_data_actions = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
+  ok_actions                = [aws_sns_topic.notification-canada-ca-alert-ok.arn]
+}

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -920,22 +920,21 @@ resource "aws_cloudwatch_metric_alarm" "queues-not-active-1-minute-warning" {
   statistic           = "Sum"
   threshold           = 1
   treat_missing_data  = "breaching"
-  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
+  alarm_actions       = [var.sns_alert_warning_arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "queues-not-active-5-minutes-critical" {
-  count                     = var.cloudwatch_enabled ? 1 : 0
-  alarm_name                = "queues-not-active-5-minutes-critical"
-  alarm_description         = "Queues have not been active for 5 minutes"
-  comparison_operator       = "LessThanThreshold"
-  evaluation_periods        = "1"
-  metric_name               = aws_cloudwatch_log_metric_filter.queues-are-active[0].metric_transformation[0].name
-  namespace                 = aws_cloudwatch_log_metric_filter.queues-are-active[0].metric_transformation[0].namespace
-  period                    = "300"
-  statistic                 = "Sum"
-  threshold                 = 1
-  treat_missing_data        = "breaching"
-  alarm_actions             = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
-  insufficient_data_actions = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
-  ok_actions                = [aws_sns_topic.notification-canada-ca-alert-ok.arn]
+  count               = var.cloudwatch_enabled ? 1 : 0
+  alarm_name          = "queues-not-active-5-minutes-critical"
+  alarm_description   = "Queues have not been active for 5 minutes"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.queues-are-active[0].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.queues-are-active[0].metric_transformation[0].namespace
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = 1
+  treat_missing_data  = "breaching"
+  alarm_actions       = [var.sns_alert_critical_arn]
+  ok_actions          = [var.sns_alert_critical_arn]
 }

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -153,3 +153,16 @@ resource "aws_cloudwatch_log_metric_filter" "documentation-evicted-pods" {
     value     = "1"
   }
 }
+
+resource "aws_cloudwatch_log_metric_filter" "queues-are-active" {
+  count          = var.cloudwatch_enabled ? 1 : 0
+  name           = "queues-are-active"
+  pattern        = "Batch saving with"
+  log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs[0].name
+
+  metric_transformation {
+    name      = "queues-are-active"
+    namespace = "LogMetrics"
+    value     = "1"
+  }
+}


### PR DESCRIPTION
# Summary | Résumé

This PR adds a metric filter to check the queues are being emptied, i.e. the `beat_inbox_*` methods in [scheduled_tasks.py](https://github.com/cds-snc/notification-api/blob/main/app/celery/scheduled_tasks.py#L284) are firing.

It also adds 2 cloud watch alarms:
- warning if no queue activity in 1 minute
- critical if no queue activity in 5 minutes
