### PR TITLE
Setting cloudwatch log subscription filters to always on

### DIFF
--- a/aws/eks/sentinel.tf
+++ b/aws/eks/sentinel.tf
@@ -26,7 +26,6 @@ module "sentinel_forwarder" {
 
 
 resource "aws_cloudwatch_log_subscription_filter" "admin_api_request" {
-  count           = var.enable_sentinel_forwarding ? 1 : 0
   name            = "Admin API request"
   log_group_name  = local.eks_application_log_group
   filter_pattern  = "Admin API request"
@@ -35,7 +34,6 @@ resource "aws_cloudwatch_log_subscription_filter" "admin_api_request" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "blazer_logging" {
-  count           = var.enable_sentinel_forwarding ? 1 : 0
   name            = "Blazer logging"
   log_group_name  = "blazer"
   filter_pattern  = "Audit "
@@ -44,7 +42,6 @@ resource "aws_cloudwatch_log_subscription_filter" "blazer_logging" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "client_vpn_connections" {
-  count           = var.enable_sentinel_forwarding ? 1 : 0
   name            = "Client VPN connections"
   log_group_name  = module.vpn.client_vpn_cloudwatch_log_group_name
   filter_pattern  = "[w1=\"*\"]" # All logs


### PR DESCRIPTION
# Summary | Résumé

Removing count from subscription filters.

## Related Issues | Cartes liées

N/A Prod release fix

# Test instructions | Instructions pour tester la modification

TF Apply works

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.