### PR TITLE
fix/make bucket name shorter

### DIFF
--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -542,7 +542,7 @@ POLICY
 module "sns_sms_usage_report_sanitized_bucket" {
   source = "github.com/cds-snc/terraform-modules//S3?ref=v9.2.3"
 
-  bucket_name       = "notification-canada-ca-${var.env}-sms-usage-logs-sanitized"
+  bucket_name       = "notification-canada-ca-${var.env}-sms-usage-logs-san"
   force_destroy     = var.force_destroy_s3
   billing_tag_value = "notification-canada-ca-${var.env}"
 
@@ -559,7 +559,7 @@ module "sns_sms_usage_report_sanitized_bucket_us_west_2" {
 
   source = "github.com/cds-snc/terraform-modules//S3?ref=v9.2.3"
 
-  bucket_name       = "notification-canada-ca-${var.env}-sms-usage-west-2-logs-sanitized"
+  bucket_name       = "notification-canada-ca-${var.env}-sms-usage-west-2-logs-san"
   force_destroy     = var.force_destroy_s3
   billing_tag_value = "notification-canada-ca-${var.env}"
 


### PR DESCRIPTION
# Summary | Résumé

```
Error: expected length of bucket to be in the range (0 - 63), got notification-canada-ca-production-sms-usage-west-2-logs-sanitized
```

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.