### PR TITLE
Logging SMS usage costs (second attempt)

### DIFF
--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -454,7 +454,9 @@ POLICY
 }
 
 module "sns_sms_usage_report_bucket_us_west_2" {
-  provider = aws.us-west-2
+  providers = {
+    aws = aws.us-west-2
+  }
 
   source = "github.com/cds-snc/terraform-modules//S3_log_bucket?ref=v6.0.3"
 

--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -509,7 +509,7 @@ resource "aws_s3_bucket_policy" "sns_sms_usage_report_bucket_us_west_2_policy" {
 					"aws:SourceAccount": "${var.account_id}"
 				},
 				"ArnLike": {
-					"aws:SourceArn": "arn:aws:sns:${var.region}:${var.account_id}:*"
+					"aws:SourceArn": "arn:aws:sns:us-west-2:${var.account_id}:*"
 				}
 			}
 		},

--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -526,7 +526,7 @@ resource "aws_s3_bucket_policy" "sns_sms_usage_report_bucket_us_west_2_policy" {
 					"aws:SourceAccount": "${var.account_id}"
 				},
 				"ArnLike": {
-					"aws:SourceArn": "arn:aws:sns:${var.region}:${var.account_id}:*"
+					"aws:SourceArn": "arn:aws:sns:us-west-2:${var.account_id}:*"
 				}
 			}
 		}

--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -376,3 +376,155 @@ module "cbs_logs_bucket" {
     CostCenter = "notification-canada-ca-${var.env}"
   }
 }
+
+module "sns_sms_usage_report_bucket" {
+  source = "github.com/cds-snc/terraform-modules//S3_log_bucket?ref=v6.0.3"
+
+  bucket_name       = "notification-canada-ca-${var.env}-sms-usage-logs"
+  force_destroy     = var.force_destroy_s3
+  billing_tag_value = "notification-canada-ca-${var.env}"
+
+  lifecycle_rule = { "lifecycle_rule" : { "enabled" : "true", "expiration" : { "days" : "7" } } }
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}
+
+resource "aws_s3_bucket_policy" "sns_sms_usage_report_bucket_policy" {
+  bucket = module.sns_sms_usage_report_bucket.s3_bucket_id
+
+  policy = <<POLICY
+{
+	"Version": "2008-10-17",
+	"Statement": [{
+			"Sid": "AllowPutObject",
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "sns.amazonaws.com"
+			},
+			"Action": "s3:PutObject",
+			"Resource": "arn:aws:s3:::${module.sns_sms_usage_report_bucket.s3_bucket_id}/*",
+			"Condition": {
+				"StringEquals": {
+					"aws:SourceAccount": "${var.account_id}"
+				},
+				"ArnLike": {
+					"aws:SourceArn": "arn:aws:sns:${var.region}:${var.account_id}:*"
+				}
+			}
+		},
+		{
+			"Sid": "AllowGetBucketLocation",
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "sns.amazonaws.com"
+			},
+			"Action": "s3:GetBucketLocation",
+			"Resource": "arn:aws:s3:::${module.sns_sms_usage_report_bucket.s3_bucket_id}",
+			"Condition": {
+				"StringEquals": {
+					"aws:SourceAccount": "${var.account_id}"
+				},
+				"ArnLike": {
+					"aws:SourceArn": "arn:aws:sns:${var.region}:${var.account_id}:*"
+				}
+			}
+		},
+		{
+			"Sid": "AllowListBucket",
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "sns.amazonaws.com"
+			},
+			"Action": "s3:ListBucket",
+			"Resource": "arn:aws:s3:::${module.sns_sms_usage_report_bucket.s3_bucket_id}",
+			"Condition": {
+				"StringEquals": {
+					"aws:SourceAccount": "${var.account_id}"
+				},
+				"ArnLike": {
+					"aws:SourceArn": "arn:aws:sns:${var.region}:${var.account_id}:*"
+				}
+			}
+		}
+	]
+}
+POLICY
+}
+
+module "sns_sms_usage_report_bucket_us_west_2" {
+  source = "github.com/cds-snc/terraform-modules//S3_log_bucket?ref=v6.0.3"
+
+  bucket_name       = "notification-canada-ca-${var.env}-sms-usage-west-2-logs"
+  force_destroy     = var.force_destroy_s3
+  billing_tag_value = "notification-canada-ca-${var.env}"
+
+  lifecycle_rule = { "lifecycle_rule" : { "enabled" : "true", "expiration" : { "days" : "7" } } }
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}
+
+resource "aws_s3_bucket_policy" "sns_sms_usage_report_bucket_us_west_2_policy" {
+  bucket = module.sns_sms_usage_report_bucket_us_west_2.s3_bucket_id
+
+  policy = <<POLICY
+{
+	"Version": "2008-10-17",
+	"Statement": [{
+			"Sid": "AllowPutObject",
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "sns.amazonaws.com"
+			},
+			"Action": "s3:PutObject",
+			"Resource": "arn:aws:s3:::${module.sns_sms_usage_report_bucket_us_west_2.s3_bucket_id}/*",
+			"Condition": {
+				"StringEquals": {
+					"aws:SourceAccount": "${var.account_id}"
+				},
+				"ArnLike": {
+					"aws:SourceArn": "arn:aws:sns:${var.region}:${var.account_id}:*"
+				}
+			}
+		},
+		{
+			"Sid": "AllowGetBucketLocation",
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "sns.amazonaws.com"
+			},
+			"Action": "s3:GetBucketLocation",
+			"Resource": "arn:aws:s3:::${module.sns_sms_usage_report_bucket_us_west_2.s3_bucket_id}",
+			"Condition": {
+				"StringEquals": {
+					"aws:SourceAccount": "${var.account_id}"
+				},
+				"ArnLike": {
+					"aws:SourceArn": "arn:aws:sns:${var.region}:${var.account_id}:*"
+				}
+			}
+		},
+		{
+			"Sid": "AllowListBucket",
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "sns.amazonaws.com"
+			},
+			"Action": "s3:ListBucket",
+			"Resource": "arn:aws:s3:::${module.sns_sms_usage_report_bucket_us_west_2.s3_bucket_id}",
+			"Condition": {
+				"StringEquals": {
+					"aws:SourceAccount": "${var.account_id}"
+				},
+				"ArnLike": {
+					"aws:SourceArn": "arn:aws:sns:${var.region}:${var.account_id}:*"
+				}
+			}
+		}
+	]
+}
+POLICY
+}

