### PR TITLE
Removing the duplication of code

### DIFF
--- a/aws/lambda-api/api_gateway.tf
+++ b/aws/lambda-api/api_gateway.tf
@@ -103,7 +103,7 @@ resource "aws_api_gateway_deployment" "api" {
 }
 
 resource "aws_api_gateway_stage" "api" {
-  depends_on    = [aws_api_gateway_account.main]
+  depends_on    = [aws_api_gateway_account.api_cloudwatch]
   deployment_id = aws_api_gateway_deployment.api.id
   rest_api_id   = aws_api_gateway_rest_api.api.id
   stage_name    = "v1"

--- a/aws/lambda-api/api_gateway.tf
+++ b/aws/lambda-api/api_gateway.tf
@@ -191,33 +191,3 @@ resource "aws_api_gateway_method_settings" "api_settings" {
     cache_data_encrypted = true
   }
 }
-
-# Allow API Gateway to push logs to CloudWatch
-resource "aws_api_gateway_account" "main" {
-  cloudwatch_role_arn = aws_iam_role.main.arn
-}
-
-resource "aws_iam_role" "main" {
-  name               = "api-gateway-logs-role"
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "apigateway.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
-
-}
-
-resource "aws_iam_role_policy_attachment" "main" {
-  role       = aws_iam_role.main.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
-}


### PR DESCRIPTION
# Summary | Résumé

We had duplicate roles for logging on the api gateway. For some reason the original wasn't working, but now that we can see that it was duplicated, we should focus on fixing the first and not having two.

## Related Issues | Cartes liées

Was originally part of BCP

# Test instructions | Instructions pour tester la modification

This may require two runs of TF apply - one to remove the duplicate and one to set the correct original (they were squashing each other so it depends on the run order)

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.