### PR TITLE
fix: set log group name instead of ARN

### DIFF
--- a/aws/rds/sentinel.tf
+++ b/aws/rds/sentinel.tf
@@ -17,7 +17,7 @@ resource "aws_cloudwatch_log_subscription_filter" "postgresql_dangerous_queries"
   count = var.sentinel_forwarder_cloudwatch_lambda_name != null && var.env != "production" ? 1 : 0
 
   name            = "Postgresql dangerous queries"
-  log_group_name  = aws_cloudwatch_log_group.logs_exports[0].arn
+  log_group_name  = aws_cloudwatch_log_group.logs_exports[0].name
   filter_pattern  = "[(w1=\"*${join("*\" || w1=\"*", concat(local.postgres_dangerous_queries, local.postgres_dangerous_queries_lower))}*\")]"
   destination_arn = var.sentinel_forwarder_cloudwatch_lambda_arn
   distribution    = "Random"


### PR DESCRIPTION
# Summary
Update the Postgress CloudWatch log group filter to use the log group's name rather than the ARN.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-terraform/pull/1264
* https://github.com/cds-snc/platform-core-services/issues/508

# Test instructions | Instructions pour tester la modification

After merging, test that log events with one of the keywords in the postgres_dangerous_queries list are forwarded to Sentinel.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.