### PR TITLE
Removing old node group

### DIFF
--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -55,44 +55,6 @@ resource "aws_eks_cluster" "notification-canada-ca-eks-cluster" {
 # AWS EKS Nodegroup configuration
 ###
 
-resource "aws_eks_node_group" "notification-canada-ca-eks-node-group" {
-  cluster_name         = aws_eks_cluster.notification-canada-ca-eks-cluster.name
-  node_group_name      = "notification-canada-ca-${var.env}-eks-primary-node-group"
-  node_role_arn        = aws_iam_role.eks-worker-role.arn
-  subnet_ids           = var.vpc_private_subnets
-  force_update_version = var.force_upgrade
-
-  disk_size = 80
-
-  release_version = var.eks_node_ami_version
-  instance_types  = var.primary_worker_instance_types
-
-  scaling_config {
-    desired_size = var.primary_worker_desired_size
-    max_size     = var.primary_worker_max_size
-    min_size     = var.primary_worker_min_size
-  }
-
-  update_config {
-    max_unavailable = 1
-  }
-
-  # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.
-  # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
-  depends_on = [
-    aws_iam_role_policy_attachment.eks-worker-AWSLoadBalancerControllerIAMPolicy,
-    aws_iam_role_policy_attachment.eks-worker-AmazonEC2ContainerRegistryReadOnly,
-    aws_iam_role_policy_attachment.eks-worker-AmazonEKSWorkerNodePolicy,
-    aws_iam_role_policy_attachment.eks-worker-AmazonEKS_CNI_Policy
-  ]
-
-  tags = {
-    Name                     = "notification-canada-ca"
-    CostCenter               = "notification-canada-ca-${var.env}"
-    "karpenter.sh/discovery" = aws_eks_cluster.notification-canada-ca-eks-cluster.name
-  }
-}
-
 resource "aws_eks_node_group" "notification-canada-ca-eks-node-group-k8s" {
   cluster_name         = aws_eks_cluster.notification-canada-ca-eks-cluster.name
   node_group_name      = "notification-canada-ca-${var.env}-eks-primary-node-group-k8s"


### PR DESCRIPTION
# Summary | Résumé

Removing old unused K8s node group in favour of the recently released new node group on the new subnets.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/322

# Test instructions | Instructions pour tester la modification

Applied in dev, TF apply in staging

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.