### PR TITLE
chore: add Sentinel Forwarder lambda outputs

### DIFF
--- a/aws/eks/outputs.tf
+++ b/aws/eks/outputs.tf
@@ -89,3 +89,12 @@ output "karpenter_instance_profile" {
 output "quicksight_security_group_id" {
   value = aws_security_group.quicksight.id
 }
+
+# Sentinel
+output "sentinel_forwarder_cloudwatch_lambda_arn" {
+  value = length(module.sentinel_forwarder) != 0 ? module.sentinel_forwarder[0].lambda_arn : null
+}
+
+output "sentinel_forwarder_cloudwatch_lambda_name" {
+  value = length(module.sentinel_forwarder) != 0 ? module.sentinel_forwarder[0].lambda_name : null
+}

--- a/aws/eks/sentinel.tf
+++ b/aws/eks/sentinel.tf
@@ -9,7 +9,7 @@ locals {
 # and https://docs.google.com/document/d/16LLelZ7WEKrnbocrl0Az74JqkCv5DBZ9QILRBUFJQt8/edit#heading=h.z87ipkd84djw
 module "sentinel_forwarder" {
   count             = var.enable_sentinel_forwarding ? 1 : 0
-  source            = "github.com/cds-snc/terraform-modules//sentinel_forwarder?ref=v9.3.8"
+  source            = "github.com/cds-snc/terraform-modules//sentinel_forwarder?ref=v9.4.2"
   function_name     = "sentinel-cloud-watch-forwarder"
   billing_tag_value = "notification-canada-ca-${var.env}"
 


### PR DESCRIPTION
# Summary
Add outputs for the Sentinel Forwarder Lambda function's ARN and name. These will be used by other modules to process CloudWatch logs with the same function.

## Related Issues | Cartes liées

- https://github.com/cds-snc/platform-core-services/issues/508
- https://github.com/cds-snc/terraform-modules/pull/470
- https://github.com/cds-snc/notification-terraform/pull/1264

# Test instructions | Instructions pour tester la modification

After merging, check that the new outputs are available in the Terraform state.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.