### PR TITLE
Allowing manual runs of TF staging

### DIFF
--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -1,6 +1,7 @@
 name: "Terragrunt plan STAGING"
 
 on:
+  workflow_dispatch: 
   pull_request:
     paths:
       - ".env"


### PR DESCRIPTION
# Summary | Résumé

Doing some testing of Github Actions and 1Password integration. I want to be able to manually trigger workflow runs in the future so I don't have to do a PR for every change (you can trigger against a branch).

## Related Issues | Cartes liées

FRIDAY FUNSIES

# Test instructions | Instructions pour tester la modification

No changes

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.