### PR TITLE
Fixing double mock outputs

### DIFF
--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -43,7 +43,6 @@ dependency "dns" {
 
   # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
   # module hasn't been applied yet.
-  mock_outputs_allowed_terraform_commands = ["validate"]
   mock_outputs = {
     internal_dns_certificate_arn = ""
     internal_dns_zone_id = "ZQSVJUPU6J1EY"


### PR DESCRIPTION
# Summary | Résumé

Removing double declaration of mock output usage in production EKS


# Test instructions | Instructions pour tester la modification

TF Validate on production should work.