### PR TITLE
Blazer db instance

### DIFF
--- a/aws/database-tools/parameterstore.tf
+++ b/aws/database-tools/parameterstore.tf
@@ -38,7 +38,7 @@ resource "aws_ssm_parameter" "notify_o11y_google_oauth_client_secret" {
 resource "aws_ssm_parameter" "sqlalchemy_database_reader_uri" {
   name  = "sqlalchemy_database_reader_uri"
   type  = "SecureString"
-  value = "postgresql://app_db_user:${var.app_db_user_password}@${var.database_read_only_proxy_endpoint}/NotificationCanadaCa${var.env}"
+  value = "postgresql://app_db_user:${var.app_db_user_password}@${var.blazer_instance_endpoint}/NotificationCanadaCa${var.env}"
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value

--- a/aws/database-tools/variables.tf
+++ b/aws/database-tools/variables.tf
@@ -64,9 +64,9 @@ variable "enable_delete_protection" {
   default     = true
 }
 
-variable "database_read_only_proxy_endpoint" {
+variable "blazer_instance_endpoint" {
   type        = string
-  description = "Base endpoint for rds proxy"
+  description = "Base endpoint for blazer serverless instance"
 }
 variable "app_db_user_password" {
   type        = string

--- a/aws/rds/outputs.tf
+++ b/aws/rds/outputs.tf
@@ -15,5 +15,5 @@ output "rds_instance_id" {
 }
 
 output "blazer_rds_endpoint" {
-  value = aws_rds_cluster_instance.notification-canada-ca-blazer-readonly.endpoint
+  value = var.create_blazer_db ? aws_rds_cluster_instance.notification-canada-ca-blazer-readonly.endpoint : "${module.rds_proxy.db_proxy_endpoints.read_only.endpoint}:${module.rds_proxy.proxy_target_port}"
 }

--- a/aws/rds/outputs.tf
+++ b/aws/rds/outputs.tf
@@ -15,5 +15,5 @@ output "rds_instance_id" {
 }
 
 output "blazer_rds_endpoint" {
-  value = var.create_blazer_db ? aws_rds_cluster_instance.notification-canada-ca-blazer-readonly.endpoint : "${module.rds_proxy.db_proxy_endpoints.read_only.endpoint}:${module.rds_proxy.proxy_target_port}"
+  value = var.create_blazer_db ? aws_rds_cluster_instance.notification-canada-ca-blazer-readonly[0].endpoint : "${module.rds_proxy.db_proxy_endpoints.read_only.endpoint}:${module.rds_proxy.proxy_target_port}"
 }

--- a/aws/rds/outputs.tf
+++ b/aws/rds/outputs.tf
@@ -13,3 +13,7 @@ output "database_subnet_ids" {
 output "rds_instance_id" {
   value = aws_rds_cluster_instance.notification-canada-ca-instances[0].identifier
 }
+
+output "blazer_rds_endpoint" {
+  value = aws_rds_cluster_instance.notification-canada-ca-blazer-readonly.endpoint
+}

--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -132,6 +132,7 @@ resource "aws_rds_cluster_instance" "notification-canada-ca-blazer-readonly" {
   # https://github.com/hashicorp/terraform-provider-aws/issues/3015#issuecomment-520667166
   preferred_maintenance_window = "wed:04:00-wed:04:30"
   auto_minor_version_upgrade   = false
+  promotion_tier               = 10
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"

--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -77,10 +77,10 @@ resource "aws_rds_cluster" "notification-canada-ca" {
     var.eks_cluster_securitygroup
   ]
 
-  serverlessv2_scaling_configuration {
-    max_capacity = 1.0
-    min_capacity = 0.5
-  }
+  #serverlessv2_scaling_configuration {
+  #  max_capacity = 1.0
+  #  min_capacity = 0.5
+  #}
 
   lifecycle {
     ignore_changes = [

--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -96,6 +96,11 @@ resource "aws_rds_cluster" "notification-canada-ca" {
     var.eks_cluster_securitygroup
   ]
 
+  serverlessv2_scaling_configuration {
+    max_capacity = 1.0
+    min_capacity = 0.5
+  }
+
   lifecycle {
     ignore_changes = [
       # Ignore changes to tags, e.g. because a management agent

--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -15,7 +15,7 @@ resource "aws_db_subnet_group" "notification-canada-ca" {
 
 resource "aws_rds_cluster_parameter_group" "default" {
   name        = "rds-cluster-pg"
-  family      = "aurora-postgresql15"
+  family      = "aurora-postgresql11"
   description = "RDS customized cluster parameter group"
 
   parameter {

--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -118,6 +118,7 @@ resource "aws_rds_cluster_instance" "notification-canada-ca-instances" {
 }
 
 resource "aws_rds_cluster_instance" "notification-canada-ca-blazer-readonly" {
+  count              = var.create_blazer_db ? 1 : 0
   identifier         = "notification-${var.env}-blazer-instance"
   cluster_identifier = aws_rds_cluster.notification-canada-ca.id
   #instance_class               = "db.serverless"

--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -13,29 +13,9 @@ resource "aws_db_subnet_group" "notification-canada-ca" {
   }
 }
 
-resource "aws_rds_cluster_instance" "notification-canada-ca-instances" {
-  count                        = var.rds_instance_count
-  identifier                   = "notification-canada-ca-${var.env}-instance-${count.index}"
-  cluster_identifier           = aws_rds_cluster.notification-canada-ca.id
-  instance_class               = var.rds_instance_type
-  db_subnet_group_name         = aws_db_subnet_group.notification-canada-ca.name
-  engine                       = aws_rds_cluster.notification-canada-ca.engine
-  engine_version               = aws_rds_cluster.notification-canada-ca.engine_version
-  performance_insights_enabled = true
-  # tfsec:ignore:AWS053 - Encryption for RDS Perfomance Insights should be enabled.
-  # Cannot set a custom KMS key after performance insights has been enabled
-  # https://github.com/hashicorp/terraform-provider-aws/issues/3015#issuecomment-520667166
-  preferred_maintenance_window = "wed:04:00-wed:04:30"
-  auto_minor_version_upgrade   = false
-
-  tags = {
-    CostCenter = "notification-canada-ca-${var.env}"
-  }
-}
-
 resource "aws_rds_cluster_parameter_group" "default" {
   name        = "rds-cluster-pg"
-  family      = "aurora-postgresql11"
+  family      = "aurora-postgresql15"
   description = "RDS customized cluster parameter group"
 
   parameter {
@@ -74,6 +54,7 @@ resource "aws_rds_cluster_parameter_group" "default" {
     CostCenter = "notification-canada-ca-${var.env}"
   }
 }
+
 
 resource "aws_rds_cluster" "notification-canada-ca" {
   cluster_identifier           = "notification-canada-ca-${var.env}-cluster"
@@ -114,6 +95,48 @@ resource "aws_rds_cluster" "notification-canada-ca" {
     CostCenter = "notification-canada-ca-${var.env}"
   }
 }
+
+
+resource "aws_rds_cluster_instance" "notification-canada-ca-instances" {
+  count                        = var.rds_instance_count
+  identifier                   = "notification-canada-ca-${var.env}-instance-${count.index}"
+  cluster_identifier           = aws_rds_cluster.notification-canada-ca.id
+  instance_class               = var.rds_instance_type
+  db_subnet_group_name         = aws_db_subnet_group.notification-canada-ca.name
+  engine                       = aws_rds_cluster.notification-canada-ca.engine
+  engine_version               = aws_rds_cluster.notification-canada-ca.engine_version
+  performance_insights_enabled = true
+  # tfsec:ignore:AWS053 - Encryption for RDS Perfomance Insights should be enabled.
+  # Cannot set a custom KMS key after performance insights has been enabled
+  # https://github.com/hashicorp/terraform-provider-aws/issues/3015#issuecomment-520667166
+  preferred_maintenance_window = "wed:04:00-wed:04:30"
+  auto_minor_version_upgrade   = false
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}
+
+resource "aws_rds_cluster_instance" "notification-canada-ca-blazer-readonly" {
+  identifier         = "notification-${var.env}-blazer-instance"
+  cluster_identifier = aws_rds_cluster.notification-canada-ca.id
+  #instance_class               = "db.serverless"
+  instance_class               = var.rds_instance_type
+  db_subnet_group_name         = aws_db_subnet_group.notification-canada-ca.name
+  engine                       = aws_rds_cluster.notification-canada-ca.engine
+  engine_version               = aws_rds_cluster.notification-canada-ca.engine_version
+  performance_insights_enabled = true
+  # tfsec:ignore:AWS053 - Encryption for RDS Perfomance Insights should be enabled.
+  # Cannot set a custom KMS key after performance insights has been enabled
+  # https://github.com/hashicorp/terraform-provider-aws/issues/3015#issuecomment-520667166
+  preferred_maintenance_window = "wed:04:00-wed:04:30"
+  auto_minor_version_upgrade   = false
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}
+
 
 resource "aws_db_event_subscription" "notification-canada-ca" {
   name      = "notification-canada-ca-events-subscription"

--- a/aws/rds/rds_proxy.tf
+++ b/aws/rds/rds_proxy.tf
@@ -114,3 +114,4 @@ module "rds_proxy" {
     CostCenter = "notification-canada-ca-${var.env}"
   }
 }
+

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -44,3 +44,9 @@ variable "rds_database_name" {
   description = "Set the name of the database"
 
 }
+
+variable "create_blazer_db" {
+  type        = bool
+  description = "Setting true/false to create/not create a separate database instance for blazer"
+  default     = true
+}

--- a/env/dev/database-tools/.terraform.lock.hcl
+++ b/env/dev/database-tools/.terraform.lock.hcl
@@ -42,3 +42,23 @@ provider "registry.terraform.io/hashicorp/random" {
     "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.0.5"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:yLqz+skP3+EbU3yyvw8JqzflQTKDQGsC9QyZAg+S4dg=",
+    "zh:01cfb11cb74654c003f6d4e32bbef8f5969ee2856394a96d127da4949c65153e",
+    "zh:0472ea1574026aa1e8ca82bb6df2c40cd0478e9336b7a8a64e652119a2fa4f32",
+    "zh:1a8ddba2b1550c5d02003ea5d6cdda2eef6870ece86c5619f33edd699c9dc14b",
+    "zh:1e3bb505c000adb12cdf60af5b08f0ed68bc3955b0d4d4a126db5ca4d429eb4a",
+    "zh:6636401b2463c25e03e68a6b786acf91a311c78444b1dc4f97c539f9f78de22a",
+    "zh:76858f9d8b460e7b2a338c477671d07286b0d287fd2d2e3214030ae8f61dd56e",
+    "zh:a13b69fb43cb8746793b3069c4d897bb18f454290b496f19d03c3387d1c9a2dc",
+    "zh:a90ca81bb9bb509063b736842250ecff0f886a91baae8de65c8430168001dad9",
+    "zh:c4de401395936e41234f1956ebadbd2ed9f414e6908f27d578614aaa529870d4",
+    "zh:c657e121af8fde19964482997f0de2d5173217274f6997e16389e7707ed8ece8",
+    "zh:d68b07a67fbd604c38ec9733069fbf23441436fecf554de6c75c032f82e1ef19",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/env/dev/database-tools/terragrunt.hcl
+++ b/env/dev/database-tools/terragrunt.hcl
@@ -33,6 +33,12 @@ dependency "eks" {
 
 dependency "rds" {
   config_path = "../rds"
+
+  mock_outputs_allowed_terraform_commands = ["validate", "plan", "init", "fmt", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    blazer_instance_endpoint   = "blazer-instance-endpoint"
+  }  
 }
 
 include {

--- a/env/dev/database-tools/terragrunt.hcl
+++ b/env/dev/database-tools/terragrunt.hcl
@@ -37,7 +37,7 @@ dependency "rds" {
   mock_outputs_allowed_terraform_commands = ["validate", "plan", "init", "fmt", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
-    blazer_instance_endpoint   = "blazer-instance-endpoint"
+    blazer_rds_endpoint   = "blazer-instance-endpoint"
   }  
 }
 

--- a/env/dev/database-tools/terragrunt.hcl
+++ b/env/dev/database-tools/terragrunt.hcl
@@ -47,7 +47,7 @@ inputs = {
   blazer_image_tag                  = "latest"
   database-tools-securitygroup      = dependency.eks.outputs.database-tools-securitygroup
   database-tools-db-securitygroup   = dependency.eks.outputs.database-tools-db-securitygroup
-  database_read_only_proxy_endpoint = dependency.rds.outputs.database_read_only_proxy_endpoint
+  blazer_instance_endpoint          = dependency.rds.outputs.blazer_rds_endpoint
 }
 
 terraform {

--- a/env/production/database-tools/terragrunt.hcl
+++ b/env/production/database-tools/terragrunt.hcl
@@ -51,5 +51,5 @@ inputs = {
   blazer_image_tag                  = "53254711eb1da91f834d933e9663c87bc5974d3d"
   database-tools-securitygroup      = dependency.eks.outputs.database-tools-securitygroup
   database-tools-db-securitygroup   = dependency.eks.outputs.database-tools-db-securitygroup
-  database_read_only_proxy_endpoint = dependency.rds.outputs.database_read_only_proxy_endpoint
+  blazer_instance_endpoint          = dependency.rds.outputs.blazer_rds_endpoint
 }

--- a/env/production/database-tools/terragrunt.hcl
+++ b/env/production/database-tools/terragrunt.hcl
@@ -37,6 +37,12 @@ dependency "eks" {
 
 dependency "rds" {
   config_path = "../rds"
+  
+  mock_outputs_allowed_terraform_commands = ["validate", "plan", "init", "fmt", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    blazer_instance_endpoint   = "blazer-instance-endpoint"
+  }
 }
 
 include {

--- a/env/production/database-tools/terragrunt.hcl
+++ b/env/production/database-tools/terragrunt.hcl
@@ -41,7 +41,7 @@ dependency "rds" {
   mock_outputs_allowed_terraform_commands = ["validate", "plan", "init", "fmt", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
-    blazer_instance_endpoint   = "blazer-instance-endpoint"
+    blazer_rds_endpoint   = "blazer-instance-endpoint"
   }
 }
 

--- a/env/scratch/database-tools/terragrunt.hcl
+++ b/env/scratch/database-tools/terragrunt.hcl
@@ -47,7 +47,7 @@ inputs = {
   blazer_image_tag                  = "latest"
   database-tools-securitygroup      = dependency.eks.outputs.database-tools-securitygroup
   database-tools-db-securitygroup   = dependency.eks.outputs.database-tools-db-securitygroup
-  database_read_only_proxy_endpoint = dependency.rds.outputs.database_read_only_proxy_endpoint
+  blazer_instance_endpoint          = dependency.rds.outputs.blazer_rds_endpoint
 }
 
 terraform {

--- a/env/scratch/database-tools/terragrunt.hcl
+++ b/env/scratch/database-tools/terragrunt.hcl
@@ -33,6 +33,12 @@ dependency "eks" {
 
 dependency "rds" {
   config_path = "../rds"
+
+  mock_outputs_allowed_terraform_commands = ["validate", "plan", "init", "fmt", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    blazer_instance_endpoint   = "blazer-instance-endpoint"
+  }
 }
 
 include {

--- a/env/scratch/database-tools/terragrunt.hcl
+++ b/env/scratch/database-tools/terragrunt.hcl
@@ -37,7 +37,7 @@ dependency "rds" {
   mock_outputs_allowed_terraform_commands = ["validate", "plan", "init", "fmt", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
-    blazer_instance_endpoint   = "blazer-instance-endpoint"
+    blazer_rds_endpoint   = "blazer-instance-endpoint"
   }
 }
 

--- a/env/staging/database-tools/terragrunt.hcl
+++ b/env/staging/database-tools/terragrunt.hcl
@@ -47,7 +47,7 @@ inputs = {
   blazer_image_tag                  = "2ad10dea8725768f37a8b833487f456ec33c67dd"
   database-tools-securitygroup      = dependency.eks.outputs.database-tools-securitygroup
   database-tools-db-securitygroup   = dependency.eks.outputs.database-tools-db-securitygroup
-  database_read_only_proxy_endpoint = dependency.rds.outputs.database_read_only_proxy_endpoint
+  blazer_instance_endpoint          = dependency.rds.outputs.blazer_rds_endpoint
 }
 
 terraform {

--- a/env/staging/database-tools/terragrunt.hcl
+++ b/env/staging/database-tools/terragrunt.hcl
@@ -33,6 +33,12 @@ dependency "eks" {
 
 dependency "rds" {
   config_path = "../rds"
+
+  mock_outputs_allowed_terraform_commands = ["validate", "plan", "init", "fmt", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    blazer_instance_endpoint   = "blazer-instance-endpoint"
+  }  
 }
 
 include {

--- a/env/staging/database-tools/terragrunt.hcl
+++ b/env/staging/database-tools/terragrunt.hcl
@@ -37,7 +37,7 @@ dependency "rds" {
   mock_outputs_allowed_terraform_commands = ["validate", "plan", "init", "fmt", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
-    blazer_instance_endpoint   = "blazer-instance-endpoint"
+    blazer_rds_endpoint   = "blazer-instance-endpoint"
   }  
 }
 


### PR DESCRIPTION
# Summary | Résumé

This creates a new DB instance outside of the main instance group but within the same database cluster. 

This DB instance has its own endpoint, which is then fed to blazer in database-tools for consumption.

Notes:
- Originally I wanted to create a complete separate cluster with replication enabled, but this doesn't seem to be supported for aurora databases
- I also wanted to put in a secondary read only proxy that went to this instance specifically, but that also is not supported
- When we upgrade to Postgres 15 we can convert this new instance into a serverless instance to save money. I have left the config for this in this PR but commented out.

# Test instructions | Instructions pour tester la modification

TF Apply in staging, connect to blazer, verify the endpoint is NOT the RDS proxy, run queries.