### PR TITLE
chore: re-enable pgAudit in Staging

### DIFF
--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -146,8 +146,8 @@ resource "aws_rds_cluster" "notification-canada-ca" {
   storage_encrypted   = true
   deletion_protection = var.enable_delete_protection
 
-  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.default.name
-  enabled_cloudwatch_logs_exports = null
+  db_cluster_parameter_group_name = var.env != "production" ? aws_rds_cluster_parameter_group.pgaudit.name : aws_rds_cluster_parameter_group.default.name
+  enabled_cloudwatch_logs_exports = var.env != "production" ? ["postgresql"] : null
 
   vpc_security_group_ids = [
     var.eks_cluster_securitygroup


### PR DESCRIPTION
# Summary
Now that the baseline database resource test is finished, re-enable pgAudit in Staging.

## Related Issues | Cartes liées

* https://github.com/cds-snc/platform-core-services/issues/508

# Test instructions | Instructions pour tester la modification

Check that database query logs are being sent to the following CloudWatch log group:
```
/aws/rds/cluster/notification-canada-ca-staging-cluster/postgresql
```

# Release Instructions | Instructions pour le déploiement

1. After merge, restart each database instance to sync the new cluster parameters.
2. Update the logging policy to disable logging for specific users:
```sql
ALTER USER rdsproxyadmin SET pgaudit.log TO 'NONE';
ALTER USER app_db_user SET pgaudit.log TO 'NONE';
```
3. Restart the database instances to apply the logging policy change.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.