### PR TITLE
add Pinpoint IAM action to k8s workers

### DIFF
--- a/aws/eks/iam.tf
+++ b/aws/eks/iam.tf
@@ -116,6 +116,7 @@ resource "aws_iam_policy" "notification-worker-policy" {
         "ses:SendRawEmail",
         "sqs:*",
         "sns:Publish",
+        "sms-voice:SendTextMessage",
         "securityhub:BatchImportFindings",
         "s3:*"
       ],


### PR DESCRIPTION
# Summary | Résumé

Got an error trying out the new Pinpoint code:

```
botocore.errorfactory.AccessDeniedException: An error occurred (AccessDeniedException) when calling the SendTextMessage operation: User: arn:aws:sts::239043911459:assumed-role/eks-worker-role/i-02248c15cedc52402 is not authorized to perform: sms-voice:SendTextMessage on resource: arn:aws:sms-voice:ca-central-1:239043911459:pool/pool-b20333ce1e4e49309ba1db3bf94a3f57 because no identity-based policy allows the sms-voice:SendTextMessage action
```

I think this will fix it? Looking at [these docs](https://docs.aws.amazon.com/sms-voice/latest/userguide/permissions-actions.html).


## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/286

# Test instructions | Instructions pour tester la modification

Test again on staging.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.