### PR TITLE
Setting coreDNS to run on ON_DEMAND only

### DIFF
--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -161,6 +161,9 @@ resource "aws_eks_addon" "coredns" {
           loadbalance
       }
       EOF
+    "nodeSelector" : {
+      "eks.amazonaws.com/capacityType" : "ON_DEMAND"
+    }
   })
 }
 


### PR DESCRIPTION
# Summary | Résumé

This will enforce coreDNS running on ON_DEMAND nodes only.

# Test instructions | Instructions pour tester la modification

TF Apply in staging, verify that coredns is not running on spot instances