### PR TITLE
removing logging from coredns

### DIFF
--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -143,7 +143,6 @@ resource "aws_eks_addon" "coredns" {
   configuration_values = jsonencode({
     corefile = <<-EOF
       .:53 {
-          log
           errors
           health {
               lameduck 5s


### PR DESCRIPTION
# Summary | Résumé

This will disable logging from coredns. To be released when we've confirmed that the coredns issue has been resolved.

# Test instructions | Instructions pour tester la modification

```shell
kubectl rollout restart deployment/coredns -n kube-system
```
kubectl logs on the new pods, verify only the version logs are sent to stdout.