### PR TITLE
chore: change entity type to resource

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,7 +2,7 @@
 # https://backstage.cdssandbox.xyz/  
 ---
 apiVersion: backstage.io/v1alpha1
-kind: Component
+kind: Resource
 metadata:
   name: notification-terraform
   description: >-
@@ -11,8 +11,10 @@ metadata:
     github.com/project-slug: cds-snc/notification-terraform
   labels:
     license: MIT
+  tags:
+    - terraform
 spec:
-  type: service
+  type: infrastructure
   lifecycle: production
   owner: group:cds-snc/notify-dev
   system: gc-notification


### PR DESCRIPTION
# Summary | Résumé

Updating the kind of the entity to Resource from Component (ref: [Backstage docs](https://backstage.io/docs/features/software-catalog/descriptor-format/#kind-resource))

Open for suggestions for a specific type. It appears to be multiple so I opted for a generic, catch-all "infrastructure" type but if something is more evocative for you we can update.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.