### PR TITLE
feat: enable pgAudit in non-prod environments

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,8 +5,8 @@
     "context": "..",
     "args": {
       "AWS_CLI_VERSION": "2.2.29",
-      "TERRAFORM_VERSION": "1.1.5",
-      "TERRAGRUNT_VERSION": "0.36.1"
+      "TERRAFORM_VERSION": "1.6.2",
+      "TERRAGRUNT_VERSION": "0.44.4"
     }
   },
   "containerEnv": {

--- a/aws/.checkov.yml
+++ b/aws/.checkov.yml
@@ -11,6 +11,7 @@ skip-check:
   - CKV_AWS_144 # S3 cross-region replication no required
   - CKV_AWS_145 # S3 default service key encryption is acceptable
   - CKV_AWS_149 # SecretsManager default service key encryption is acceptable
+  - CKV_AWS_158 # CloudWatch log group default service key encryption is acceptable
   - CKV_AWS_162 # RDS IAM authentication will not be used
   - CKV_AWS_173 # Lambda env var default service key encryption is acceptable
   - CKV2_AWS_5  # Security groups are attached in seperate Terragrunt modules

--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -77,6 +77,59 @@ resource "aws_rds_cluster_parameter_group" "default" {
   }
 }
 
+#
+# Dedicated pgAudit parameter group to avoid impacting production while
+# this is tested.
+#
+resource "aws_rds_cluster_parameter_group" "pgaudit" {
+  name        = "rds-cluster-pg-audit"
+  family      = "aurora-postgresql15"
+  description = "RDS customized cluster parameter group that enables pgAudit"
+
+  parameter {
+    name  = "log_min_error_statement"
+    value = "NOTICE"
+  }
+
+  parameter {
+    name  = "log_connections"
+    value = "1"
+  }
+
+  parameter {
+    name  = "log_disconnections"
+    value = "1"
+  }
+
+  parameter {
+    name         = "shared_preload_libraries"
+    value        = "pgaudit,pg_stat_statements"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "pgaudit.log"
+    value        = "read,role,write,ddl"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "rds.logical_replication"
+    value        = "1"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "rds.log_retention_period"
+    value        = "1440" # 1 day (in minutes)
+    apply_method = "pending-reboot"
+  }
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}
+
 resource "aws_rds_cluster" "notification-canada-ca" {
   cluster_identifier           = "notification-canada-ca-${var.env}-cluster"
   engine                       = "aurora-postgresql"
@@ -90,9 +143,11 @@ resource "aws_rds_cluster" "notification-canada-ca" {
   preferred_maintenance_window = "wed:04:00-wed:04:30"
   db_subnet_group_name         = aws_db_subnet_group.notification-canada-ca.name
   #tfsec:ignore:AWS051 - database is encrypted without a custom key and that's fine
-  storage_encrypted               = true
-  deletion_protection             = var.enable_delete_protection
-  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.default.name
+  storage_encrypted   = true
+  deletion_protection = var.enable_delete_protection
+
+  db_cluster_parameter_group_name = var.env != "production" ? aws_rds_cluster_parameter_group.pgaudit.name : aws_rds_cluster_parameter_group.default.name
+  enabled_cloudwatch_logs_exports = var.env != "production" ? ["postgresql"] : null
 
   vpc_security_group_ids = [
     var.eks_cluster_securitygroup
@@ -106,6 +161,17 @@ resource "aws_rds_cluster" "notification-canada-ca" {
       engine_version
     ]
   }
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}
+
+# Holds the exported postgresql logs
+resource "aws_cloudwatch_log_group" "logs_exports" {
+  count             = var.env != "production" ? 1 : 0
+  name              = "/aws/rds/cluster/notification-canada-ca-${var.env}-cluster/postgresql"
+  retention_in_days = 3
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"

--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -169,8 +169,9 @@ resource "aws_rds_cluster" "notification-canada-ca" {
 
 # Holds the exported postgresql logs
 resource "aws_cloudwatch_log_group" "logs_exports" {
-  count             = var.env != "production" ? 1 : 0
-  name              = "/aws/rds/cluster/notification-canada-ca-${var.env}-cluster/postgresql"
+  count = var.env != "production" ? 1 : 0
+  name  = "/aws/rds/cluster/notification-canada-ca-${var.env}-cluster/postgresql"
+  #checkov:skip=CKV_AWS_338:The short retention is required to respect Notify's privacy policy
   retention_in_days = 3
 
   tags = {


### PR DESCRIPTION
# Summary
Add a new RDS cluster parameter group that enables the pgAudit extension. Additionally, export these logs to a CloudWatch log group with a 3 day retention period to respect Notify's privacy policy.

Also updates the devcontainer Terraform versions to match the GitHub workflows.

⚠️ `Note` these changes will only be applied to non-production environments so they can be properly tested.

## Related Issues | Cartes liées

- https://github.com/cds-snc/platform-core-services/issues/508

# Test instructions | Instructions pour tester la modification

After release and restarting all database instances, confirm that pgAudit logs are being published to the following log group:
```
/aws/rds/cluster/notification-canada-ca-staging-cluster/postgresql
```

# Release Instructions | Instructions pour le déploiement

Restart each database instance in the cluster to apply the new cluster parameter group changes.  This can be done with the following command:
```sh
aws rds reboot-db-instance \
  --db-instance-identifier notification-canada-ca-staging-instance-$NUM
```

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.