### PR TITLE
Sentinel forwarder always on

### DIFF
--- a/aws/eks/outputs.tf
+++ b/aws/eks/outputs.tf
@@ -92,9 +92,9 @@ output "quicksight_security_group_id" {
 
 # Sentinel
 output "sentinel_forwarder_cloudwatch_lambda_arn" {
-  value = length(module.sentinel_forwarder) != 0 ? module.sentinel_forwarder[0].lambda_arn : ""
+  value = module.sentinel_forwarder.lambda_arn
 }
 
 output "sentinel_forwarder_cloudwatch_lambda_name" {
-  value = length(module.sentinel_forwarder) != 0 ? module.sentinel_forwarder[0].lambda_name : ""
+  value = module.sentinel_forwarder.lambda_name
 }

--- a/aws/eks/sentinel.tf
+++ b/aws/eks/sentinel.tf
@@ -8,7 +8,6 @@ locals {
 # see https://github.com/cds-snc/terraform-modules/issues/203 
 # and https://docs.google.com/document/d/16LLelZ7WEKrnbocrl0Az74JqkCv5DBZ9QILRBUFJQt8/edit#heading=h.z87ipkd84djw
 module "sentinel_forwarder" {
-  count             = var.enable_sentinel_forwarding ? 1 : 0
   source            = "github.com/cds-snc/terraform-modules//sentinel_forwarder?ref=v9.4.2"
   function_name     = "sentinel-cloud-watch-forwarder"
   billing_tag_value = "notification-canada-ca-${var.env}"

--- a/aws/eks/sentinel.tf
+++ b/aws/eks/sentinel.tf
@@ -30,7 +30,7 @@ resource "aws_cloudwatch_log_subscription_filter" "admin_api_request" {
   name            = "Admin API request"
   log_group_name  = local.eks_application_log_group
   filter_pattern  = "Admin API request"
-  destination_arn = module.sentinel_forwarder[0].lambda_arn
+  destination_arn = module.sentinel_forwarder.lambda_arn
   distribution    = "Random"
 }
 
@@ -39,7 +39,7 @@ resource "aws_cloudwatch_log_subscription_filter" "blazer_logging" {
   name            = "Blazer logging"
   log_group_name  = "blazer"
   filter_pattern  = "Audit "
-  destination_arn = module.sentinel_forwarder[0].lambda_arn
+  destination_arn = module.sentinel_forwarder.lambda_arn
   distribution    = "Random"
 }
 
@@ -48,6 +48,6 @@ resource "aws_cloudwatch_log_subscription_filter" "client_vpn_connections" {
   name            = "Client VPN connections"
   log_group_name  = module.vpn.client_vpn_cloudwatch_log_group_name
   filter_pattern  = "[w1=\"*\"]" # All logs
-  destination_arn = module.sentinel_forwarder[0].lambda_arn
+  destination_arn = module.sentinel_forwarder.lambda_arn
   distribution    = "Random"
 }

--- a/aws/eks/sentinel.tf
+++ b/aws/eks/sentinel.tf
@@ -12,7 +12,7 @@ module "sentinel_forwarder" {
   function_name     = "sentinel-cloud-watch-forwarder"
   billing_tag_value = "notification-canada-ca-${var.env}"
 
-  layer_arn = "arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:126"
+  layer_arn = "arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:131"
 
   customer_id = var.sentinel_customer_id
   shared_key  = var.sentinel_shared_key


### PR DESCRIPTION
# Summary | Résumé

Removing the feature flag for  sentinel forwarder on the module - it will always be on, but the flag will still control whether or not it's used.

## Related Issues | Cartes liées
N/A - release problems

# Test instructions | Instructions pour tester la modification

TF plan/apply works

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.