### PR TITLE
chore: update to latest Sentinel Forwarder module

### DIFF
--- a/aws/eks/sentinel.tf
+++ b/aws/eks/sentinel.tf
@@ -9,11 +9,11 @@ locals {
 # and https://docs.google.com/document/d/16LLelZ7WEKrnbocrl0Az74JqkCv5DBZ9QILRBUFJQt8/edit#heading=h.z87ipkd84djw
 module "sentinel_forwarder" {
   count             = var.enable_sentinel_forwarding ? 1 : 0
-  source            = "github.com/cds-snc/terraform-modules//sentinel_forwarder?ref=v4.0.3"
+  source            = "github.com/cds-snc/terraform-modules//sentinel_forwarder?ref=v9.3.8"
   function_name     = "sentinel-cloud-watch-forwarder"
   billing_tag_value = "notification-canada-ca-${var.env}"
 
-  layer_arn = "arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:37"
+  layer_arn = "arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:125"
 
   customer_id = var.sentinel_customer_id
   shared_key  = var.sentinel_shared_key


### PR DESCRIPTION
# Summary
Update to the Terraform Sentinel Forwarder module that does not store its authentication credentials as Lambda env vars.

## Related Issues | Cartes liées

- https://github.com/cds-snc/platform-core-services/issues/557
- https://github.com/cds-snc/site-reliability-engineering/issues/1215

# Test instructions | Instructions pour tester la modification

1. After merging, connect to the Client VPN.
1. After ~5 minutes check the CloudWatch logs for `sentinel-cloud-watch-forwarder`.  Expect to see an invocation with an `INFO` log showing a successful response from Sentinel.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.