### PR TITLE
Logging SMS usage costs

### DIFF
--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -384,7 +384,7 @@ module "sns_sms_usage_report_bucket" {
   force_destroy     = var.force_destroy_s3
   billing_tag_value = "notification-canada-ca-${var.env}"
 
-  lifecycle_rule = { "lifecycle_rule" : { "enabled" : "true", "expiration" : { "days" : "90" } } }
+  lifecycle_rule = { "lifecycle_rule" : { "enabled" : "true", "expiration" : { "days" : "7" } } }
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
@@ -460,7 +460,7 @@ module "sns_sms_usage_report_bucket_us_west_2" {
   force_destroy     = var.force_destroy_s3
   billing_tag_value = "notification-canada-ca-${var.env}"
 
-  lifecycle_rule = { "lifecycle_rule" : { "enabled" : "true", "expiration" : { "days" : "90" } } }
+  lifecycle_rule = { "lifecycle_rule" : { "enabled" : "true", "expiration" : { "days" : "7" } } }
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"

--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -376,3 +376,31 @@ module "cbs_logs_bucket" {
     CostCenter = "notification-canada-ca-${var.env}"
   }
 }
+
+module "sns_sms_usage_report_bucket" {
+  source = "github.com/cds-snc/terraform-modules//S3_log_bucket?ref=v6.0.3"
+
+  bucket_name       = "notification-canada-ca-${var.env}-sms-usage-logs"
+  force_destroy     = var.force_destroy_s3
+  billing_tag_value = "notification-canada-ca-${var.env}"
+
+  lifecycle_rule = { "lifecycle_rule" : { "enabled" : "true", "expiration" : { "days" : "90" } } }
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}
+
+module "sns_sms_usage_report_bucket_us_west_2" {
+  source = "github.com/cds-snc/terraform-modules//S3_log_bucket?ref=v6.0.3"
+
+  bucket_name       = "notification-canada-ca-${var.env}-sms-usage-west-2-logs"
+  force_destroy     = var.force_destroy_s3
+  billing_tag_value = "notification-canada-ca-${var.env}"
+
+  lifecycle_rule = { "lifecycle_rule" : { "enabled" : "true", "expiration" : { "days" : "90" } } }
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}

--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -391,6 +391,68 @@ module "sns_sms_usage_report_bucket" {
   }
 }
 
