### PR TITLE
Removing k8s subnets since it seems to break

### DIFF
--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -193,9 +193,9 @@ output "sqs_deliver_receipts_queue_arn" {
 }
 
 output "subnet_ids" {
-  value = concat(aws_subnet.notification-canada-ca-private[*].id, aws_subnet.notification-canada-ca-private-k8s.*.id)
+  value = aws_subnet.notification-canada-ca-private[*].id
 }
 
 output "subnet_cidr_blocks" {
-  value = concat(aws_subnet.notification-canada-ca-private[*].cidr_block, aws_subnet.notification-canada-ca-private-k8s.*.cidr_block)
+  value = aws_subnet.notification-canada-ca-private[*].cidr_block
 }


### PR DESCRIPTION
# Summary | Résumé

Removing k8s subnets from VPN peering since it seems to break and VPN works without them 🤷 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/318

# Test instructions | Instructions pour tester la modification

TF Plan should show no changes because I tested it on staging manually 

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.