### PR TITLE
Switching github arc to PR BOT app

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -49,7 +49,9 @@ env:
   TF_VAR_client_vpn_access_group_id: ${{ secrets.PRODUCTION_CLIENT_VPN_ACCESS_GROUP_ID }}
   TF_VAR_client_vpn_saml_metadata: ${{ secrets.PRODUCTION_CLIENT_VPN_SAML_METADATA }}
   TF_VAR_client_vpn_self_service_saml_metadata: ${{ secrets.PRODUCTION_CLIENT_VPN_SELF_SERVICE_SAML_METADATA }}
-  TF_VAR_gha_arc_pat: ${{ secrets.GHA_ARC_PAT }}
+  TF_VAR_pr_bot_installation_id: ${{ secrets.NOTIFY_PR_BOT_INSTALLATION_ID_MANIFESTS }}
+  TF_VAR_pr_bot_app_id: ${{ secrets.NOTIFY_PR_BOT_APP_ID }}
+  TF_VAR_pr_bot_private_key: ${{ secrets.NOTIFY_PR_BOT_PRIVATE_KEY }}
 
 jobs:
   terraform-apply:

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -55,7 +55,9 @@ env:
   TF_VAR_client_vpn_access_group_id: ${{ secrets.STAGING_CLIENT_VPN_ACCESS_GROUP_ID }}
   TF_VAR_client_vpn_saml_metadata: ${{ secrets.STAGING_CLIENT_VPN_SAML_METADATA }}
   TF_VAR_client_vpn_self_service_saml_metadata: ${{ secrets.STAGING_CLIENT_VPN_SELF_SERVICE_SAML_METADATA }}
-  TF_VAR_gha_arc_pat: ${{ secrets.GHA_ARC_PAT }}
+  TF_VAR_pr_bot_installation_id: ${{ secrets.NOTIFY_PR_BOT_INSTALLATION_ID_MANIFESTS }}
+  TF_VAR_pr_bot_app_id: ${{ secrets.NOTIFY_PR_BOT_APP_ID }}
+  TF_VAR_pr_bot_private_key: ${{ secrets.NOTIFY_PR_BOT_PRIVATE_KEY }}
 
 jobs:
   terraform-apply:

--- a/.github/workflows/terragrunt_plan_production.yml
+++ b/.github/workflows/terragrunt_plan_production.yml
@@ -44,7 +44,9 @@ env:
   TF_VAR_client_vpn_access_group_id: ${{ secrets.PRODUCTION_CLIENT_VPN_ACCESS_GROUP_ID }}
   TF_VAR_client_vpn_saml_metadata: ${{ secrets.PRODUCTION_CLIENT_VPN_SAML_METADATA }}
   TF_VAR_client_vpn_self_service_saml_metadata: ${{ secrets.PRODUCTION_CLIENT_VPN_SELF_SERVICE_SAML_METADATA }}
-  TF_VAR_gha_arc_pat: ${{ secrets.GHA_ARC_PAT }}
+  TF_VAR_pr_bot_installation_id: ${{ secrets.NOTIFY_PR_BOT_INSTALLATION_ID_MANIFESTS }}
+  TF_VAR_pr_bot_app_id: ${{ secrets.NOTIFY_PR_BOT_APP_ID }}
+  TF_VAR_pr_bot_private_key: ${{ secrets.NOTIFY_PR_BOT_PRIVATE_KEY }}
 
 jobs:
   terragrunt-plan-production:

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -51,7 +51,9 @@ env:
   TF_VAR_client_vpn_access_group_id: ${{ secrets.STAGING_CLIENT_VPN_ACCESS_GROUP_ID }}
   TF_VAR_client_vpn_saml_metadata: ${{ secrets.STAGING_CLIENT_VPN_SAML_METADATA }}
   TF_VAR_client_vpn_self_service_saml_metadata: ${{ secrets.STAGING_CLIENT_VPN_SELF_SERVICE_SAML_METADATA }}
