### PR TITLE
feat: send potentially dangerous queries to Sentinel

### DIFF
--- a/aws/eks/sentinel.tf
+++ b/aws/eks/sentinel.tf
@@ -2,6 +2,10 @@ locals {
   application_log_group_arn = "arn:aws:logs:${var.region}:${var.account_id}:log-group:${local.eks_application_log_group}"
   client_vpn_log_group_arn  = "arn:aws:logs:${var.region}:${var.account_id}:log-group:${module.vpn.client_vpn_cloudwatch_log_group_name}"
   blazer_log_group_arn      = "arn:aws:logs:${var.region}:${var.account_id}:log-group:blazer"
+  postgresql_log_group_arn  = "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws/rds/cluster/notification-canada-ca-${var.env}-cluster/postgresql"
+
+  postgres_dangerous_queries       = ["ALTER", "CREATE", "DELETE", "DROP", "GRANT", "REVOKE", "TRUNCATE"]
+  postgres_dangerous_queries_lower = formatlist(lower("%s"), local.postgres_dangerous_queries)
 }
 
 # The sentinel_forwarder module fails to Terraform apply if the layer_arn being used is not the most recently published layer version
@@ -21,7 +25,8 @@ module "sentinel_forwarder" {
   cloudwatch_log_arns = [
     local.application_log_group_arn,
     local.blazer_log_group_arn,
-    local.client_vpn_log_group_arn
+    local.client_vpn_log_group_arn,
+    local.postgresql_log_group_arn
   ]
 }
 
@@ -49,6 +54,15 @@ resource "aws_cloudwatch_log_subscription_filter" "client_vpn_connections" {
   name            = "Client VPN connections"
   log_group_name  = module.vpn.client_vpn_cloudwatch_log_group_name
   filter_pattern  = "[w1=\"*\"]" # All logs
+  destination_arn = module.sentinel_forwarder[0].lambda_arn
+  distribution    = "Random"
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "postgresql_dangerous_queries" {
+  count           = var.enable_sentinel_forwarding ? 1 : 0
+  name            = "Postgresql dangerous queries"
+  log_group_name  = local.postgresql_log_group_arn
+  filter_pattern  = "[(w1=\"*${join("*\" || w1=\"*", concat(local.postgres_dangerous_queries, local.postgres_dangerous_queries_lower))}*\")]"
   destination_arn = module.sentinel_forwarder[0].lambda_arn
   distribution    = "Random"
 }

--- a/aws/eks/sentinel.tf
+++ b/aws/eks/sentinel.tf
@@ -5,7 +5,7 @@ locals {
   postgresql_log_group_arn  = "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws/rds/cluster/notification-canada-ca-${var.env}-cluster/postgresql"
 
   postgres_dangerous_queries       = ["ALTER", "CREATE", "DELETE", "DROP", "GRANT", "REVOKE", "TRUNCATE"]
-  postgres_dangerous_queries_lower = formatlist(lower("%s"), local.postgres_dangerous_queries)
+  postgres_dangerous_queries_lower = [for sql in local.postgres_dangerous_queries : lower(sql)]
 }
 
 # The sentinel_forwarder module fails to Terraform apply if the layer_arn being used is not the most recently published layer version

