### PR TITLE
Adding alarms for github arc runner failures

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -938,3 +938,19 @@ resource "aws_cloudwatch_metric_alarm" "aggregating-queues-not-active-5-minutes-
   alarm_actions       = [var.sns_alert_critical_arn]
   ok_actions          = [var.sns_alert_critical_arn]
 }
+
+resource "aws_cloudwatch_metric_alarm" "github-arc-runner-write-alarm" {
+  count               = var.cloudwatch_enabled ? 1 : 0
+  alarm_name          = "github-arc-runner-write-alarm"
+  alarm_description   = "GitHub ARC Runners Are Failing - Check Version Deprecation"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.github-arc-write-alarm[0].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.github-arc-write-alarm[0].metric_transformation[0].namespace
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [var.sns_alert_critical_arn]
+  ok_actions          = [var.sns_alert_critical_arn]
+}

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -166,3 +166,16 @@ resource "aws_cloudwatch_log_metric_filter" "aggregating-queues-are-active" {
     value     = "1"
   }
 }
+
+resource "aws_cloudwatch_log_metric_filter" "github-arc-write-alarm" {
+  count          = var.cloudwatch_enabled ? 1 : 0
+  name           = "GitHub ARC Runners Write Alarm"
+  pattern        = "WRITE ERROR: An error occured:"
+  log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs[0].name
+
+  metric_transformation {
+    name      = "aggregating-github-arc-write-alarm"
+    namespace = "LogMetrics"
+    value     = "1"
+  }
+}


### PR DESCRIPTION
# Summary | Résumé

This will trigger an alarm when github actions runners fail due to deprecated versions.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/324

# Test instructions | Instructions pour tester la modification

Terraform apply works - if we want to test the alarm, we can break the github actions runners by going back to a deprecated version

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.