### PR TITLE
feat: add RDS cluster activity stream

### DIFF
--- a/aws/rds/rds_activity_stream.tf
+++ b/aws/rds/rds_activity_stream.tf
@@ -1,0 +1,10 @@
+module "rds_activity_stream" {
+  source = "github.com/cds-snc/terraform-modules//rds_activity_stream?ref=v9.3.0"
+
+  rds_stream_name = "notification-canada-ca-${var.env}-cluster-activity-stream"
+  rds_cluster_arn = aws_rds_cluster.notification-canada-ca.arn
+
+  activity_log_retention_days = 7
+
+  billing_tag_value = "notification-canada-ca-${var.env}"
+}

--- a/aws/rds/rds_activity_stream.tf
+++ b/aws/rds/rds_activity_stream.tf
@@ -1,7 +1,11 @@
+#
+# Creates an RDS activity stream for the cluster and stores its events
+# in an S3 bucket for 7 days.
+#
 module "rds_activity_stream" {
-  source = "github.com/cds-snc/terraform-modules//rds_activity_stream?ref=v9.3.0"
+  source = "github.com/cds-snc/terraform-modules//rds_activity_stream?ref=v9.3.1"
 
-  rds_stream_name = "notification-canada-ca-${var.env}-cluster-activity-stream"
+  rds_stream_name = "notification-canada-ca-${var.env}-cluster"
   rds_cluster_arn = aws_rds_cluster.notification-canada-ca.arn
 
   activity_log_retention_days = 7

--- a/aws/rds/rds_activity_stream.tf
+++ b/aws/rds/rds_activity_stream.tf
@@ -1,6 +1,6 @@
 #
 # Creates an RDS activity stream for the cluster and stores its events
-# in an S3 bucket for 7 days.
+# in an S3 bucket for 4 days.
 #
 module "rds_activity_stream" {
   count = var.env != "production" ? 1 : 0 # Disable in prod until fully tested
@@ -10,7 +10,7 @@ module "rds_activity_stream" {
   rds_stream_name = "notification-canada-ca-${var.env}-cluster"
   rds_cluster_arn = aws_rds_cluster.notification-canada-ca.arn
 
-  activity_log_retention_days = 7
+  activity_log_retention_days = 4
 
   billing_tag_value = "notification-canada-ca-${var.env}"
 }

--- a/aws/rds/rds_activity_stream.tf
+++ b/aws/rds/rds_activity_stream.tf
@@ -3,6 +3,8 @@
 # in an S3 bucket for 7 days.
 #
 module "rds_activity_stream" {
+  count = var.env != "production" ? 1 : 0 # Disable in prod until fully tested
+
   source = "github.com/cds-snc/terraform-modules//rds_activity_stream?ref=v9.3.1"
 
   rds_stream_name = "notification-canada-ca-${var.env}-cluster"


### PR DESCRIPTION
# Summary | Résumé
Add an async RDS cluster activity stream.  This will write the database activity events to an S3 bucket, where they will be available for audting and alerting for 4 days.

The async mode of the activity stream will prioritize database performance and the stream will start during the next maintenance window.

## Related Issues | Cartes liées

- https://github.com/cds-snc/platform-core-services/issues/508
- https://github.com/cds-snc/terraform-modules/pull/448
- https://github.com/cds-snc/notification-adr/pull/63

# Test instructions | Instructions pour tester la modification

After a database restart (manual or the next maintenance window):

1. Confirm that `notification-canada-ca-staging-cluster-decrypt-activity` Lambda function is being invoked with no error.
2. Confirm that the `notification-canada-ca-staging-cluster-activity-${suffix}` bucket contains event logs and no `processing-errors` folder.

# Release Instructions | Instructions pour le déploiement
## Security concern
The activity logs in the S3 bucket will potentially contain sensitive plaintext data.  The following mitigations should be put in place:
1. Restrict access to the S3 bucket.
2. Monitor query log data in Staging to determine the sensitive data being logged.
3. Add logic to the Kinesis Firehose Lambda processing function to redact sensitive data from the logs.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.