### PR TITLE
chore: update alarm names/descriptions/metric filters to be more accu…

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -908,14 +908,14 @@ resource "aws_cloudwatch_metric_alarm" "karpenter-replicas-unavailable" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "queues-not-active-1-minute-warning" {
+resource "aws_cloudwatch_metric_alarm" "sqs-beat-inbox-tasks-not-active-1-minute-warning" {
   count               = var.cloudwatch_enabled ? 1 : 0
-  alarm_name          = "queues-not-active-1-minute-warning"
-  alarm_description   = "Queues have not been active for one minute"
+  alarm_name          = "sqs-beat-inbox-tasks-not-active-1-minute-warning"
+  alarm_description   = "Beat inbox tasks have not been active for one minute"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.queues-are-active[0].metric_transformation[0].name
-  namespace           = aws_cloudwatch_log_metric_filter.queues-are-active[0].metric_transformation[0].namespace
+  metric_name         = aws_cloudwatch_log_metric_filter.beat-inbox-tasks-are-active[0].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.beat-inbox-tasks-are-active[0].metric_transformation[0].namespace
   period              = "60"
   statistic           = "Sum"
   threshold           = 1
@@ -923,14 +923,14 @@ resource "aws_cloudwatch_metric_alarm" "queues-not-active-1-minute-warning" {
   alarm_actions       = [var.sns_alert_warning_arn]
 }
 
-resource "aws_cloudwatch_metric_alarm" "queues-not-active-5-minutes-critical" {
+resource "aws_cloudwatch_metric_alarm" "sqs-beat-inbox-tasks-not-active-5-minutes-critical" {
   count               = var.cloudwatch_enabled ? 1 : 0
-  alarm_name          = "queues-not-active-5-minutes-critical"
-  alarm_description   = "Queues have not been active for 5 minutes"
+  alarm_name          = "sqs-beat-inbox-tasks-not-active-5-minutes-critical"
+  alarm_description   = "Beat inbox tasks have not been active for 5 minutes"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.queues-are-active[0].metric_transformation[0].name
-  namespace           = aws_cloudwatch_log_metric_filter.queues-are-active[0].metric_transformation[0].namespace
+  metric_name         = aws_cloudwatch_log_metric_filter.beat-inbox-tasks-are-active[0].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.beat-inbox-tasks-are-active[0].metric_transformation[0].namespace
   period              = "300"
   statistic           = "Sum"
   threshold           = 1

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -908,14 +908,14 @@ resource "aws_cloudwatch_metric_alarm" "karpenter-replicas-unavailable" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "beat-inbox-tasks-not-active-1-minute-warning" {
+resource "aws_cloudwatch_metric_alarm" "aggregating-queues-not-active-1-minute-warning" {
   count               = var.cloudwatch_enabled ? 1 : 0
-  alarm_name          = "beat-inbox-tasks-not-active-1-minute-warning"
+  alarm_name          = "aggregating-queues-not-active-1-minute-warning"
   alarm_description   = "Beat inbox tasks have not been active for one minute"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.beat-inbox-tasks-are-active[0].metric_transformation[0].name
-  namespace           = aws_cloudwatch_log_metric_filter.beat-inbox-tasks-are-active[0].metric_transformation[0].namespace
+  metric_name         = aws_cloudwatch_log_metric_filter.aggregating-queues-are-active[0].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.aggregating-queues-are-active[0].metric_transformation[0].namespace
   period              = "60"
   statistic           = "Sum"
   threshold           = 1
@@ -923,14 +923,14 @@ resource "aws_cloudwatch_metric_alarm" "beat-inbox-tasks-not-active-1-minute-war
   alarm_actions       = [var.sns_alert_warning_arn]
 }
 
-resource "aws_cloudwatch_metric_alarm" "beat-inbox-tasks-not-active-5-minutes-critical" {
+resource "aws_cloudwatch_metric_alarm" "aggregating-queues-not-active-5-minutes-critical" {
   count               = var.cloudwatch_enabled ? 1 : 0
-  alarm_name          = "beat-inbox-tasks-not-active-5-minutes-critical"
+  alarm_name          = "aggregating-queues-not-active-5-minutes-critical"
   alarm_description   = "Beat inbox tasks have not been active for 5 minutes"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.beat-inbox-tasks-are-active[0].metric_transformation[0].name
-  namespace           = aws_cloudwatch_log_metric_filter.beat-inbox-tasks-are-active[0].metric_transformation[0].namespace
+  metric_name         = aws_cloudwatch_log_metric_filter.aggregating-queues-are-active[0].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.aggregating-queues-are-active[0].metric_transformation[0].namespace
   period              = "300"
   statistic           = "Sum"
   threshold           = 1

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -908,9 +908,9 @@ resource "aws_cloudwatch_metric_alarm" "karpenter-replicas-unavailable" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "sqs-beat-inbox-tasks-not-active-1-minute-warning" {
+resource "aws_cloudwatch_metric_alarm" "beat-inbox-tasks-not-active-1-minute-warning" {
   count               = var.cloudwatch_enabled ? 1 : 0
-  alarm_name          = "sqs-beat-inbox-tasks-not-active-1-minute-warning"
+  alarm_name          = "beat-inbox-tasks-not-active-1-minute-warning"
   alarm_description   = "Beat inbox tasks have not been active for one minute"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
@@ -923,9 +923,9 @@ resource "aws_cloudwatch_metric_alarm" "sqs-beat-inbox-tasks-not-active-1-minute
   alarm_actions       = [var.sns_alert_warning_arn]
 }
 
-resource "aws_cloudwatch_metric_alarm" "sqs-beat-inbox-tasks-not-active-5-minutes-critical" {
+resource "aws_cloudwatch_metric_alarm" "beat-inbox-tasks-not-active-5-minutes-critical" {
   count               = var.cloudwatch_enabled ? 1 : 0
-  alarm_name          = "sqs-beat-inbox-tasks-not-active-5-minutes-critical"
+  alarm_name          = "beat-inbox-tasks-not-active-5-minutes-critical"
   alarm_description   = "Beat inbox tasks have not been active for 5 minutes"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -154,14 +154,14 @@ resource "aws_cloudwatch_log_metric_filter" "documentation-evicted-pods" {
   }
 }
 
-resource "aws_cloudwatch_log_metric_filter" "queues-are-active" {
+resource "aws_cloudwatch_log_metric_filter" "beat-inbox-tasks-are-active" {
   count          = var.cloudwatch_enabled ? 1 : 0
-  name           = "queues-are-active"
+  name           = "beat-inbox-tasks-are-active"
   pattern        = "Batch saving with"
   log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs[0].name
 
   metric_transformation {
-    name      = "queues-are-active"
+    name      = "beat-inbox-tasks-are-active"
     namespace = "LogMetrics"
     value     = "1"
   }

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -154,14 +154,14 @@ resource "aws_cloudwatch_log_metric_filter" "documentation-evicted-pods" {
   }
 }
 
-resource "aws_cloudwatch_log_metric_filter" "beat-inbox-tasks-are-active" {
+resource "aws_cloudwatch_log_metric_filter" "aggregating-queues-are-active" {
   count          = var.cloudwatch_enabled ? 1 : 0
-  name           = "beat-inbox-tasks-are-active"
+  name           = "aggregating-queues-are-active"
   pattern        = "Batch saving with"
   log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs[0].name
 
   metric_transformation {
-    name      = "beat-inbox-tasks-are-active"
+    name      = "aggregating-queues-are-active"
     namespace = "LogMetrics"
     value     = "1"
   }


### PR DESCRIPTION
# Summary | Résumé

This pr amends #1123 to make the alarm names, alarm description, and metric filter names more accurate, i.e. this is monitoring that the beat inbox celery tasks are constantly firing and not so much watching the queues themselves.

