### PR TITLE
Setting rds to 4096 certificates

### DIFF
--- a/aws/database-tools/rds.tf
+++ b/aws/database-tools/rds.tf
@@ -22,6 +22,7 @@ resource "aws_db_instance" "database-tools" {
   username            = "postgres"
   password            = var.dbtools_password
   ca_cert_identifier  = var.env == "production" ? "rds-ca-2019" : "rds-ca-rsa4096-g1"
+  apply_immediately   = var.env == "production" ? false : true
   skip_final_snapshot = true
 
   storage_encrypted   = true

--- a/aws/database-tools/rds.tf
+++ b/aws/database-tools/rds.tf
@@ -21,6 +21,7 @@ resource "aws_db_instance" "database-tools" {
   instance_class      = "db.t3.micro"
   username            = "postgres"
   password            = var.dbtools_password
+  ca_cert_identifier  = var.env == "production" ? "rds-ca-2019" : "rds-ca-rsa4096-g1"
   skip_final_snapshot = true
 
   storage_encrypted   = true

--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -18,7 +18,7 @@ resource "aws_rds_cluster_instance" "notification-canada-ca-instances" {
   identifier                   = "notification-canada-ca-${var.env}-instance-${count.index}"
   cluster_identifier           = aws_rds_cluster.notification-canada-ca.id
   instance_class               = var.rds_instance_type
-  ca_cert_identifier           = var.env == "production" ? "rds-ca-2019" : "rds-ca-rsa2048-g1"
+  ca_cert_identifier           = var.env == "production" ? "rds-ca-2019" : "rds-ca-rsa4096-g1"
   db_subnet_group_name         = aws_db_subnet_group.notification-canada-ca.name
   engine                       = aws_rds_cluster.notification-canada-ca.engine
   engine_version               = aws_rds_cluster.notification-canada-ca.engine_version


### PR DESCRIPTION
# Summary | Résumé

Setting RDS certificates to 4096 bit encryption. Also setting blazer DB to 4096.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/303

# Test instructions | Instructions pour tester la modification

Soak test while merging. Perf test once complete

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.