### PR TITLE
Declare only 1 source for logical table source on smsusage dataset

### DIFF
--- a/aws/quicksight/dataset_notifications.tf
+++ b/aws/quicksight/dataset_notifications.tf
@@ -183,6 +183,15 @@ resource "aws_quicksight_data_set" "notifications" {
       }
     }
   }
+
+  logical_table_map {
+    logical_table_map_id = "notificationslog"
+    alias                = "Notifications"
+    source {
+      physical_table_id  = "notifications"
+    }
+  }
+
   permissions {
     actions   = local.dataset_viewer_permissions
     principal = aws_quicksight_group.dataset_viewer.arn

--- a/aws/quicksight/dataset_sms_usage.tf
+++ b/aws/quicksight/dataset_sms_usage.tf
@@ -54,7 +54,12 @@ resource "aws_quicksight_data_set" "sms_usage" {
     alias = "smsusage"
 
     source {
-      physical_table_id = "smsusage"
+      join_instruction {
+        left_operand  = "smsusage"
+        right_operand = aws_quicksight_data_set.notifications.data_set_id
+        on_clause     = "smsusage.MessageId = notifications.notification_id"
+        type          = "LEFT"
+      }
     }
 
     data_transforms {

--- a/aws/quicksight/dataset_sms_usage.tf
+++ b/aws/quicksight/dataset_sms_usage.tf
@@ -49,15 +49,16 @@ resource "aws_quicksight_data_set" "sms_usage" {
   }
 
   logical_table_map {
-    logical_table_map_id = "smsusage"
-
-    alias = "smsusage"
+    logical_table_map_id = "smsusagelog"
+    alias = "SMS Usage Report"
 
     source {
+      # physical_table_id = ""
       join_instruction {
-        left_operand  = "smsusage"
-        right_operand = aws_quicksight_data_set.notifications.data_set_id
-        on_clause     = "smsusage.MessageId = notifications.notification_id"
+        left_operand  = "smsusagelog"
+        #right_operand = "notificationslog"
+        right_operand = aws_quicksight_data_set.notifications.logical_table_map.notificationslog.logical_table_map_id
+        on_clause     = "{MessageId} = {notification_id}"
         type          = "LEFT"
       }
     }

--- a/aws/quicksight/vpc_connection.tf
+++ b/aws/quicksight/vpc_connection.tf
@@ -1,6 +1,7 @@
 resource "aws_quicksight_vpc_connection" "rds" {
-  vpc_connection_id  = var.vpc_id
-  name               = "Quicksight RDS connection"
+  depends_on         = [aws_quicksight_account_subscription.subscription]
+  vpc_connection_id  = "quicksight-rds-vpc-connection"
+  name               = "Quicksight RDS connection TEMP"
   role_arn           = aws_iam_role.vpc_connection_role.arn
   security_group_ids = [var.quicksight_security_group_id]
   subnet_ids         = var.database_subnet_ids


### PR DESCRIPTION
# Summary | Résumé

On my last attempt to fix the TF changes to left join both smsusage and notifications dataset of quicksight, we got the following error:

```
Message_: "Exactly one of PhysicalTableId, JoinInstruction or DataSetArn must be set for LogicalTable"
```

Hence it seems that declaring the `PhysicalTableId` and a `JoinInstruction` are considered two different sources, even though the physical table is actually used in the join. I assume that the join instruction will get the references right. The documentation did not declare this constraint by the way, of having only one of these. Let's try this to see if that will fix our current issue and move on to the next one.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/309

# Test instructions | Instructions pour tester la modification

* Plan should pass.
* The terragrunt apply op should pass.

# Release Instructions | Instructions pour le déploiement

Monitor the `merge to main` github action closely to make sure it is successful. 

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.