### PR TITLE
github arc runner update

### DIFF
--- a/aws/ecr/github-runner/Dockerfile
+++ b/aws/ecr/github-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/actions/actions-runner:2.313.0
+FROM ghcr.io/actions/actions-runner:2.315.0
 USER root
 
 RUN apt update


### PR DESCRIPTION
# Summary | Résumé

This will update the github arc runner to the latest version. This is required as the version we were previously using (only two minor versions back) was deprecated.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/324

# Test instructions | Instructions pour tester la modification

Terraform apply works

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.