### PR TITLE
Revert "Quicksight: smsusage leftjoin notifications"

### DIFF
--- a/aws/quicksight/dataset_sms_usage.tf
+++ b/aws/quicksight/dataset_sms_usage.tf
@@ -1,6 +1,5 @@
 # valid column types are [STRING INTEGER DECIMAL DATETIME BIT BOOLEAN JSON]
 
-
 resource "aws_quicksight_data_set" "sms_usage" {
   data_set_id = "sms_usage"
   name        = "SmsUsage"
@@ -56,13 +55,6 @@ resource "aws_quicksight_data_set" "sms_usage" {
 
     source {
       physical_table_id = "smsusage"
-
-      join_instruction {
-        left_operand  = "smsusage"
-        right_operand = aws_quicksight_data_set.notifications.id
-        on_clause     = "smsusage.MessageId = notifications.notification_id"
-        type          = "LEFT"
-      }
     }
 
     data_transforms {


### PR DESCRIPTION
# Description

This is a prevemptive reverts cds-snc/notification-terraform#1214, because QuickSight changes in TF tend to break. This is because of the immature documentation and plugins around Quicksight so while the plan might pass and we follow documentation, it tends to fail while the `terragrunt apply` step happens.