### PR TITLE
fix: dangerous query log group subscription

### DIFF
--- a/aws/rds/sentinel.tf
+++ b/aws/rds/sentinel.tf
@@ -1,5 +1,5 @@
 locals {
-  postgres_dangerous_queries       = ["ALTER", "CREATE", "DELETE", "DROP", "GRANT", "REVOKE", "TRUNCATE"]
+  postgres_dangerous_queries       = ["ALTER ", "CREATE ", "DELETE ", "DROP ", "GRANT ", "REVOKE ", "TRUNCATE "]
   postgres_dangerous_queries_lower = [for sql in local.postgres_dangerous_queries : lower(sql)]
 }
 


### PR DESCRIPTION
# Summary 
Update the Postgres dangerous query log group subscription filter to include a space after the SQL verbs.  This is needed as otherwise the filter matches field names like `created_data`.

## Related Issues | Cartes liées

* https://github.com/cds-snc/platform-core-services/issues/508

# Test instructions | Instructions pour tester la modification

- After merging, create a matching log group event and expect it to be forwarded to Sentinel.
- Expect no additional queries to have been filtered.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.