### PR TITLE
Adding base domain and region to secrets

### DIFF
--- a/aws/eks/secrets.tf
+++ b/aws/eks/secrets.tf
@@ -34,3 +34,21 @@ resource "aws_secretsmanager_secret_version" "pr_bot_installation_id" {
   secret_string = var.pr_bot_installation_id
 }
 
+resource "aws_secretsmanager_secret" "base_domain" {
+  name = "BASE_DOMAIN"
+}
+
+resource "aws_secretsmanager_secret_version" "base_domain" {
+  secret_id     = aws_secretsmanager_secret.base_domain.id
+  secret_string = var.base_domain
+}
+
+resource "aws_secretsmanager_secret" "aws_region" {
+  name = "AWS_REGION"
+}
+
+resource "aws_secretsmanager_secret_version" "aws_region" {
+  secret_id     = aws_secretsmanager_secret.aws_region.id
+  secret_string = var.region
+}
+

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -290,3 +290,12 @@ variable "pr_bot_installation_id" {
   sensitive   = true
 }
 
+variable "base_domain" {
+  type        = string
+  description = "The base domain for the environment"
+}
+
+variable "region" {
+  type        = string
+  description = "The AWS region"
+}

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -294,8 +294,3 @@ variable "base_domain" {
   type        = string
   description = "The base domain for the environment"
 }
-
-variable "region" {
-  type        = string
-  description = "The AWS region"
-}


### PR DESCRIPTION
# Summary | Résumé

Required for the helmfile work - the base domain and region are set as secrets.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/339

# Test instructions | Instructions pour tester la modification

- TF Apply Works
- Notify Helm Chart PR works

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.