### PR TITLE
fix: remove `DELETE` query filter

### DIFF
--- a/aws/rds/sentinel.tf
+++ b/aws/rds/sentinel.tf
@@ -1,5 +1,5 @@
 locals {
-  postgres_dangerous_queries       = ["ALTER ", "CREATE ", "DELETE ", "DROP ", "GRANT ", "REVOKE ", "TRUNCATE "]
+  postgres_dangerous_queries       = ["ALTER ", "CREATE ", "DROP ", "GRANT ", "REVOKE ", "TRUNCATE "]
   postgres_dangerous_queries_lower = [for sql in local.postgres_dangerous_queries : lower(sql)]
 }
 


### PR DESCRIPTION
# Summary
Remove `DELETE` queries from the dangerous query filter as these are a normal part of the Notify app's behaviour.

## Related Issues | Cartes liées

- https://github.com/cds-snc/platform-core-services/issues/508
- 
# Test instructions | Instructions pour tester la modification

After merging check that `DELETE` SQL queries are no longer forwarded to Sentinel.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.