### PR TITLE
Adding target group secrets

### DIFF
--- a/aws/eks/secrets.tf
+++ b/aws/eks/secrets.tf
@@ -52,3 +52,38 @@ resource "aws_secretsmanager_secret_version" "aws_region" {
   secret_string = var.region
 }
 
+resource "aws_secretsmanager_secret" "admin_target_group_arn" {
+  name = "ADMIN_TARGET_GROUP_ARN"
+}
+
+resource "aws_secretsmanager_secret_version" "admin_target_group_arn" {
+  secret_id     = aws_secretsmanager_secret.admin_target_group_arn.id
+  secret_string = aws_alb_target_group.notification-canada-ca-admin.arn
+}
+
+resource "aws_secretsmanager_secret" "api_target_group_arn" {
+  name = "API_TARGET_GROUP_ARN"
+}
+
+resource "aws_secretsmanager_secret_version" "api_target_group_arn" {
+  secret_id     = aws_secretsmanager_secret.api_target_group_arn.id
+  secret_string = aws_alb_target_group.notification-canada-ca-api.arn
+}
+
+resource "aws_secretsmanager_secret" "documentation_target_group_arn" {
+  name = "DOCUMENTATION_TARGET_GROUP_ARN"
+}
+
+resource "aws_secretsmanager_secret_version" "documentation_target_group_arn" {
+  secret_id     = aws_secretsmanager_secret.documentation_target_group_arn.id
+  secret_string = aws_alb_target_group.notification-canada-ca-documentation.arn
+}
+
+resource "aws_secretsmanager_secret" "document_download_api_target_group_arn" {
+  name = "DOCUMENT_DOWNLOAD_API_TARGET_GROUP_ARN"
+}
+
+resource "aws_secretsmanager_secret_version" "document_download_api_target_group_arn" {
+  secret_id     = aws_secretsmanager_secret.document_download_api_target_group_arn.id
+  secret_string = aws_alb_target_group.notification-canada-ca-document-api.arn
+}


### PR DESCRIPTION
# Summary | Résumé

Needed target group ARNs as well for helmfile diff.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/339

# Test instructions | Instructions pour tester la modification

Helmfile diff should work on notify-helm-chart pr

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.