### PR TITLE
fix: increase RDS activity stream decrypt Lambda resources

### DIFF
--- a/aws/rds/rds_activity_stream.tf
+++ b/aws/rds/rds_activity_stream.tf
@@ -5,7 +5,7 @@
 module "rds_activity_stream" {
   count = var.env != "production" ? 1 : 0 # Disable in prod until fully tested
 
-  source = "github.com/cds-snc/terraform-modules//rds_activity_stream?ref=4db411b499072d93ab28deb229ef9292dd4fccfa"
+  source = "github.com/cds-snc/terraform-modules//rds_activity_stream?ref=v9.3.5"
 
   rds_stream_name = "notification-canada-ca-${var.env}-cluster"
   rds_cluster_arn = aws_rds_cluster.notification-canada-ca.arn

--- a/aws/rds/rds_activity_stream.tf
+++ b/aws/rds/rds_activity_stream.tf
@@ -1,16 +1,20 @@
 #
 # Creates an RDS activity stream for the cluster and stores its events
-# in an S3 bucket for 4 days.
+# in an S3 bucket for 3 days.
 #
 module "rds_activity_stream" {
   count = var.env != "production" ? 1 : 0 # Disable in prod until fully tested
 
-  source = "github.com/cds-snc/terraform-modules//rds_activity_stream?ref=v9.3.1"
+  source = "github.com/cds-snc/terraform-modules//rds_activity_stream?ref=v9.3.4"
 
   rds_stream_name = "notification-canada-ca-${var.env}-cluster"
   rds_cluster_arn = aws_rds_cluster.notification-canada-ca.arn
 
-  activity_log_retention_days = 4
+  # Increase these if the volume of database activity events is causing the lambda to timeout
+  decrypt_lambda_memory_size = 1024
+  decrypt_lambda_timeout     = 10
+
+  activity_log_retention_days = 3
 
   billing_tag_value = "notification-canada-ca-${var.env}"
 }

--- a/aws/rds/rds_activity_stream.tf
+++ b/aws/rds/rds_activity_stream.tf
@@ -5,7 +5,7 @@
 module "rds_activity_stream" {
   count = var.env != "production" ? 1 : 0 # Disable in prod until fully tested
 
-  source = "github.com/cds-snc/terraform-modules//rds_activity_stream?ref=v9.3.4"
+  source = "github.com/cds-snc/terraform-modules//rds_activity_stream?ref=4db411b499072d93ab28deb229ef9292dd4fccfa"
 
   rds_stream_name = "notification-canada-ca-${var.env}-cluster"
   rds_cluster_arn = aws_rds_cluster.notification-canada-ca.arn


### PR DESCRIPTION
# Summary
Update the TF module version to increase timeout and memory available to the decrypt Lambda function.  This will allow it to keep up with the heavier load of the database.

Update the lifecycle policy on the activity log bucket to only keep query logs for 3 days as this is the policy used by services with more stringent data retention requirements.

# Related
- https://github.com/cds-snc/platform-core-services/issues/508