### PR TITLE
Adding make dependencies to arc runner

### DIFF
--- a/aws/ecr/github-runner/Dockerfile
+++ b/aws/ecr/github-runner/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/actions/actions-runner:2.313.0
 USER root
 
 RUN apt update
-RUN apt install -y git curl unzip
+RUN apt install -y git curl unzip build-essential
 WORKDIR /var/tmp
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip


### PR DESCRIPTION
# Summary | Résumé

The merge to main staging (and production) jobs require makefile to be installed via the build-essentials package. Adding it here.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/293

# Test instructions | Instructions pour tester la modification

Tested in dev - ran a debug staging workflow with makefile on it.
In staging update the merge to main staging workflow to run on the internal github runners.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.