### PR TITLE
Switched to a full refresh for sms usage reports

### DIFF
--- a/aws/quicksight/dataset_sms_usage.tf
+++ b/aws/quicksight/dataset_sms_usage.tf
@@ -64,7 +64,7 @@ resource "aws_quicksight_refresh_schedule" "sms_usage" {
   depends_on  = [aws_quicksight_data_set.sms_usage]
 
   schedule {
-    refresh_type = "INCREMENTAL_REFRESH"
+    refresh_type = "FULL_REFRESH"
 
     # SMS usage reports are generated around 01:00 UTC.
     schedule_frequency {


### PR DESCRIPTION
# Summary | Résumé

This replaces the incremental refresh of the SMS usage report into a full refresh, because a partial refresh isn't possible with S3 buckets but only database queries:
https://docs.aws.amazon.com/quicksight/latest/user/refreshing-data.html

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/309

# Test instructions | Instructions pour tester la modification

Merge into staging and monitor the gh actions!

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.