### PR TITLE
Moving VPN to EKS Folder

### DIFF
--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -188,10 +188,10 @@ output "sqs_deliver_receipts_queue_arn" {
   value = aws_sqs_queue.eks_notification_canada_cadelivery_receipts.arn
 }
 
-output "client_vpn_cloudwatch_log_group_name" {
-  value = module.vpn.client_vpn_cloudwatch_log_group_name
+output "subnet_ids" {
+  value = concat(aws_subnet.notification-canada-ca-private[*].id, aws_subnet.notification-canada-ca-private-k8s.*.id)
 }
 
-output "client_vpn_security_group_id" {
-  value = module.vpn.client_vpn_security_group_id
+output "subnet_cidr_blocks" {
+  value = concat(aws_subnet.notification-canada-ca-private[*].cidr_block, aws_subnet.notification-canada-ca-private-k8s.*.cidr_block)
 }

--- a/aws/common/variables.tf
+++ b/aws/common/variables.tf
@@ -262,24 +262,6 @@ variable "eks_cluster_name" {
   type        = string
 }
 
-variable "client_vpn_access_group_id" {
-  description = "IAM Identity Center group ID that will be allowed access to the VPN."
-  type        = string
-  sensitive   = true
-}
-
-variable "client_vpn_saml_metadata" {
-  description = "IAM Identity Center application SAML metadata.  Users that want to connect to the VPN must be granted access to this app."
-  type        = string
-  sensitive   = true
-}
-
-variable "client_vpn_self_service_saml_metadata" {
-  description = "IAM Identity Center self-service application SAML metadata.  This allows users to download the VPN client and configuration."
-  type        = string
-  sensitive   = true
-}
-
 variable "account_budget_limit" {
   description = "The dollar amount in USD that this AWS account should be budgeted to"
   type        = number
@@ -297,4 +279,9 @@ variable "budget_sre_bot_webhook" {
   description = "Slack webhook used to post budget alerts to the SRE bot"
   type        = string
   sensitive   = true
+}
+
+variable "vpc_cidr_block" {
+  description = "CIDR block for the VPC"
+  type        = string
 }

--- a/aws/common/variables.tf
+++ b/aws/common/variables.tf
@@ -284,4 +284,5 @@ variable "budget_sre_bot_webhook" {
 variable "vpc_cidr_block" {
   description = "CIDR block for the VPC"
   type        = string
+  default     = "10.0.0.0/16"
 }

--- a/aws/common/vpc.tf
+++ b/aws/common/vpc.tf
@@ -7,7 +7,7 @@ data "aws_availability_zones" "available" {
 }
 
 resource "aws_vpc" "notification-canada-ca" {
-  cidr_block           = "var.vpc_cidr_block"
+  cidr_block           = var.vpc_cidr_block
   enable_dns_hostnames = true
 
   tags = {
@@ -101,7 +101,7 @@ resource "aws_subnet" "notification-canada-ca-private" {
   count = 3
 
   vpc_id            = aws_vpc.notification-canada-ca.id
-  cidr_block        = cidrsubnet("var.vpc_cidr_block", 8, count.index)
+  cidr_block        = cidrsubnet(var.vpc_cidr_block, 8, count.index)
   availability_zone = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
@@ -118,7 +118,7 @@ resource "aws_subnet" "notification-canada-ca-public" {
   count = 3
 
   vpc_id            = aws_vpc.notification-canada-ca.id
-  cidr_block        = cidrsubnet("var.vpc_cidr_block", 8, count.index + 3)
+  cidr_block        = cidrsubnet(var.vpc_cidr_block, 8, count.index + 3)
   availability_zone = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
@@ -133,7 +133,7 @@ resource "aws_subnet" "notification-canada-ca-private-k8s" {
   count = 3
 
   vpc_id            = aws_vpc.notification-canada-ca.id
-  cidr_block        = cidrsubnet("var.vpc_cidr_block", 3, count.index + 1)
+  cidr_block        = cidrsubnet(var.vpc_cidr_block, 3, count.index + 1)
   availability_zone = element(data.aws_availability_zones.available.names, count.index + 1)
 
   tags = {

--- a/aws/common/vpc.tf
+++ b/aws/common/vpc.tf
@@ -7,7 +7,7 @@ data "aws_availability_zones" "available" {
 }
 
 resource "aws_vpc" "notification-canada-ca" {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = "var.vpc_cidr_block"
   enable_dns_hostnames = true
 
   tags = {
@@ -101,7 +101,7 @@ resource "aws_subnet" "notification-canada-ca-private" {
   count = 3
 
   vpc_id            = aws_vpc.notification-canada-ca.id
-  cidr_block        = cidrsubnet("10.0.0.0/16", 8, count.index)
+  cidr_block        = cidrsubnet("var.vpc_cidr_block", 8, count.index)
   availability_zone = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
@@ -118,7 +118,7 @@ resource "aws_subnet" "notification-canada-ca-public" {
   count = 3
 
   vpc_id            = aws_vpc.notification-canada-ca.id
-  cidr_block        = cidrsubnet("10.0.0.0/16", 8, count.index + 3)
+  cidr_block        = cidrsubnet("var.vpc_cidr_block", 8, count.index + 3)
   availability_zone = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
@@ -133,7 +133,7 @@ resource "aws_subnet" "notification-canada-ca-private-k8s" {
   count = 3
 
   vpc_id            = aws_vpc.notification-canada-ca.id
-  cidr_block        = cidrsubnet("10.0.0.0/16", 3, count.index + 1)
+  cidr_block        = cidrsubnet("var.vpc_cidr_block", 3, count.index + 1)
   availability_zone = element(data.aws_availability_zones.available.names, count.index + 1)
 
   tags = {

--- a/aws/eks/securitygroups.tf
+++ b/aws/eks/securitygroups.tf
@@ -359,7 +359,7 @@ resource "aws_security_group_rule" "client-vpn-ingress-database" {
   from_port                = 5432
   to_port                  = 5432
   protocol                 = "tcp"
-  source_security_group_id = var.client_vpn_security_group_id
+  source_security_group_id = module.vpn.client_vpn_security_group_id
   security_group_id        = data.aws_security_group.eks-securitygroup-rds.id
 }
 
@@ -369,7 +369,7 @@ resource "aws_security_group_rule" "client-vpn-ingress-redis" {
   from_port                = 6379
   to_port                  = 6379
   protocol                 = "tcp"
-  source_security_group_id = var.client_vpn_security_group_id
+  source_security_group_id = module.vpn.client_vpn_security_group_id
   security_group_id        = data.aws_security_group.eks-securitygroup-rds.id
 }
 

--- a/aws/eks/sentinel.tf
+++ b/aws/eks/sentinel.tf
@@ -1,6 +1,6 @@
 locals {
   application_log_group_arn = "arn:aws:logs:${var.region}:${var.account_id}:log-group:${local.eks_application_log_group}"
-  client_vpn_log_group_arn  = "arn:aws:logs:${var.region}:${var.account_id}:log-group:${var.client_vpn_cloudwatch_log_group_name}"
+  client_vpn_log_group_arn  = "arn:aws:logs:${var.region}:${var.account_id}:log-group:${module.vpn.client_vpn_cloudwatch_log_group_name}"
   blazer_log_group_arn      = "arn:aws:logs:${var.region}:${var.account_id}:log-group:blazer"
 }
 
@@ -47,7 +47,7 @@ resource "aws_cloudwatch_log_subscription_filter" "blazer_logging" {
 resource "aws_cloudwatch_log_subscription_filter" "client_vpn_connections" {
   count           = var.enable_sentinel_forwarding ? 1 : 0
   name            = "Client VPN connections"
-  log_group_name  = var.client_vpn_cloudwatch_log_group_name
+  log_group_name  = module.vpn.client_vpn_cloudwatch_log_group_name
   filter_pattern  = "[w1=\"*\"]" # All logs
   destination_arn = module.sentinel_forwarder[0].lambda_arn
   distribution    = "Random"

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -303,6 +303,7 @@ variable "client_vpn_access_group_id" {
 variable "vpc_cidr_block" {
   type        = string
   description = "The CIDR block for the VPC"
+  default     = "10.0.0.0/16"
 }
 
 variable "subnet_cidr_blocks" {

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -236,16 +236,6 @@ variable "celery_queue_prefix" {
   description = "Celery queue prefix"
 }
 
-variable "client_vpn_cloudwatch_log_group_name" {
-  type        = string
-  description = "Client VPN CloudWatch log group name. This is used by the Sentinel forwarder to send logs to Sentinel."
-}
-
-variable "client_vpn_security_group_id" {
-  type        = string
-  description = "Client VPN security group ID"
-}
-
 variable "eks_addon_ebs_driver_version" {
   type        = string
   description = "Version for EBS driver addon for EKS (Persistence)"
@@ -293,4 +283,34 @@ variable "pr_bot_installation_id" {
 variable "base_domain" {
   type        = string
   description = "The base domain for the environment"
+}
+
+variable "client_vpn_self_service_saml_metadata" {
+  type        = string
+  description = "The SAML metadata for the client VPN self service"
+}
+
+variable "client_vpn_saml_metadata" {
+  type        = string
+  description = "The SAML metadata for the client VPN"
+}
+
+variable "client_vpn_access_group_id" {
+  type        = string
+  description = "The access group ID for the client VPN"
+}
+
+variable "vpc_cidr_block" {
+  type        = string
+  description = "The CIDR block for the VPC"
+}
+
+variable "subnet_cidr_blocks" {
+  type        = list(string)
+  description = "The CIDR blocks for the subnets"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "The IDs for the subnets"
 }

--- a/aws/eks/vpn.tf
+++ b/aws/eks/vpn.tf
@@ -8,10 +8,10 @@ module "vpn" {
   endpoint_name   = "private-subnets"
   access_group_id = var.client_vpn_access_group_id
 
-  vpc_id              = aws_vpc.notification-canada-ca.id
-  vpc_cidr_block      = aws_vpc.notification-canada-ca.cidr_block
-  subnet_cidr_blocks  = aws_subnet.notification-canada-ca-private.*.cidr_block
-  subnet_ids          = aws_subnet.notification-canada-ca-private.*.id
+  vpc_id              = var.vpc_id
+  vpc_cidr_block      = var.vpc_cidr_block
+  subnet_cidr_blocks  = var.subnet_cidr_blocks
+  subnet_ids          = var.subnet_ids
   acm_certificate_arn = aws_acm_certificate.client_vpn.arn
 
   # Only create a self-service portal in prod  

--- a/env/dev/eks/terragrunt.hcl
+++ b/env/dev/eks/terragrunt.hcl
@@ -25,6 +25,11 @@ dependency "common" {
       "subnet-0c7d18c0c51b28b61",
       "subnet-0c91f7c6b8211904b",
     ]
+    subnet_ids = [
+      "subnet-0cecd9e634daf82d3",
+      "subnet-0c7d18c0c51b28b61",
+      "subnet-0c91f7c6b8211904b",
+    ]
     sns_alert_warning_arn                     = ""
     sns_alert_critical_arn                    = ""
     sns_alert_general_arn                     = ""
@@ -37,8 +42,6 @@ dependency "common" {
     notification_base_url_regex_arn           = ""
     private-links-vpc-endpoints-securitygroup = ""
     private-links-gateway-prefix-list-ids     = []
-    client_vpn_cloudwatch_log_group_name      = "/aws/vpc/client-vpn-endpoint-logs"
-    client_vpn_security_group_id              = "sg-1234"
   }
 }
 
@@ -107,11 +110,11 @@ inputs = {
   private-links-vpc-endpoints-securitygroup = dependency.common.outputs.private-links-vpc-endpoints-securitygroup
   private-links-gateway-prefix-list-ids     = dependency.common.outputs.private-links-gateway-prefix-list-ids
   celery_queue_prefix                       = "eks-notification-canada-ca"
-  client_vpn_cloudwatch_log_group_name      = dependency.common.outputs.client_vpn_cloudwatch_log_group_name
-  client_vpn_security_group_id              = dependency.common.outputs.client_vpn_security_group_id  
   internal_dns_certificate_arn              = dependency.dns.outputs.internal_dns_certificate_arn
   internal_dns_zone_id                      = dependency.dns.outputs.internal_dns_zone_id
   internal_dns_name                         = dependency.dns.outputs.internal_dns_name
+  subnet_ids                                = dependency.common.outputs.subnet_ids
+  subnet_cidr_blocks                        = dependency.common.outputs.subnet_cidr_blocks
   
 }
 

--- a/env/dev/eks/terragrunt.hcl
+++ b/env/dev/eks/terragrunt.hcl
@@ -30,6 +30,14 @@ dependency "common" {
       "subnet-0c7d18c0c51b28b61",
       "subnet-0c91f7c6b8211904b",
     ]
+    subnet_cidr_blocks = [
+      "10.0.0.0/24",
+      "10.0.1.0/24",
+      "10.0.2.0/24",
+      "10.0.32.0/19",
+      "10.0.64.0/19",
+      "10.0.96.0/19",
+    ]        
     sns_alert_warning_arn                     = ""
     sns_alert_critical_arn                    = ""
     sns_alert_general_arn                     = ""

--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -23,7 +23,25 @@ dependency "common" {
       "subnet-0cecd9e634daf82d3",
       "subnet-0c7d18c0c51b28b61",
       "subnet-0c91f7c6b8211904b",
-    ]        
+    ]   
+    vpc_private_subnets = [
+      "subnet-001e585d12cce4d1e",
+      "subnet-08de34a9e1a7458dc",
+      "subnet-0af8b8402f1d605ff",
+    ]
+    vpc_public_subnets = [
+      "subnet-0cecd9e634daf82d3",
+      "subnet-0c7d18c0c51b28b61",
+      "subnet-0c91f7c6b8211904b",
+    ]     
+    subnet_cidr_blocks = [
+      "10.0.0.0/24",
+      "10.0.1.0/24",
+      "10.0.2.0/24",
+      "10.0.32.0/19",
+      "10.0.64.0/19",
+      "10.0.96.0/19",
+    ]            
     ip_blocklist_arn                          = ""
     re_admin_arn                              = ""
     re_api_arn                                = ""

--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -18,6 +18,11 @@ dependency "common" {
       "subnet-001e585d12cce4d1e",
       "subnet-08de34a9e1a7458dc",
       "subnet-0af8b8402f1d605ff",
+    ]
+    subnet_ids = [
+      "subnet-0cecd9e634daf82d3",
+      "subnet-0c7d18c0c51b28b61",
+      "subnet-0c91f7c6b8211904b",
     ]        
     ip_blocklist_arn                          = ""
     re_admin_arn                              = ""
@@ -33,8 +38,6 @@ dependency "common" {
     sqs_send_sms_low_queue_name               = ""
     sqs_send_sms_medium_queue_name            = ""
     sqs_send_sms_high_queue_name              = ""
-    client_vpn_cloudwatch_log_group_name      = "/aws/vpc/client-vpn-endpoint-logs"
-    client_vpn_security_group_id              = "sg-1234"
   }
 }
 
@@ -103,10 +106,10 @@ inputs = {
   sqs_send_sms_medium_queue_name            = dependency.common.outputs.sqs_send_sms_medium_queue_name
   sqs_send_sms_high_queue_name              = dependency.common.outputs.sqs_send_sms_high_queue_name
   celery_queue_prefix                       = "eks-notification-canada-ca"
-  client_vpn_cloudwatch_log_group_name      = dependency.common.outputs.client_vpn_cloudwatch_log_group_name
-  client_vpn_security_group_id              = dependency.common.outputs.client_vpn_security_group_id  
   internal_dns_certificate_arn              = dependency.dns.outputs.internal_dns_certificate_arn
   internal_dns_zone_id                      = dependency.dns.outputs.internal_dns_zone_id
   internal_dns_name                         = dependency.dns.outputs.internal_dns_name
+  subnet_ids                                = dependency.common.outputs.subnet_ids
+  subnet_cidr_blocks                        = dependency.common.outputs.subnet_cidr_blocks
 
 }

--- a/env/scratch/eks/terragrunt.hcl
+++ b/env/scratch/eks/terragrunt.hcl
@@ -32,8 +32,6 @@ dependency "common" {
     notification_base_url_regex_arn           = ""
     private-links-vpc-endpoints-securitygroup = ""
     private-links-gateway-prefix-list-ids     = []
-    client_vpn_cloudwatch_log_group_name      = "/aws/vpc/client-vpn-endpoint-logs"
-    client_vpn_security_group_id              = "sg-1234"
   }
 }
 
@@ -85,8 +83,6 @@ inputs = {
   notification_base_url_regex_arn           = dependency.common.outputs.notification_base_url_regex_arn
   private-links-vpc-endpoints-securitygroup = dependency.common.outputs.private-links-vpc-endpoints-securitygroup
   private-links-gateway-prefix-list-ids     = dependency.common.outputs.private-links-gateway-prefix-list-ids
-  client_vpn_cloudwatch_log_group_name      = dependency.common.outputs.client_vpn_cloudwatch_log_group_name
-  client_vpn_security_group_id              = dependency.common.outputs.client_vpn_security_group_id  
 }
 
 terraform {

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -30,6 +30,14 @@ dependency "common" {
       "subnet-0c7d18c0c51b28b61",
       "subnet-0c91f7c6b8211904b",
     ]
+    subnet_cidr_blocks = [
+      "10.0.0.0/24",
+      "10.0.1.0/24",
+      "10.0.2.0/24",
+      "10.0.32.0/19",
+      "10.0.64.0/19",
+      "10.0.96.0/19",
+    ]    
     sns_alert_warning_arn                     = ""
     sns_alert_critical_arn                    = ""
     sns_alert_general_arn                     = ""

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -25,6 +25,11 @@ dependency "common" {
       "subnet-0c7d18c0c51b28b61",
       "subnet-0c91f7c6b8211904b",
     ]
+    subnet_ids = [
+      "subnet-0cecd9e634daf82d3",
+      "subnet-0c7d18c0c51b28b61",
+      "subnet-0c91f7c6b8211904b",
+    ]
     sns_alert_warning_arn                     = ""
     sns_alert_critical_arn                    = ""
     sns_alert_general_arn                     = ""
@@ -43,8 +48,6 @@ dependency "common" {
     sqs_send_sms_low_queue_name               = ""
     sqs_send_sms_medium_queue_name            = ""
     sqs_send_sms_high_queue_name              = ""
-    client_vpn_cloudwatch_log_group_name      = "/aws/vpc/client-vpn-endpoint-logs"
-    client_vpn_security_group_id              = "sg-1234"
   }
 }
 
@@ -119,12 +122,12 @@ inputs = {
   sqs_send_sms_low_queue_name               = dependency.common.outputs.sqs_send_sms_low_queue_name
   sqs_send_sms_medium_queue_name            = dependency.common.outputs.sqs_send_sms_medium_queue_name
   sqs_send_sms_high_queue_name              = dependency.common.outputs.sqs_send_sms_high_queue_name
-  celery_queue_prefix                       = "eks-notification-canada-ca"
-  client_vpn_cloudwatch_log_group_name      = dependency.common.outputs.client_vpn_cloudwatch_log_group_name
-  client_vpn_security_group_id              = dependency.common.outputs.client_vpn_security_group_id  
+  celery_queue_prefix                       = "eks-notification-canada-ca" 
   internal_dns_certificate_arn              = dependency.dns.outputs.internal_dns_certificate_arn
   internal_dns_zone_id                      = dependency.dns.outputs.internal_dns_zone_id
   internal_dns_name                         = dependency.dns.outputs.internal_dns_name
+  subnet_ids                                = dependency.common.outputs.subnet_ids
+  subnet_cidr_blocks                        = dependency.common.outputs.subnet_cidr_blocks  
 }
 
 


### PR DESCRIPTION
# Summary | Résumé

This is required for the BCP work - the VPN can't be created if the subnets don't already exists. There will be manual steps to migrate the VPN before merging this PR.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/318

# Test instructions | Instructions pour tester la modification

TF Apply works AFTER RELEASE INSTRUCTIONS

# Release Instructions | Instructions pour le déploiement

1. Clone this branch locally.
2. In Common:
```
terragrunt state pull > /var/tmp/common.tfstate
```
3. In EKS:
```
terragrunt state pull > /var/tmp/eks.tfstate
```
4. Open both files
5. Cut all resources under module.vpn from common.tfstate and paste them at the end of eks.tfstate
6. Cut the aws_acm_certificate client_vpn from common.tfstate and paste at the end of eks.tfstate
7. Cut the tls_self_signed_cert client_vpn from common.tfstate and paste at the end of eks.tfstate
8. Cut the tls_private_key client_vpn from common.tfstate and paste at the end of eks.tfstate

9. Increment the "Serial" field by 1 in both common and eks.tfstate
10. In Common:
```
terragrunt state push /var/tmp/common.tfstate
```
11. In EKS:
```
terragrunt state push /var/tmp/eks.tfstate
```
12. Re-run the terraform plan here to verify the changes

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.