+resource "aws_s3_bucket_policy" "sns_sms_usage_report_bucket_policy" {
+  bucket = module.sns_sms_usage_report_bucket.s3_bucket_id
+
+  policy = <<POLICY
+{
+	"Version": "2008-10-17",
+	"Statement": [{
+			"Sid": "AllowPutObject",
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "sns.amazonaws.com"
+			},
+			"Action": "s3:PutObject",
+			"Resource": "arn:aws:s3:::${module.sns_sms_usage_report_bucket.s3_bucket_id}/*",
+			"Condition": {
+				"StringEquals": {
+					"aws:SourceAccount": "${var.account_id}"
+				},
+				"ArnLike": {
+					"aws:SourceArn": "arn:aws:sns:${var.region}:${var.account_id}:*"
+				}
+			}
+		},
+		{
+			"Sid": "AllowGetBucketLocation",
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "sns.amazonaws.com"
+			},
+			"Action": "s3:GetBucketLocation",
+			"Resource": "arn:aws:s3:::${module.sns_sms_usage_report_bucket.s3_bucket_id}",
+			"Condition": {
+				"StringEquals": {
+					"aws:SourceAccount": "${var.account_id}"
+				},
+				"ArnLike": {
+					"aws:SourceArn": "arn:aws:sns:${var.region}:${var.account_id}:*"
+				}
+			}
+		},
+		{
+			"Sid": "AllowListBucket",
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "sns.amazonaws.com"
+			},
+			"Action": "s3:ListBucket",
+			"Resource": "arn:aws:s3:::${module.sns_sms_usage_report_bucket.s3_bucket_id}",
+			"Condition": {
+				"StringEquals": {
+					"aws:SourceAccount": "${var.account_id}"
+				},
+				"ArnLike": {
+					"aws:SourceArn": "arn:aws:sns:${var.region}:${var.account_id}:*"
+				}
+			}
+		}
+	]
+}
+POLICY
+}
+
 module "sns_sms_usage_report_bucket_us_west_2" {
   source = "github.com/cds-snc/terraform-modules//S3_log_bucket?ref=v6.0.3"
 
@@ -403,4 +465,66 @@ module "sns_sms_usage_report_bucket_us_west_2" {
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
   }
+}
+
+resource "aws_s3_bucket_policy" "sns_sms_usage_report_bucket_us_west_2_policy" {
+  bucket = module.sns_sms_usage_report_bucket_us_west_2.s3_bucket_id
+
+  policy = <<POLICY
+{
+	"Version": "2008-10-17",
+	"Statement": [{
+			"Sid": "AllowPutObject",
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "sns.amazonaws.com"
+			},
+			"Action": "s3:PutObject",
+			"Resource": "arn:aws:s3:::${module.sns_sms_usage_report_bucket_us_west_2.s3_bucket_id}/*",
+			"Condition": {
+				"StringEquals": {
+					"aws:SourceAccount": "${var.account_id}"
+				},
+				"ArnLike": {
+					"aws:SourceArn": "arn:aws:sns:${var.region}:${var.account_id}:*"
+				}
+			}
+		},
+		{
+			"Sid": "AllowGetBucketLocation",
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "sns.amazonaws.com"
+			},
+			"Action": "s3:GetBucketLocation",
+			"Resource": "arn:aws:s3:::${module.sns_sms_usage_report_bucket_us_west_2.s3_bucket_id}",
+			"Condition": {
+				"StringEquals": {
+					"aws:SourceAccount": "${var.account_id}"
+				},
+				"ArnLike": {
+					"aws:SourceArn": "arn:aws:sns:${var.region}:${var.account_id}:*"
+				}
+			}
+		},
+		{
+			"Sid": "AllowListBucket",
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "sns.amazonaws.com"
+			},
+			"Action": "s3:ListBucket",
+			"Resource": "arn:aws:s3:::${module.sns_sms_usage_report_bucket_us_west_2.s3_bucket_id}",
+			"Condition": {
+				"StringEquals": {
+					"aws:SourceAccount": "${var.account_id}"
+				},
+				"ArnLike": {
+					"aws:SourceArn": "arn:aws:sns:${var.region}:${var.account_id}:*"
+				}
+			}
+		}
+	]
+}
+POLICY
 }

--- a/aws/common/sns.tf
+++ b/aws/common/sns.tf
@@ -83,17 +83,26 @@ resource "aws_sns_topic" "notification-canada-ca-alert-general" {
 }
 
 resource "aws_sns_sms_preferences" "update-sms-prefs" {
+  depends_on = [
+    module.sns_sms_usage_report_bucket
+  ]
   delivery_status_iam_role_arn          = aws_iam_role.sns-delivery-role.arn
   delivery_status_success_sampling_rate = 100
   monthly_spend_limit                   = var.sns_monthly_spend_limit
+  usage_report_s3_bucket                = module.sns_sms_usage_report_bucket.s3_bucket_id
 }
 
 resource "aws_sns_sms_preferences" "update-sms-prefs-us-west-2" {
+  depends_on = [
+    module.sns_sms_usage_report_bucket_us_west_2
+  ]
+
   provider = aws.us-west-2
 
   delivery_status_iam_role_arn          = aws_iam_role.sns-delivery-role.arn
   delivery_status_success_sampling_rate = 100
   monthly_spend_limit                   = var.sns_monthly_spend_limit_us_west_2
+  usage_report_s3_bucket                = module.sns_sms_usage_report_bucket_us_west_2.s3_bucket_id
 }
 
 resource "aws_sns_topic_subscription" "sns_alert_ok_us_west_2_to_lambda" {


### PR DESCRIPTION
# Summary | Résumé

This adds S3 buckets into which the SMS usage report, including cost, will be generated and dropped into.

Instructions on how to register to these are located here:
https://docs.aws.amazon.com/sns/latest/dg/sms_stats_usage.html

# Test instructions | Instructions pour tester la modification

We'll have to merge to see if the permissions and config works.
