### PR TITLE
Using data set id instead of the mere id

### DIFF
--- a/aws/quicksight/dataset_sms_usage.tf
+++ b/aws/quicksight/dataset_sms_usage.tf
@@ -59,7 +59,7 @@ resource "aws_quicksight_data_set" "sms_usage" {
 
       join_instruction {
         left_operand  = "smsusage"
-        right_operand = aws_quicksight_data_set.notifications.id
+        right_operand = aws_quicksight_data_set.notifications.data_set_id
         on_clause     = "smsusage.MessageId = notifications.notification_id"
         type          = "LEFT"
       }


### PR DESCRIPTION
# Summary | Résumé

Current `terragrunt apply` fails as the name of the right operand does not comply with validation. It seems that `data_set_id` attribute includes the AWS account ID and that is not supported by the `left_operand` attribute. Hence this change tries to reference the `data_set_id` as this should refer to the simple `notifications` data set name!

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-core-planning/309

# Test instructions | Instructions pour tester la modification

Plan should pass, monitor github action around the `terragrunt apply`.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.