-  TF_VAR_gha_arc_pat: ${{ secrets.GHA_ARC_PAT }}
+  TF_VAR_pr_bot_installation_id: ${{ secrets.NOTIFY_PR_BOT_INSTALLATION_ID_MANIFESTS }}
+  TF_VAR_pr_bot_app_id: ${{ secrets.NOTIFY_PR_BOT_APP_ID }}
+  TF_VAR_pr_bot_private_key: ${{ secrets.NOTIFY_PR_BOT_PRIVATE_KEY }}
 
 jobs:
   terragrunt-plan-staging:

--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -12,8 +12,8 @@ resource "aws_eks_cluster" "notification-canada-ca-eks-cluster" {
   vpc_config {
 
     # Setting this explicitly for now, until manifests release is in
-    endpoint_private_access = false
-    endpoint_public_access  = true
+    endpoint_private_access = true
+    endpoint_public_access  = false
 
     # tfsec:ignore:AWS068 EKS cluster should not have open CIDR range for public access
     # Will be tackled in the future https://github.com/cds-snc/notification-terraform/issues/203

--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -12,8 +12,8 @@ resource "aws_eks_cluster" "notification-canada-ca-eks-cluster" {
   vpc_config {
 
     # Setting this explicitly for now, until manifests release is in
-    endpoint_private_access = true
-    endpoint_public_access  = false
+    endpoint_private_access = false
+    endpoint_public_access  = true
 
     # tfsec:ignore:AWS068 EKS cluster should not have open CIDR range for public access
     # Will be tackled in the future https://github.com/cds-snc/notification-terraform/issues/203

--- a/aws/eks/secrets.tf
+++ b/aws/eks/secrets.tf
@@ -7,11 +7,30 @@ resource "aws_secretsmanager_secret_version" "nginx_target_group_arn" {
   secret_string = aws_alb_target_group.internal_nginx_http.arn
 }
 
-resource "aws_secretsmanager_secret" "gha_arc_pat" {
-  name = "GITHUB_ARC_PAT"
+resource "aws_secretsmanager_secret" "pr_bot_app_id" {
+  name = "PR_BOT_APP_ID"
 }
 
-resource "aws_secretsmanager_secret_version" "gha_arc_pat" {
-  secret_id     = aws_secretsmanager_secret.gha_arc_pat.id
-  secret_string = var.gha_arc_pat
+resource "aws_secretsmanager_secret_version" "pr_bot_app_id" {
+  secret_id     = aws_secretsmanager_secret.pr_bot_app_id.id
+  secret_string = var.pr_bot_app_id
 }
+
+resource "aws_secretsmanager_secret" "pr_bot_private_key" {
+  name = "PR_BOT_PRIVATE_KEY"
+}
+
+resource "aws_secretsmanager_secret_version" "pr_bot_private_key" {
+  secret_id     = aws_secretsmanager_secret.pr_bot_private_key.id
+  secret_string = var.pr_bot_private_key
+}
+
+resource "aws_secretsmanager_secret" "pr_bot_installation_id" {
+  name = "PR_BOT_INSTALLATION_ID"
+}
+
+resource "aws_secretsmanager_secret_version" "pr_bot_installation_id" {
+  secret_id     = aws_secretsmanager_secret.pr_bot_installation_id.id
+  secret_string = var.pr_bot_installation_id
+}
+

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -276,9 +276,21 @@ variable "internal_dns_name" {
   description = "The fqdn for the internal DNS"
 }
 
-variable "gha_arc_pat" {
+variable "pr_bot_private_key" {
   type        = string
-  description = "The Personal Access Token that Github ARC will use to authenticate"
+  description = "The Private Key for PR Bot, used by Github ARC"
   sensitive   = true
-
 }
+
+variable "pr_bot_app_id" {
+  type        = string
+  description = "The AppID for PR Bot, used by Github ARC"
+  sensitive   = true
+}
+
+variable "pr_bot_installation_id" {
+  type        = string
+  description = "The installation ID for PR Bot, used by Github ARC"
+  sensitive   = true
+}
+


### PR DESCRIPTION
# Summary | Résumé

Switching github arc off of PAT and onto github app (piggybacking off notify pr bot).

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/293

# Test instructions | Instructions pour tester la modification

Terraform apply works.

# Release Instructions | Instructions pour le déploiement

This needs to be released in quick succession with the complimentary manifests rollout, since this gets rid of the PAT.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.