### PR TITLE
task: refactor admin WAF regex to add an extra regex

### DIFF
--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -81,6 +81,11 @@ output "re_admin_arn" {
   description = "The ARN of the regex pattern set for the allowed URLs of the admin"
 }
 
+output "re_admin_arn2" {
+  value       = aws_wafv2_regex_pattern_set.re_admin2.arn
+  description = "The ARN of the regex pattern set for the allowed URLs of the admin"
+}
+
 output "re_document_download_arn" {
   value       = aws_wafv2_regex_pattern_set.re_document_download.arn
   description = "The ARN of the regex pattern set for the allowed URLs of the document download API"

--- a/aws/common/waf.tf
+++ b/aws/common/waf.tf
@@ -40,7 +40,7 @@ resource "aws_wafv2_regex_pattern_set" "re_admin" {
   # https://docs.aws.amazon.com/waf/latest/developerguide/waf-regex-pattern-set-managing.html
 
   regular_expression {
-    regex_string = "/.well-known.*|/_email.*|/_letter.*|/_status.*|/_styleguide.*|/a11y.*|/accounts.*|/accounts-or-dashboard.*|/activity.*|/add-service.*|/callbacks.*|/contact.*|/documentation.*|/email.*|/sitemap"
+    regex_string = "/.well-known.*|/_email.*|/_letter.*|/_status.*|/_styleguide.*|/a11y.*|/accounts.*|/accounts-or-dashboard.*|/activity.*|/add-service.*|/callbacks.*|/contact.*|/documentation.*|/email.*"
   }
 
   regular_expression {
@@ -81,6 +81,24 @@ resource "aws_wafv2_regex_pattern_set" "re_admin" {
   # GCA routes
   regular_expression {
     regex_string = "/.*-contact-information|/.*-a-jour-les-coordonnees|/delivery-and-failure|/livraison-.*-et-echec|/system-status|/etat-du-systeme|/comprendre-.*-livraison|/sending-custom-content|/utiliser-.*-de-calcul"
+  }
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}
+
+resource "aws_wafv2_regex_pattern_set" "re_admin2" {
+  name        = "re_admin2"
+  description = "Regex matching valid admin endpoints"
+  scope       = "REGIONAL"
+
+  # WAF Regex blocks are combined with OR logic.
+  # Regex support is limited, please see:
+  # https://docs.aws.amazon.com/waf/latest/developerguide/waf-regex-pattern-set-managing.html
+
+  regular_expression {
+    regex_string = "/sitemap|/plandesite"
   }
 
   tags = {

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -129,6 +129,11 @@ variable "re_admin_arn" {
   type        = string
 }
 
+variable "re_admin_arn2" {
+  description = "Regular expression (2) to match the admin urls"
+  type        = string
+}
+
 variable "re_document_download_arn" {
   description = "Regular expression to match the document download api urls"
   type        = string

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -381,6 +381,26 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
         statement {
           not_statement {
             statement {
+              regex_pattern_set_reference_statement {
+                arn = var.re_admin_arn2
+                field_to_match {
+                  uri_path {}
+                }
+                text_transformation {
+                  priority = 1
+                  type     = "COMPRESS_WHITE_SPACE"
+                }
+                text_transformation {
+                  priority = 2
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+          }
+        }
+        statement {
+          not_statement {
+            statement {
               byte_match_statement {
                 field_to_match {
                   uri_path {}

--- a/env/dev/eks/terragrunt.hcl
+++ b/env/dev/eks/terragrunt.hcl
@@ -44,6 +44,7 @@ dependency "common" {
     firehose_waf_logs_iam_role_arn            = ""
     ip_blocklist_arn                          = ""
     re_admin_arn                              = ""
+    re_admin_arn2                             = ""
     re_api_arn                                = ""
     re_document_download_arn                  = ""
     re_documentation_arn                      = ""
@@ -111,6 +112,7 @@ inputs = {
   sign_in_waf_rate_limit                    = 100
   ip_blocklist_arn                          = dependency.common.outputs.ip_blocklist_arn
   re_admin_arn                              = dependency.common.outputs.re_admin_arn
+  re_admin_arn2                             = dependency.common.outputs.re_admin_arn2
   re_api_arn                                = dependency.common.outputs.re_api_arn
   re_document_download_arn                  = dependency.common.outputs.re_document_download_arn
   re_documentation_arn                      = dependency.common.outputs.re_documentation_arn

--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -44,6 +44,7 @@ dependency "common" {
     ]            
     ip_blocklist_arn                          = ""
     re_admin_arn                              = ""
+    re_admin_arn2                             = ""
     re_api_arn                                = ""
     notification_base_url_regex_arn           = ""
     re_document_download_arn                  = ""
@@ -111,6 +112,7 @@ inputs = {
   sign_in_waf_rate_limit                    = 100
   ip_blocklist_arn                          = dependency.common.outputs.ip_blocklist_arn
   re_admin_arn                              = dependency.common.outputs.re_admin_arn
+  re_admin_arn2                             = dependency.common.outputs.re_admin_arn2
   re_api_arn                                = dependency.common.outputs.re_api_arn
   re_document_download_arn                  = dependency.common.outputs.re_document_download_arn
   re_documentation_arn                      = dependency.common.outputs.re_documentation_arn

--- a/env/sandbox/eks/terragrunt.hcl
+++ b/env/sandbox/eks/terragrunt.hcl
@@ -31,6 +31,7 @@ dependency "common" {
     firehose_waf_logs_iam_role_arn            = ""
     ip_blocklist_arn                          = ""
     re_admin_arn                              = ""
+    re_admin_arn2                             = ""
     re_api_arn                                = ""
     re_document_download_arn                  = ""
     re_documentation_arn                      = ""
@@ -103,6 +104,7 @@ inputs = {
   sign_in_waf_rate_limit                    = 100
   ip_blocklist_arn                          = dependency.common.outputs.ip_blocklist_arn
   re_admin_arn                              = dependency.common.outputs.re_admin_arn
+  re_admin_arn2                             = dependency.common.outputs.re_admin_arn2
   re_api_arn                                = dependency.common.outputs.re_api_arn
   re_document_download_arn                  = dependency.common.outputs.re_document_download_arn
   re_documentation_arn                      = dependency.common.outputs.re_documentation_arn

--- a/env/scratch/eks/terragrunt.hcl
+++ b/env/scratch/eks/terragrunt.hcl
@@ -26,6 +26,7 @@ dependency "common" {
     firehose_waf_logs_iam_role_arn            = ""
     ip_blocklist_arn                          = ""
     re_admin_arn                              = ""
+    re_admin_arn2                             = ""
     re_api_arn                                = ""
     re_document_download_arn                  = ""
     re_documentation_arn                      = ""
@@ -77,6 +78,7 @@ inputs = {
   sign_in_waf_rate_limit                    = 100
   ip_blocklist_arn                          = dependency.common.outputs.ip_blocklist_arn
   re_admin_arn                              = dependency.common.outputs.re_admin_arn
+  re_admin_arn2                             = dependency.common.outputs.re_admin_arn2
   re_api_arn                                = dependency.common.outputs.re_api_arn
   re_document_download_arn                  = dependency.common.outputs.re_document_download_arn
   re_documentation_arn                      = dependency.common.outputs.re_documentation_arn

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -44,6 +44,7 @@ dependency "common" {
     firehose_waf_logs_iam_role_arn            = ""
     ip_blocklist_arn                          = ""
     re_admin_arn                              = ""
+    re_admin_arn2                             = ""
     re_api_arn                                = ""
     notification_base_url_regex_arn           = ""
     re_document_download_arn                  = ""
@@ -118,6 +119,7 @@ inputs = {
   sign_in_waf_rate_limit                    = 100
   ip_blocklist_arn                          = dependency.common.outputs.ip_blocklist_arn
   re_admin_arn                              = dependency.common.outputs.re_admin_arn
+  re_admin_arn2                             = dependency.common.outputs.re_admin_arn2
   re_api_arn                                = dependency.common.outputs.re_api_arn
   re_document_download_arn                  = dependency.common.outputs.re_document_download_arn
   re_documentation_arn                      = dependency.common.outputs.re_documentation_arn


### PR DESCRIPTION
# Summary | Résumé
This PR refactors the admin WAF regex to add a second rule we can work with. This alleviates the regex character limitations a bit by giving us twice as much space.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/558

# Test instructions | Instructions pour tester la modification

- [ ] hitting `/sitemap` should work
- [ ] hitting `/plandesite` should work

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.