### PR TITLE
Docker ARC GHA Take 2

### DIFF
--- a/.github/workflows/build_github_arc_docker_staging.yml
+++ b/.github/workflows/build_github_arc_docker_staging.yml
@@ -30,7 +30,7 @@ jobs:
       with:
         role-to-assume: arn:aws:iam::${{ secrets.STAGING_ACCOUNT_ID }}:role/github_docker_push
         role-session-name: NotifyTerraformGitHubActions
-        region: us-east-1
+        aws-region: us-east-1
   
     - name: Login to Amazon ECR
       id: login-ecr

--- a/.github/workflows/build_github_arc_docker_staging.yml
+++ b/.github/workflows/build_github_arc_docker_staging.yml
@@ -30,6 +30,7 @@ jobs:
       with:
         role-to-assume: arn:aws:iam::${{ secrets.STAGING_ACCOUNT_ID }}:role/github_docker_push
         role-session-name: NotifyTerraformGitHubActions
+        region: us-east-1
   
     - name: Login to Amazon ECR
       id: login-ecr

--- a/.github/workflows/build_github_arc_docker_staging.yml
+++ b/.github/workflows/build_github_arc_docker_staging.yml
@@ -30,7 +30,7 @@ jobs:
       with:
         role-to-assume: arn:aws:iam::${{ secrets.STAGING_ACCOUNT_ID }}:role/github_docker_push
         role-session-name: NotifyTerraformGitHubActions
-        aws-region: us-east-1
+        aws-region: ca-central-1
   
     - name: Login to Amazon ECR
       id: login-ecr

--- a/.github/workflows/build_github_arc_docker_staging.yml
+++ b/.github/workflows/build_github_arc_docker_staging.yml
@@ -66,4 +66,4 @@ jobs:
       if: ${{ failure() }}
       run: |
         json="{'text':'<!here> Docker Build for Github ARC is failing in <https://github.com/cds-snc/notification-terraform/actions/runs/${GITHUB_RUN_ID}|notification-terraform> !'}"
-        curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}
+        curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.GHA_FAIL_SLACK_WEBHOOK }}

--- a/aws/ecr/iam.tf
+++ b/aws/ecr/iam.tf
@@ -7,7 +7,7 @@ module "oidc" {
     {
       name : "github_docker_push"
       repo_name : "notification-terraform"
-      claim : "ref:refs/heads/main"
+      claim : "ref:refs/heads/*"
     }
   ]
 }
@@ -34,7 +34,8 @@ resource "aws_iam_role_policy" "github_docker_push" {
               "ecr:UploadLayerPart",
               "ecr:InitiateLayerUpload",
               "ecr:BatchCheckLayerAvailability",
-              "ecr:PutImage"
+              "ecr:PutImage",
+              "ecr:BatchGetImage"
           ],
           "Resource": "arn:aws:ecr:${var.region}:${var.account_id}:repository/*"
         },


### PR DESCRIPTION
# Summary | Résumé

Made some progress on getting the GHA to work. This should at least build and push the image. 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/324

# Test instructions | Instructions pour tester la modification

Run the docker build push for ARC

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.