### PR TITLE
Added data transformation on the logical table of smsusage

### DIFF
--- a/aws/quicksight/dataset_sms_usage.tf
+++ b/aws/quicksight/dataset_sms_usage.tf
@@ -48,6 +48,43 @@ resource "aws_quicksight_data_set" "sms_usage" {
     }
   }
 
+  logical_table_map {
+    logical_table_map_id = "smsusage"
+
+    alias = "smsusage"
+
+    source {
+      physical_table_id = "smsusage"
+    }
+
+    data_transforms {
+
+      # cast_column_type_operation {
+      #   column_name = "PublishTimeUTC"
+      #   new_column_type = "DATETIME"
+      # }
+
+      cast_column_type_operation {
+        column_name     = "PriceInUSD"
+        new_column_type = "DECIMAL"
+      }
+    }
+
+    data_transforms {
+      cast_column_type_operation {
+        column_name     = "PartNumber"
+        new_column_type = "INTEGER"
+      }
+    }
+
+    data_transforms {
+      cast_column_type_operation {
+        column_name     = "TotalParts"
+        new_column_type = "INTEGER"
+      }
+    }
+  }
+
   permissions {
     actions   = local.dataset_viewer_permissions
     principal = aws_quicksight_group.dataset_viewer.arn


### PR DESCRIPTION
# Summary | Résumé

Transform data types that require proper type casting into appropriate types, such as the SMS price. Without this transformation, we cannot have a sum operation on that column.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/309

# Test instructions | Instructions pour tester la modification

* Check at the TF plan.
* Check at the Github action apply status, revert or fix issue if problem arise.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.