### PR TITLE
Added new budget notification for slack to our budget alerts terraform

### DIFF
--- a/aws/common/budget_alerts.tf
+++ b/aws/common/budget_alerts.tf
@@ -1,5 +1,34 @@
+
 resource "aws_budgets_budget" "notify_global" {
+  count        = var.env != "dev" ? 1 : 0
   name         = "notify-global-budget"
+  budget_type  = "COST"
+  limit_amount = var.account_budget_limit
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "FORECASTED"
+    subscriber_sns_topic_arns  = [aws_sns_topic.notification-canada-ca-alert-general.arn]
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_sns_topic_arns  = [aws_sns_topic.notification-canada-ca-alert-general.arn]
+  }
+}
+
+# Dev is not connected to slack, so we still need to have an email notification set up on dev
+
+resource "aws_budgets_budget" "notify_global_dev" {
+  count        = var.env == "dev" ? 1 : 0
+  name         = "notify-global-dev-budget"
   budget_type  = "COST"
   limit_amount = var.account_budget_limit
   limit_unit   = "USD"

--- a/aws/common/variables.tf
+++ b/aws/common/variables.tf
@@ -306,5 +306,5 @@ variable "account_budget_limit" {
 variable "account_budget_alert_emails" {
   description = "List of people who should be alerted when budget thresholds are met"
   type        = list(any)
-  default     = ["jimmy.royer@cds-snc.ca", "stephen.astels@cds-snc.ca", "ben.larabie@cds-snc.ca"]
+  default     = ["jimmy.royer@cds-snc.ca", "stephen.astels@cds-snc.ca", "ben.larabie@cds-snc.ca", "michael.pond@cds-snc.ca" ]
 }


### PR DESCRIPTION
# Summary | Résumé
Added a change to our budget alerts terraform so that budget alerts would be sent to slack.  Also added some conditional logic to ensure that email notifications are still being sent to the core team for dev -- because Slack integration has not been set up on Dev yet.

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/274

# Test instructions | Instructions pour tester la modification

Verify to see if alert gets sent to slack

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.