### PR TITLE
Capitalize name of notifications dataset

### DIFF
--- a/aws/quicksight/dataset_notifications.tf
+++ b/aws/quicksight/dataset_notifications.tf
@@ -2,7 +2,7 @@
 
 resource "aws_quicksight_data_set" "notifications" {
   data_set_id = "notifications"
-  name        = "notifications"
+  name        = "Notifications"
   import_mode = "SPICE"
 
   physical_table_map {


### PR DESCRIPTION
# Summary | Résumé

When refactoring the notifications dataset I didn't capitalize the name (as we do for all the other datasets) 😞 
