### PR TITLE
add more Athena queries

### DIFF
--- a/aws/common/athena_queries_support.tf
+++ b/aws/common/athena_queries_support.tf
@@ -39,3 +39,27 @@ resource "aws_athena_named_query" "http_four_hundreds" {
   database    = aws_athena_database.notification_athena.name
   query       = templatefile("${path.module}/sql/find_400s.sql.tmpl", {})
 }
+
+resource "aws_athena_named_query" "direct_ip_queries" {
+  name        = "WAF: Direct IPs hits by hosts, countries, actions and URIs"
+  description = "Find requests made directly to ips rather than urls"
+  workgroup   = aws_athena_workgroup.support.name
+  database    = aws_athena_database.notification_athena.name
+  query       = templatefile("${path.module}/sql/direct_ip_queries.sql.tmpl", {})
+}
+
+resource "aws_athena_named_query" "monitor_blocked_requests" {
+  name        = "WAF: monitor blocked requests"
+  description = "See what requests have been blocked"
+  workgroup   = aws_athena_workgroup.support.name
+  database    = aws_athena_database.notification_athena.name
+  query       = templatefile("${path.module}/sql/monitor_blocked_requests.sql.tmpl", {})
+}
+
+resource "aws_athena_named_query" "fuzzing_attack" {
+  name        = "WAF: Fuzzing attack (not blocked)"
+  description = "Find ips with a lot of requests allowed through the WAF"
+  workgroup   = aws_athena_workgroup.support.name
+  database    = aws_athena_database.notification_athena.name
+  query       = templatefile("${path.module}/sql/fuzzing_attack.sql.tmpl", {})
+}

--- a/aws/common/sql/direct_ip_queries.sql.tmpl
+++ b/aws/common/sql/direct_ip_queries.sql.tmpl
@@ -1,0 +1,18 @@
+with data as (
+    select
+        date_format(from_unixtime(timestamp / 1000e0), '%Y-%m-%d') as time, header.value as host, action,
+        httprequest.clientip, httprequest.country, httprequest.httpmethod, httprequest.uri,
+        nonterminatingmatchingrule.ruleid as count_rule
+    from waf_logs
+    cross join UNNEST(httprequest.headers) AS t(header)
+    cross join UNNEST(nonterminatingmatchingrules) AS t(nonterminatingmatchingrule)
+    where lower(header.name)='host'
+      and REGEXP_LIKE(header.value, '\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}')
+      and from_unixtime(timestamp/1000) > now() - interval '1' day
+)
+select 
+    count(*) as num, host, country, action, count_rule, 
+    array_join(array_agg(distinct uri), ', ') as uris
+ from data
+group by host, country, action, count_rule
+order by count(*) desc

--- a/aws/common/sql/fuzzing_attack.sql.tmpl
+++ b/aws/common/sql/fuzzing_attack.sql.tmpl
@@ -1,0 +1,14 @@
+with data as (
+    select
+        date_format(from_unixtime(timestamp / 1000e0), '%Y-%m-%d') as day, header.value as host,
+        httprequest.clientip, httprequest.country, httprequest.httpmethod, httprequest.uri, action
+    FROM waf_logs
+    CROSS JOIN UNNEST(httprequest.headers) AS t(header)
+    where LOWER(header.name)='host'
+    -- and date_format(from_unixtime(timestamp / 1000e0), '%Y-%m-%d') = '2022-08-09'
+        and action != 'BLOCK'
+)
+select day, count(*) as num, clientip, country,  host, array_join(array_agg(distinct uri), ', ') as uris
+from data
+group by day, clientip, country, host
+order by day desc, count(*) desc

--- a/aws/common/sql/monitor_blocked_requests.sql.tmpl
+++ b/aws/common/sql/monitor_blocked_requests.sql.tmpl
@@ -1,0 +1,17 @@
+with data as (
+    select
+        from_unixtime(timestamp / 1000e0) as datetime, header.value as host, httprequest.uri, header_agent.value as user_agent, action,
+        terminatingruleid,
+        httprequest.clientip, httprequest.country, httprequest.httpmethod
+    from waf_logs
+    cross join UNNEST(httprequest.headers) AS t(header)
+    cross join UNNEST(httprequest.headers) AS t(header_agent)
+    where lower(header.name)='host'
+    and lower(header_agent.name)='user-agent'
+    and action = 'BLOCK'
+)
+select * from data
+where host = 'api.notification.canada.ca' or host = 'api.notification.alpha.canada.ca/'
+    and lower(user_agent) like '%notify%'
+order by datetime desc
+limit 1000


### PR DESCRIPTION
# Summary | Résumé

Add more Athena queries, as discussed at Dev Review:
* WAF: Direct IPs hits by hosts, countries, actions and URIs
* WAF: monitor blocked requests
* WAF: Fuzzing attack

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/204

# Test instructions | Instructions pour tester la modification

Run the queries

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.