### PR TITLE
Fix / Increase cloudformation timeout

### DIFF
--- a/aws/quicksight/dataset_sms_usage_notifications.tf
+++ b/aws/quicksight/dataset_sms_usage_notifications.tf
@@ -3,6 +3,13 @@
 # Ref: https://github.com/hashicorp/terraform-provider-aws/issues/34199
 
 resource "aws_cloudformation_stack" "sms-usage-notifications" {
+
+  timeouts {
+    create = "2h"
+    update = "2h"
+    delete = "20m"
+  }
+
   name              = "sms-usage-notifications"
   notification_arns = ["arn:aws:sns:ca-central-1:${var.account_id}:aws-controltower-SecurityNotifications"]
 


### PR DESCRIPTION
# Summary | Résumé

increase timeout for the `sms-usage-notifications` cloudformation resource. The dataset takes about 45 minutes to build on production but the default timeout is 30 minutes.

I tried to add a filter to the `notifications` logical table in the cloudformation script but kept getting a syntax error that I could not diagnose 😞 So Plan B is trying to increase the timeout.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/309
* 

# Release Instructions | Instructions pour le déploiement

verify that the terragrunt apply runs and the dataset gets built.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.