--- a/aws/rds/sentinel.tf
+++ b/aws/rds/sentinel.tf
@@ -4,13 +4,13 @@ locals {
 }
 
 resource "aws_lambda_permission" "sentinel_forwarder_cloudwatch_log_subscription" {
-    count = var.sentinel_forwarder_cloudwatch_lambda_name != null && var.env != "production" ? 1 : 0
+  count = var.sentinel_forwarder_cloudwatch_lambda_name != null && var.env != "production" ? 1 : 0
 
-    action        = "lambda:InvokeFunction"
-    function_name = var.sentinel_forwarder_cloudwatch_lambda_name
-    principal     = "logs.${var.region}.amazonaws.com"
-    source_arn    = "${aws_cloudwatch_log_group.logs_exports.arn}:*"
-    statement_id  = "AllowExecutionFromCloudWatchLogs-sentinel-cloud-watch-forwarder-postgres"
+  action        = "lambda:InvokeFunction"
+  function_name = var.sentinel_forwarder_cloudwatch_lambda_name
+  principal     = "logs.${var.region}.amazonaws.com"
+  source_arn    = "${aws_cloudwatch_log_group.logs_exports.arn}:*"
+  statement_id  = "AllowExecutionFromCloudWatchLogs-sentinel-cloud-watch-forwarder-postgres"
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "postgresql_dangerous_queries" {

--- a/aws/rds/sentinel.tf
+++ b/aws/rds/sentinel.tf
@@ -9,7 +9,7 @@ resource "aws_lambda_permission" "sentinel_forwarder_cloudwatch_log_subscription
   action        = "lambda:InvokeFunction"
   function_name = var.sentinel_forwarder_cloudwatch_lambda_name
   principal     = "logs.${var.region}.amazonaws.com"
-  source_arn    = "${aws_cloudwatch_log_group.logs_exports.arn}:*"
+  source_arn    = "${aws_cloudwatch_log_group.logs_exports[0].arn}:*"
   statement_id  = "AllowExecutionFromCloudWatchLogs-sentinel-cloud-watch-forwarder-postgres"
 }
 
@@ -17,7 +17,7 @@ resource "aws_cloudwatch_log_subscription_filter" "postgresql_dangerous_queries"
   count = var.sentinel_forwarder_cloudwatch_lambda_name != null && var.env != "production" ? 1 : 0
 
   name            = "Postgresql dangerous queries"
-  log_group_name  = aws_cloudwatch_log_group.logs_exports.arn
+  log_group_name  = aws_cloudwatch_log_group.logs_exports[0].arn
   filter_pattern  = "[(w1=\"*${join("*\" || w1=\"*", concat(local.postgres_dangerous_queries, local.postgres_dangerous_queries_lower))}*\")]"
   destination_arn = var.sentinel_forwarder_cloudwatch_lambda_arn
   distribution    = "Random"

