### PR TITLE
fix: remove trailing slash from FR route

### DIFF
--- a/aws/common/waf.tf
+++ b/aws/common/waf.tf
@@ -70,7 +70,7 @@ resource "aws_wafv2_regex_pattern_set" "re_admin" {
 
   # GCA routes
   regular_expression {
-    regex_string = "/terms|/conditions-dutilisation|/personalisation-guide|/guide-personnalisation|/.*-delivery-.*|/etat-livraison-messages|/formatting-.*|/guide-mise-en-forme|/spreadsheets|/feuille-de-calcu|/sins.*demo/"
+    regex_string = "/terms|/conditions-dutilisation|/personalisation-guide|/guide-personnalisation|/.*-delivery-.*|/etat-livraison-messages|/formatting-.*|/guide-mise-en-forme|/spreadsheets|/feuille-de-calcu|/sins.*demo"
   }
 
   # GCA routes


### PR DESCRIPTION
# Summary | Résumé

Make the route work in FR by removing trailing slash