### PR TITLE
Creating new subnets for eks with larger pools.

### DIFF
--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -10,6 +10,11 @@ output "vpc_private_subnets" {
   value = aws_subnet.notification-canada-ca-private.*.id
 }
 
+output "vpc_private_subnets_new" {
+  value = aws_subnet.notification-canada-ca-private-new.*.id
+}
+
+
 output "vpc_public_subnets" {
   value = aws_subnet.notification-canada-ca-public.*.id
 }

--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -10,8 +10,8 @@ output "vpc_private_subnets" {
   value = aws_subnet.notification-canada-ca-private.*.id
 }
 
-output "vpc_private_subnets_new" {
-  value = aws_subnet.notification-canada-ca-private-new.*.id
+output "vpc_private_subnets_k8s" {
+  value = aws_subnet.notification-canada-ca-private-k8s.*.id
 }
 
 

--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -25,6 +25,7 @@ resource "aws_s3_bucket" "csv_bucket" {
 
   #tfsec:ignore:AWS077 - Versioning is not enabled
   logging {
+    target_prefix = var.env
     target_bucket = module.csv_bucket_logs.s3_bucket_id
   }
 
@@ -155,6 +156,7 @@ resource "aws_s3_bucket" "document_bucket" {
 
   #tfsec:ignore:AWS077 - Versioning is not enabled
   logging {
+    target_prefix = var.env
     target_bucket = module.document_download_logs.s3_bucket_id
   }
 
@@ -188,6 +190,7 @@ resource "aws_s3_bucket" "scan_files_document_bucket" {
 
   #tfsec:ignore:AWS077 - Versioning is not enabled
   logging {
+    target_prefix = var.env
     target_bucket = module.document_download_logs.s3_bucket_id
   }
 
@@ -329,6 +332,7 @@ resource "aws_s3_bucket" "athena_bucket" {
 
   #tfsec:ignore:AWS077 - Versioning is not enabled
   logging {
+    target_prefix = var.env
     target_bucket = module.athena_logs_bucket.s3_bucket_id
   }
 

--- a/aws/common/vpc.tf
+++ b/aws/common/vpc.tf
@@ -53,7 +53,7 @@ resource "aws_eip" "notification-canada-ca-natgw" {
   }
 }
 
-resource "aws_eip" "notification-canada-ca-natgw-new" {
+resource "aws_eip" "notification-canada-ca-natgw-k8s" {
   count      = 3
   depends_on = [aws_internet_gateway.notification-canada-ca]
 
@@ -78,11 +78,11 @@ resource "aws_nat_gateway" "notification-canada-ca" {
   }
 }
 
-resource "aws_nat_gateway" "notification-canada-ca-new" {
+resource "aws_nat_gateway" "notification-canada-ca-k8s" {
   count      = 3
   depends_on = [aws_internet_gateway.notification-canada-ca]
 
-  allocation_id = aws_eip.notification-canada-ca-natgw-new.*.id[count.index]
+  allocation_id = aws_eip.notification-canada-ca-natgw-k8s.*.id[count.index]
   subnet_id     = aws_subnet.notification-canada-ca-public.*.id[count.index]
 
   tags = {
@@ -129,7 +129,7 @@ resource "aws_subnet" "notification-canada-ca-public" {
   }
 }
 
-resource "aws_subnet" "notification-canada-ca-private-new" {
+resource "aws_subnet" "notification-canada-ca-private-k8s" {
   count = 3
 
   vpc_id            = aws_vpc.notification-canada-ca.id
@@ -194,14 +194,14 @@ resource "aws_route_table_association" "notification-canada-ca-private" {
   route_table_id = aws_route_table.notification-canada-ca-private_subnet.*.id[count.index]
 }
 
-resource "aws_route_table" "notification-canada-ca-private_subnet_new" {
+resource "aws_route_table" "notification-canada-ca-private_subnet_k8s" {
   count = 3
 
   vpc_id = aws_vpc.notification-canada-ca.id
 
   route {
     cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.notification-canada-ca-new.*.id[count.index]
+    nat_gateway_id = aws_nat_gateway.notification-canada-ca-k8s.*.id[count.index]
   }
 
   tags = {
@@ -210,11 +210,11 @@ resource "aws_route_table" "notification-canada-ca-private_subnet_new" {
   }
 }
 
-resource "aws_route_table_association" "notification-canada-ca-private-new" {
+resource "aws_route_table_association" "notification-canada-ca-private-k8s" {
   count = 3
 
-  subnet_id      = aws_subnet.notification-canada-ca-private-new.*.id[count.index]
-  route_table_id = aws_route_table.notification-canada-ca-private_subnet_new.*.id[count.index]
+  subnet_id      = aws_subnet.notification-canada-ca-private-k8s.*.id[count.index]
+  route_table_id = aws_route_table.notification-canada-ca-private_subnet_k8s.*.id[count.index]
 }
 
 ###

--- a/aws/common/vpc.tf
+++ b/aws/common/vpc.tf
@@ -205,7 +205,7 @@ resource "aws_route_table" "notification-canada-ca-private_subnet_k8s" {
   }
 
   tags = {
-    Name       = "Private Subnet Route Table ${count.index}"
+    Name       = "Private Subnet Route Table ${count.index + 3}"
     CostCenter = "notification-canada-ca-${var.env}"
   }
 }

--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -93,11 +93,11 @@ resource "aws_eks_node_group" "notification-canada-ca-eks-node-group" {
   }
 }
 
-resource "aws_eks_node_group" "notification-canada-ca-eks-node-group-new" {
+resource "aws_eks_node_group" "notification-canada-ca-eks-node-group-k8s" {
   cluster_name         = aws_eks_cluster.notification-canada-ca-eks-cluster.name
-  node_group_name      = "notification-canada-ca-${var.env}-eks-primary-node-group-new"
+  node_group_name      = "notification-canada-ca-${var.env}-eks-primary-node-group-k8s"
   node_role_arn        = aws_iam_role.eks-worker-role.arn
-  subnet_ids           = var.vpc_private_subnets_new
+  subnet_ids           = var.vpc_private_subnets_k8s
   force_update_version = var.force_upgrade
 
   disk_size = 80
@@ -136,7 +136,7 @@ resource "aws_eks_node_group" "notification-canada-ca-eks-secondary-node-group" 
   cluster_name         = aws_eks_cluster.notification-canada-ca-eks-cluster.name
   node_group_name      = "notification-canada-ca-${var.env}-eks-secondary-node-group"
   node_role_arn        = aws_iam_role.eks-worker-role.arn
-  subnet_ids           = var.vpc_private_subnets
+  subnet_ids           = var.vpc_private_subnets_k8s
   force_update_version = var.force_upgrade
 
   disk_size = 80

--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -93,6 +93,44 @@ resource "aws_eks_node_group" "notification-canada-ca-eks-node-group" {
   }
 }
 
+resource "aws_eks_node_group" "notification-canada-ca-eks-node-group-new" {
+  cluster_name         = aws_eks_cluster.notification-canada-ca-eks-cluster.name
+  node_group_name      = "notification-canada-ca-${var.env}-eks-primary-node-group-new"
+  node_role_arn        = aws_iam_role.eks-worker-role.arn
+  subnet_ids           = var.vpc_private_subnets_new
+  force_update_version = var.force_upgrade
+
+  disk_size = 80
+
+  release_version = var.eks_node_ami_version
+  instance_types  = var.primary_worker_instance_types
+
+  scaling_config {
+    desired_size = var.primary_worker_desired_size
+    max_size     = var.primary_worker_max_size
+    min_size     = var.primary_worker_min_size
+  }
+
+  update_config {
+    max_unavailable = 1
+  }
+
+  # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.
+  # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
+  depends_on = [
+    aws_iam_role_policy_attachment.eks-worker-AWSLoadBalancerControllerIAMPolicy,
+    aws_iam_role_policy_attachment.eks-worker-AmazonEC2ContainerRegistryReadOnly,
+    aws_iam_role_policy_attachment.eks-worker-AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.eks-worker-AmazonEKS_CNI_Policy
+  ]
+
+  tags = {
+    Name                     = "notification-canada-ca"
+    CostCenter               = "notification-canada-ca-${var.env}"
+    "karpenter.sh/discovery" = aws_eks_cluster.notification-canada-ca-eks-cluster.name
+  }
+}
+
 resource "aws_eks_node_group" "notification-canada-ca-eks-secondary-node-group" {
   count                = var.node_upgrade ? 1 : 0
   cluster_name         = aws_eks_cluster.notification-canada-ca-eks-cluster.name

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -32,7 +32,7 @@ variable "vpc_private_subnets" {
   type = list(any)
 }
 
-variable "vpc_private_subnets_new" {
+variable "vpc_private_subnets_k8s" {
   type = list(any)
 }
 

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -32,6 +32,10 @@ variable "vpc_private_subnets" {
   type = list(any)
 }
 
+variable "vpc_private_subnets_new" {
+  type = list(any)
+}
+
 variable "vpc_public_subnets" {
   type = list(any)
 }

--- a/env/dev/eks/terragrunt.hcl
+++ b/env/dev/eks/terragrunt.hcl
@@ -76,6 +76,7 @@ inputs = {
   primary_worker_min_size                   = 1
   vpc_id                                    = dependency.common.outputs.vpc_id
   vpc_private_subnets                       = dependency.common.outputs.vpc_private_subnets
+  vpc_private_subnets_new                   = dependency.common.outputs.vpc_private_subnets_new
   vpc_public_subnets                        = dependency.common.outputs.vpc_public_subnets
   sns_alert_warning_arn                     = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                    = dependency.common.outputs.sns_alert_critical_arn

--- a/env/dev/eks/terragrunt.hcl
+++ b/env/dev/eks/terragrunt.hcl
@@ -15,6 +15,11 @@ dependency "common" {
       "subnet-08de34a9e1a7458dc",
       "subnet-0af8b8402f1d605ff",
     ]
+    vpc_private_subnets_new = [
+      "subnet-001e585d12cce4d1e",
+      "subnet-08de34a9e1a7458dc",
+      "subnet-0af8b8402f1d605ff",
+    ]        
     vpc_public_subnets = [
       "subnet-0cecd9e634daf82d3",
       "subnet-0c7d18c0c51b28b61",

--- a/env/dev/eks/terragrunt.hcl
+++ b/env/dev/eks/terragrunt.hcl
@@ -15,7 +15,7 @@ dependency "common" {
       "subnet-08de34a9e1a7458dc",
       "subnet-0af8b8402f1d605ff",
     ]
-    vpc_private_subnets_new = [
+    vpc_private_subnets_k8s = [
       "subnet-001e585d12cce4d1e",
       "subnet-08de34a9e1a7458dc",
       "subnet-0af8b8402f1d605ff",
@@ -81,7 +81,7 @@ inputs = {
   primary_worker_min_size                   = 1
   vpc_id                                    = dependency.common.outputs.vpc_id
   vpc_private_subnets                       = dependency.common.outputs.vpc_private_subnets
-  vpc_private_subnets_new                   = dependency.common.outputs.vpc_private_subnets_new
+  vpc_private_subnets_k8s                   = dependency.common.outputs.vpc_private_subnets_k8s
   vpc_public_subnets                        = dependency.common.outputs.vpc_public_subnets
   sns_alert_warning_arn                     = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                    = dependency.common.outputs.sns_alert_critical_arn

--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -14,7 +14,7 @@ dependency "common" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
-    vpc_private_subnets_new = [
+    vpc_private_subnets_k8s = [
       "subnet-001e585d12cce4d1e",
       "subnet-08de34a9e1a7458dc",
       "subnet-0af8b8402f1d605ff",
@@ -72,7 +72,7 @@ inputs = {
   vpc_id                                    = dependency.common.outputs.vpc_id
   vpc_private_subnets                       = dependency.common.outputs.vpc_private_subnets
   vpc_public_subnets                        = dependency.common.outputs.vpc_public_subnets
-  vpc_private_subnets_new                   = dependency.common.outputs.vpc_private_subnets_new
+  vpc_private_subnets_k8s                   = dependency.common.outputs.vpc_private_subnets_k8s
   sns_alert_warning_arn                     = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                    = dependency.common.outputs.sns_alert_critical_arn
   sns_alert_general_arn                     = dependency.common.outputs.sns_alert_general_arn

--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -67,6 +67,7 @@ inputs = {
   vpc_id                                    = dependency.common.outputs.vpc_id
   vpc_private_subnets                       = dependency.common.outputs.vpc_private_subnets
   vpc_public_subnets                        = dependency.common.outputs.vpc_public_subnets
+  vpc_private_subnets_new                   = dependency.common.outputs.vpc_private_subnets_new
   sns_alert_warning_arn                     = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                    = dependency.common.outputs.sns_alert_critical_arn
   sns_alert_general_arn                     = dependency.common.outputs.sns_alert_general_arn

--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -14,6 +14,11 @@ dependency "common" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
+    vpc_private_subnets_new = [
+      "subnet-001e585d12cce4d1e",
+      "subnet-08de34a9e1a7458dc",
+      "subnet-0af8b8402f1d605ff",
+    ]        
     ip_blocklist_arn                          = ""
     re_admin_arn                              = ""
     re_api_arn                                = ""

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -15,6 +15,11 @@ dependency "common" {
       "subnet-08de34a9e1a7458dc",
       "subnet-0af8b8402f1d605ff",
     ]
+    vpc_private_subnets_new = [
+      "subnet-001e585d12cce4d1e",
+      "subnet-08de34a9e1a7458dc",
+      "subnet-0af8b8402f1d605ff",
+    ]    
     vpc_public_subnets = [
       "subnet-0cecd9e634daf82d3",
       "subnet-0c7d18c0c51b28b61",

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -15,7 +15,7 @@ dependency "common" {
       "subnet-08de34a9e1a7458dc",
       "subnet-0af8b8402f1d605ff",
     ]
-    vpc_private_subnets_new = [
+    vpc_private_subnets_k8s = [
       "subnet-001e585d12cce4d1e",
       "subnet-08de34a9e1a7458dc",
       "subnet-0af8b8402f1d605ff",
@@ -89,7 +89,7 @@ inputs = {
   vpc_id                                    = dependency.common.outputs.vpc_id
   vpc_private_subnets                       = dependency.common.outputs.vpc_private_subnets
   vpc_public_subnets                        = dependency.common.outputs.vpc_public_subnets
-  vpc_private_subnets_new                   = dependency.common.outputs.vpc_private_subnets_new
+  vpc_private_subnets_k8s                   = dependency.common.outputs.vpc_private_subnets_k8s
   sns_alert_warning_arn                     = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                    = dependency.common.outputs.sns_alert_critical_arn
   sns_alert_general_arn                     = dependency.common.outputs.sns_alert_general_arn

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -84,6 +84,7 @@ inputs = {
   vpc_id                                    = dependency.common.outputs.vpc_id
   vpc_private_subnets                       = dependency.common.outputs.vpc_private_subnets
   vpc_public_subnets                        = dependency.common.outputs.vpc_public_subnets
+  vpc_private_subnets_new                   = dependency.common.outputs.vpc_private_subnets_new
   sns_alert_warning_arn                     = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                    = dependency.common.outputs.sns_alert_critical_arn
   sns_alert_general_arn                     = dependency.common.outputs.sns_alert_general_arn


### PR DESCRIPTION
# Summary | Résumé

This will create new private subnets for our EKS cluster nodes with larger address pools (8192 address vs 255). 

It will also create a new EKS node group attached to these subnets.

Once this is done, we will have to migrate our workload over to the new nodes, and then create a new PR to delete the old nodes and subnets. 

## Related Issues | Cartes liées

- https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/322

# Test instructions | Instructions pour tester la modification

Terraform apply works

# Release Instructions | Instructions pour le déploiement

1. Release to staging/production
2. kubectl cordon -l eks.amazonaws.com/nodegroup=notification-canada-ca-<environment>-eks-primary-node-group
3. kubectl drain -l eks.amazonaws.com/nodegroup=notification-canada-ca-dev-eks-primary-node-group --ignore-daemonsets --delete-emptydir-data
4. Create new PR deleting old node group and subnets

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.