--- a/aws/rds/sentinel.tf
+++ b/aws/rds/sentinel.tf
@@ -1,0 +1,24 @@
+locals {
+  postgres_dangerous_queries       = ["ALTER", "CREATE", "DELETE", "DROP", "GRANT", "REVOKE", "TRUNCATE"]
+  postgres_dangerous_queries_lower = [for sql in local.postgres_dangerous_queries : lower(sql)]
+}
+
+resource "aws_lambda_permission" "sentinel_forwarder_cloudwatch_log_subscription" {
+    count = var.sentinel_forwarder_cloudwatch_lambda_name != null && var.env != "production" ? 1 : 0
+
+    action        = "lambda:InvokeFunction"
+    function_name = var.sentinel_forwarder_cloudwatch_lambda_name
+    principal     = "logs.${var.region}.amazonaws.com"
+    source_arn    = "${aws_cloudwatch_log_group.logs_exports.arn}:*"
+    statement_id  = "AllowExecutionFromCloudWatchLogs-sentinel-cloud-watch-forwarder-postgres"
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "postgresql_dangerous_queries" {
+  count = var.sentinel_forwarder_cloudwatch_lambda_name != null && var.env != "production" ? 1 : 0
+
+  name            = "Postgresql dangerous queries"
+  log_group_name  = aws_cloudwatch_log_group.logs_exports.arn
+  filter_pattern  = "[(w1=\"*${join("*\" || w1=\"*", concat(local.postgres_dangerous_queries, local.postgres_dangerous_queries_lower))}*\")]"
+  destination_arn = var.sentinel_forwarder_cloudwatch_lambda_arn
+  distribution    = "Random"
+}

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -42,5 +42,14 @@ variable "enable_delete_protection" {
 variable "rds_database_name" {
   type        = string
   description = "Set the name of the database"
+}
 
+variable "sentinel_forwarder_cloudwatch_lambda_name" {
+  type        = string
+  description = "Name of the Sentinel forwarder lambda function."
+}
+
+variable "sentinel_forwarder_cloudwatch_lambda_arn" {
+  type        = string
+  description = "ARN of the Sentinel forwarder lambda function."
 }

--- a/env/dev/rds/terragrunt.hcl
+++ b/env/dev/rds/terragrunt.hcl
@@ -26,7 +26,9 @@ dependency "eks" {
   # module hasn't been applied yet.
   mock_outputs_allowed_terraform_commands = ["validate"]
   mock_outputs = {
-    eks-cluster-securitygroup = "sg-0e2c3ef6c5c75b74c"
+    eks-cluster-securitygroup                 = "sg-0e2c3ef6c5c75b74c"
+    sentinel_forwarder_cloudwatch_lambda_arn  = "arn:aws:lambda:ca-central-1:123456789012:function:sentinel-cloud-watch-forwarder"
+    sentinel_forwarder_cloudwatch_lambda_name = "sentinel-cloud-watch-forwarder"
   }
 }
 
@@ -42,6 +44,9 @@ inputs = {
   vpc_private_subnets       = dependency.common.outputs.vpc_private_subnets
   sns_alert_general_arn     = dependency.common.outputs.sns_alert_general_arn
   rds_database_name         = "notificationcanadacadev"
+
+  sentinel_forwarder_cloudwatch_lambda_arn  = dependency.eks.outputs.sentinel_forwarder_cloudwatch_lambda_arn
+  sentinel_forwarder_cloudwatch_lambda_name = dependency.eks.outputs.sentinel_forwarder_cloudwatch_lambda_name
 }
 
 terraform {

--- a/env/production/rds/terragrunt.hcl
+++ b/env/production/rds/terragrunt.hcl
@@ -26,4 +26,7 @@ inputs = {
   vpc_private_subnets       = dependency.common.outputs.vpc_private_subnets
   sns_alert_general_arn     = dependency.common.outputs.sns_alert_general_arn
   rds_database_name         = "NotificationCanadaCaproduction"
+
+  sentinel_forwarder_cloudwatch_lambda_arn  = dependency.eks.outputs.sentinel_forwarder_cloudwatch_lambda_arn
+  sentinel_forwarder_cloudwatch_lambda_name = dependency.eks.outputs.sentinel_forwarder_cloudwatch_lambda_name
 }

--- a/env/staging/rds/terragrunt.hcl
+++ b/env/staging/rds/terragrunt.hcl
@@ -26,7 +26,9 @@ dependency "eks" {
   # module hasn't been applied yet.
   mock_outputs_allowed_terraform_commands = ["validate"]
   mock_outputs = {
-    eks-cluster-securitygroup = "sg-0e2c3ef6c5c75b74c"
+    eks-cluster-securitygroup                 = "sg-0e2c3ef6c5c75b74c"
+    sentinel_forwarder_cloudwatch_lambda_arn  = "arn:aws:lambda:ca-central-1:123456789012:function:sentinel-cloud-watch-forwarder"
+    sentinel_forwarder_cloudwatch_lambda_name = "sentinel-cloud-watch-forwarder"
   }
 }
 
@@ -41,7 +43,10 @@ inputs = {
   rds_instance_type         = "db.r6g.large"
   vpc_private_subnets       = dependency.common.outputs.vpc_private_subnets
   sns_alert_general_arn     = dependency.common.outputs.sns_alert_general_arn
-  rds_database_name = "NotificationCanadaCastaging"
+  rds_database_name         = "NotificationCanadaCastaging"
+
+  sentinel_forwarder_cloudwatch_lambda_arn  = dependency.eks.outputs.sentinel_forwarder_cloudwatch_lambda_arn
+  sentinel_forwarder_cloudwatch_lambda_name = dependency.eks.outputs.sentinel_forwarder_cloudwatch_lambda_name
 }
 
 terraform {


### PR DESCRIPTION
# Summary
Update the Sentinel forwarder to send potentially dangerous SQL queries.  These will be used to create alarms.

## Related Issues | Cartes liées

- https://github.com/cds-snc/platform-core-services/issues/508

# Test instructions | Instructions pour tester la modification

After merging, test that log events with one of the keywords in the `postgres_dangerous_queries` list are forwarded to Sentinel.

# Release Instructions | Instructions pour le déploiement

This needs to wait until `pgAudit` has been enabled in Production before being merged.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.