### PR TITLE
Docker Build and Push for Github ARC Runner

### DIFF
--- a/.github/workflows/build_github_arc_docker_staging.yml
+++ b/.github/workflows/build_github_arc_docker_staging.yml
@@ -1,0 +1,74 @@
+name: "Build and Push Github ARC Image"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "aws/ecr/github-runner/**"
+
+env:
+  AWS_REGION: ca-central-1
+  DOCKER_ORG:  ${{ secrets.STAGING_ECR_URL }}
+  DOCKER_SLUG: ${{ secrets.STAGING_ECR_URL }}/notify/github_arc_runner
+  WORKFLOW_PAT: ${{ secrets.WORKFLOW_GITHUB_PAT }}
+
+permissions:
+  id-token: write   # This is required for requesting the OIDC JWT
+  contents: read    # This is required for actions/checkout
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Build and push
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Install AWS CLI
+      run: |
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+        unzip -q awscliv2.zip
+        sudo ./aws/install --update
+        aws --version
+
+    - name: Configure credentials to CDS public ECR using OIDC
+      uses: aws-actions/configure-aws-credentials@master
+      with:
+        role-to-assume: arn:aws:iam::${{ secrets.STAGING_ACCOUNT_ID }}:role/github_docker_push
+        role-session-name: NotifyTerraformGitHubActions
+        aws-region: "us-east-1"
+  
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v2
+
+    - name: Set INFRASTRUCTURE_VERSION
+      run: |
+        INFRASTRUCTURE_VERSION=`cat ./.github/workflows/infrastructure_version.txt`
+        echo "INFRASTRUCTURE_VERSION=$INFRASTRUCTURE_VERSION" >> $GITHUB_ENV
+
+    - name: Build
+      run: |
+        docker build \
+        -t $DOCKER_SLUG:$INFRASTRUCTURE_VERSION \
+        -t $DOCKER_SLUG:latest \
+        -f aws/ecr/github-runner/Dockerfile . 
+
+    - name: Publish
+      run: |
+        docker push $DOCKER_SLUG:latest && docker push $DOCKER_SLUG:$INFRASTRUCTURE_VERSION
+
+# TODO: Helmfile rollout
+
+    - name: Generate docker SBOM
+      uses: cds-snc/security-tools/.github/actions/generate-sbom@eecd7a02a0294b379411c126b61e5c29e253676a # v2.1.4
+      with:
+        docker_image: "${{ env.DOCKER_SLUG }}:latest"
+        dockerfile_path: "ci/Dockerfile"
+        sbom_name: "notification-github-runner"
+        token: "${{ secrets.GITHUB_TOKEN }}"
+
+    - name: Notify Slack channel if this job failed
+      if: ${{ failure() }}
+      run: |
+        json="{'text':'<!here> Docker Build for Github ARC is failing in <https://github.com/cds-snc/notification-terraform/actions/runs/${GITHUB_RUN_ID}|notification-terraform> !'}"
+        curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/build_github_arc_docker_staging.yml
+++ b/.github/workflows/build_github_arc_docker_staging.yml
@@ -1,6 +1,7 @@
 name: "Build and Push Github ARC Image"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/build_github_arc_docker_staging.yml
+++ b/.github/workflows/build_github_arc_docker_staging.yml
@@ -24,19 +24,12 @@ jobs:
     name: Build and push
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-    - name: Install AWS CLI
-      run: |
-        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-        unzip -q awscliv2.zip
-        sudo ./aws/install --update
-        aws --version
-
+    
     - name: Configure credentials to CDS public ECR using OIDC
       uses: aws-actions/configure-aws-credentials@master
       with:
         role-to-assume: arn:aws:iam::${{ secrets.STAGING_ACCOUNT_ID }}:role/github_docker_push
         role-session-name: NotifyTerraformGitHubActions
-        aws-region: "us-east-1"
   
     - name: Login to Amazon ECR
       id: login-ecr