--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -454,6 +454,8 @@ POLICY
 }
 
 module "sns_sms_usage_report_bucket_us_west_2" {
+  provider = aws.us-west-2
+
   source = "github.com/cds-snc/terraform-modules//S3_log_bucket?ref=v6.0.3"
 
   bucket_name       = "notification-canada-ca-${var.env}-sms-usage-west-2-logs"
@@ -468,6 +470,8 @@ module "sns_sms_usage_report_bucket_us_west_2" {
 }
 
 resource "aws_s3_bucket_policy" "sns_sms_usage_report_bucket_us_west_2_policy" {
+  provider = aws.us-west-2
+
   bucket = module.sns_sms_usage_report_bucket_us_west_2.s3_bucket_id
 
   policy = <<POLICY

--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -492,7 +492,7 @@ resource "aws_s3_bucket_policy" "sns_sms_usage_report_bucket_us_west_2_policy" {
 					"aws:SourceAccount": "${var.account_id}"
 				},
 				"ArnLike": {
-					"aws:SourceArn": "arn:aws:sns:${var.region}:${var.account_id}:*"
+					"aws:SourceArn": "arn:aws:sns:us-west-2:${var.account_id}:*"
 				}
 			}
 		},

--- a/aws/common/sns.tf
+++ b/aws/common/sns.tf
@@ -90,10 +90,6 @@ resource "aws_sns_sms_preferences" "update-sms-prefs" {
 }
 
 resource "aws_sns_sms_preferences" "update-sms-prefs-us-west-2" {
-  depends_on = [
-    module.sns_sms_usage_report_bucket_us_west_2
-  ]
-
   provider = aws.us-west-2
 
   delivery_status_iam_role_arn          = aws_iam_role.sns-delivery-role.arn

--- a/aws/common/sns.tf
+++ b/aws/common/sns.tf
@@ -83,17 +83,26 @@ resource "aws_sns_topic" "notification-canada-ca-alert-general" {
 }
 
 resource "aws_sns_sms_preferences" "update-sms-prefs" {
+  depends_on = [
+    module.sns_sms_usage_report_bucket
+  ]
   delivery_status_iam_role_arn          = aws_iam_role.sns-delivery-role.arn
   delivery_status_success_sampling_rate = 100
   monthly_spend_limit                   = var.sns_monthly_spend_limit
+  usage_report_s3_bucket                = module.sns_sms_usage_report_bucket.s3_bucket_id
 }
 
 resource "aws_sns_sms_preferences" "update-sms-prefs-us-west-2" {
+  depends_on = [
+    module.sns_sms_usage_report_bucket_us_west_2
+  ]
+
   provider = aws.us-west-2
 
   delivery_status_iam_role_arn          = aws_iam_role.sns-delivery-role.arn
   delivery_status_success_sampling_rate = 100
   monthly_spend_limit                   = var.sns_monthly_spend_limit_us_west_2
+  usage_report_s3_bucket                = module.sns_sms_usage_report_bucket_us_west_2.s3_bucket_id
 }
 
 resource "aws_sns_topic_subscription" "sns_alert_ok_us_west_2_to_lambda" {

--- a/aws/common/sns.tf
+++ b/aws/common/sns.tf
@@ -83,9 +83,6 @@ resource "aws_sns_topic" "notification-canada-ca-alert-general" {
 }
 
 resource "aws_sns_sms_preferences" "update-sms-prefs" {
-  depends_on = [
-    module.sns_sms_usage_report_bucket
-  ]
   delivery_status_iam_role_arn          = aws_iam_role.sns-delivery-role.arn
   delivery_status_success_sampling_rate = 100
   monthly_spend_limit                   = var.sns_monthly_spend_limit


### PR DESCRIPTION
# Summary | Résumé

This adds S3 buckets into which the SMS usage report, including cost, will be generated and dropped into.

Instructions on how to register to these are located here:
https://docs.aws.amazon.com/sns/latest/dg/sms_stats_usage.html

First attempt was #1173 . This one hopefully fixes the previous attempt that did not work:

```
 "errorCode": "AuthorizationErrorException",
    "errorMessage": "You are not authorized to perform actions for the provided bucket",
```

The cause is likely that the us-west-2 provider was not defined on the new s3 bucket that was meant for that region. This new PR fixes that.

# Test instructions | Instructions pour tester la modification

We'll have to merge to see if the permissions and config works.