--- a/aws/ecr/iam.tf
+++ b/aws/ecr/iam.tf
@@ -46,8 +46,13 @@ resource "aws_iam_role_policy" "github_docker_push" {
               "ecr:BatchCheckLayerAvailability",
               "ecr:PutImage"
           ],
-          "Resource": "*"
-      }
+          "Resource": "arn:aws:ecr:${var.region}:${var.account_id}:repository/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "ecr:GetAuthorizationToken",
+            "Resource": "*"
+        }
   ]
 }
 POLICY

--- a/aws/ecr/iam.tf
+++ b/aws/ecr/iam.tf
@@ -1,0 +1,54 @@
+resource "aws_iam_role" "github_docker_push" {
+  name = "github_docker_push"
+
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  assume_role_policy = <<ROLE
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Sid": "",
+          "Effect": "Allow",
+          "Principal": {
+              "Federated": "arn:aws:iam::283582579564:oidc-provider/token.actions.githubusercontent.com"
+          },
+          "Action": "sts:AssumeRoleWithWebIdentity",
+          "Condition": {
+              "StringLike": {
+                  "token.actions.githubusercontent.com:sub": "repo:cds-snc/notification-terraform:ref:refs/heads/main"
+              }
+          }
+      }
+  ]
+}
+ROLE
+
+}
+
+resource "aws_iam_role_policy" "github_docker_push" {
+  name = "github_docker_push"
+  role = aws_iam_role.github_docker_push.id
+
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Effect": "Allow",
+          "Action": [
+              "ecr:CompleteLayerUpload",
+              "ecr:GetAuthorizationToken",
+              "ecr:UploadLayerPart",
+              "ecr:InitiateLayerUpload",
+              "ecr:BatchCheckLayerAvailability",
+              "ecr:PutImage"
+          ],
+          "Resource": "*"
+      }
+  ]
+}
+POLICY
+}

--- a/aws/ecr/iam.tf
+++ b/aws/ecr/iam.tf
@@ -1,34 +1,24 @@
-resource "aws_iam_role" "github_docker_push" {
-  name = "github_docker_push"
-
-  # Terraform's "jsonencode" function converts a
-  # Terraform expression result to valid JSON syntax.
-  assume_role_policy = <<ROLE
-{
-  "Version": "2012-10-17",
-  "Statement": [
-      {
-          "Sid": "",
-          "Effect": "Allow",
-          "Principal": {
-              "Federated": "arn:aws:iam::283582579564:oidc-provider/token.actions.githubusercontent.com"
-          },
-          "Action": "sts:AssumeRoleWithWebIdentity",
-          "Condition": {
-              "StringLike": {
-                  "token.actions.githubusercontent.com:sub": "repo:cds-snc/notification-terraform:ref:refs/heads/main"
-              }
-          }
-      }
+module "oidc" {
+  source            = "github.com/cds-snc/terraform-modules?ref=v2.0.1//gh_oidc_role"
+  billing_tag_key   = "CostCentre"
+  billing_tag_value = "notification-canada-ca-${var.env}"
+  oidc_exists       = true
+  roles = [
+    {
+      name : "github_docker_push"
+      repo_name : "notification-terraform"
+      claim : "ref:refs/heads/main"
+    }
   ]
 }
-ROLE
 
-}
 
 resource "aws_iam_role_policy" "github_docker_push" {
+
+  depends_on = [module.oidc]
+
   name = "github_docker_push"
-  role = aws_iam_role.github_docker_push.id
+  role = "github_docker_push"
 
   # Terraform's "jsonencode" function converts a
   # Terraform expression result to valid JSON syntax.
@@ -57,3 +47,5 @@ resource "aws_iam_role_policy" "github_docker_push" {
 }
 POLICY
 }
+
+


### PR DESCRIPTION
# Summary | Résumé

This will build, tag, and push the github arc runner in staging... I think... I need this in so that I can test the workflow.


## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/324

# Test instructions | Instructions pour tester la modification

I'll be running manual dispatch runs once this is merged to main.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.