### PR TITLE
SES DKIM for us-east-1

### DIFF
--- a/aws/dns/outputs.tf
+++ b/aws/dns/outputs.tf
@@ -28,6 +28,10 @@ output "notification_canada_ca_dkim" {
   value = aws_ses_domain_dkim.notification-canada-ca.dkim_tokens
 
 }
+
+output "notification_canada_ca_receiving_dkim" {
+  value = aws_ses_domain_dkim.notification-canada-ca-receiving.dkim_tokens
+}
 output "notification_internal_dns_cert" {
   value = base64encode(tls_self_signed_cert.internal_dns.cert_pem)
 }

--- a/aws/dns/ses.tf
+++ b/aws/dns/ses.tf
@@ -27,6 +27,7 @@ resource "aws_ses_domain_dkim" "notification-canada-ca" {
   domain = var.domain
 }
 
+
 # TODO: SES Domain Validation Records Programmatically
 
 resource "aws_ses_identity_notification_topic" "notification-canada-ca-bounce-topic" {
@@ -67,6 +68,12 @@ resource "aws_ses_domain_identity" "notification-canada-ca-receiving" {
 
   domain = var.domain
 }
+
+resource "aws_ses_domain_dkim" "notification-canada-ca-receiving" {
+  provider = aws.us-east-1
+  domain   = var.domain
+}
+
 
 resource "aws_ses_receipt_rule_set" "main" {
   provider = aws.us-east-1

--- a/aws/ses_validation_dns_entries/sesValidationDnsEntries.tf
+++ b/aws/ses_validation_dns_entries/sesValidationDnsEntries.tf
@@ -21,6 +21,17 @@ resource "aws_route53_record" "notification_canada_ca_dkim_record" {
   records         = ["${each.value}.dkim.amazonses.com"]
 }
 
+resource "aws_route53_record" "notification_canada_ca_receiving_dkim_record" {
+  for_each        = { for s in jsondecode(var.notification_canada_ca_receiving_dkim) : "${s}" => s }
+  provider        = aws.dns
+  zone_id         = var.route_53_zone_arn
+  name            = "${each.value}._domainkey.${var.domain}"
+  type            = "CNAME"
+  ttl             = "600"
+  allow_overwrite = true
+  records         = ["${each.value}.dkim.amazonses.com"]
+}
+
 
 resource "aws_route53_record" "ses_cic_trvapply_vrtdemande_dkim_record" {
   for_each        = { for cd in jsondecode(var.cic_trvapply_vrtdemande_dkim) : "${cd.domain}.${cd.token}" => cd }

--- a/aws/ses_validation_dns_entries/variables.tf
+++ b/aws/ses_validation_dns_entries/variables.tf
@@ -24,3 +24,8 @@ variable "notification_canada_ca_dkim" {
   type        = string
   description = "Used to fetch the validation tokens for the root notify domain"
 }
+
+variable "notification_canada_ca_receiving_dkim" {
+  type        = string
+  description = "Used to fetch the validation tokens for the root notify domain in US-EAST-1"
+}

--- a/env/dev/ses_validation_dns_entries/terragrunt.hcl
+++ b/env/dev/ses_validation_dns_entries/terragrunt.hcl
@@ -34,6 +34,7 @@ inputs = {
   custom_sending_domains_dkim   = dependency.dns.outputs.custom_sending_domains_dkim
   cic_trvapply_vrtdemande_dkim  = dependency.dns.outputs.cic_trvapply_vrtdemande_dkim
   notification_canada_ca_dkim   = dependency.dns.outputs.notification_canada_ca_dkim
+  notification_canada_ca_receiving_dkim   = dependency.dns.outputs.notification_canada_ca_receiving_dkim
 }
 
 terraform {

--- a/env/dev/ses_validation_dns_entries/terragrunt.hcl
+++ b/env/dev/ses_validation_dns_entries/terragrunt.hcl
@@ -22,6 +22,10 @@ dependency "dns" {
   mock_outputs_merge_with_state           = true
   mock_outputs = {
     lambda_ses_receiving_emails_image_arn = ""
+    notification_canada_ca_receiving_dkim = []
+    notification_canada_ca_dkim = []
+    cic_trvapply_vrtdemande_dkim = []
+    custom_sending_domains_dkim = []
   }
 }
 

--- a/env/production/ses_validation_dns_entries/terragrunt.hcl
+++ b/env/production/ses_validation_dns_entries/terragrunt.hcl
@@ -27,6 +27,10 @@ dependency "dns" {
   mock_outputs_merge_with_state           = true
   mock_outputs = {
     lambda_ses_receiving_emails_image_arn = ""
+    notification_canada_ca_receiving_dkim = []
+    notification_canada_ca_dkim = []
+    cic_trvapply_vrtdemande_dkim = []
+    custom_sending_domains_dkim = []    
   }
 }
 

--- a/env/production/ses_validation_dns_entries/terragrunt.hcl
+++ b/env/production/ses_validation_dns_entries/terragrunt.hcl
@@ -39,4 +39,5 @@ inputs = {
   custom_sending_domains_dkim   = dependency.dns.outputs.custom_sending_domains_dkim
   cic_trvapply_vrtdemande_dkim  = dependency.dns.outputs.cic_trvapply_vrtdemande_dkim
   notification_canada_ca_dkim   = dependency.dns.outputs.notification_canada_ca_dkim
+  notification_canada_ca_receiving_dkim   = dependency.dns.outputs.notification_canada_ca_receiving_dkim
 }

--- a/env/sandbox/ses_validation_dns_entries/terragrunt.hcl
+++ b/env/sandbox/ses_validation_dns_entries/terragrunt.hcl
@@ -22,6 +22,10 @@ dependency "dns" {
   mock_outputs_merge_with_state           = true
   mock_outputs = {
     lambda_ses_receiving_emails_image_arn = ""
+    notification_canada_ca_receiving_dkim = []
+    notification_canada_ca_dkim = []
+    cic_trvapply_vrtdemande_dkim = []
+    custom_sending_domains_dkim = []    
   }
 }
 

--- a/env/sandbox/ses_validation_dns_entries/terragrunt.hcl
+++ b/env/sandbox/ses_validation_dns_entries/terragrunt.hcl
@@ -34,6 +34,7 @@ inputs = {
   custom_sending_domains_dkim   = dependency.dns.outputs.custom_sending_domains_dkim
   cic_trvapply_vrtdemande_dkim  = dependency.dns.outputs.cic_trvapply_vrtdemande_dkim
   notification_canada_ca_dkim   = dependency.dns.outputs.notification_canada_ca_dkim
+  notification_canada_ca_receiving_dkim   = dependency.dns.outputs.notification_canada_ca_receiving_dkim
 }
 
 terraform {

--- a/env/staging/ses_validation_dns_entries/terragrunt.hcl
+++ b/env/staging/ses_validation_dns_entries/terragrunt.hcl
@@ -34,6 +34,7 @@ inputs = {
   custom_sending_domains_dkim   = dependency.dns.outputs.custom_sending_domains_dkim
   cic_trvapply_vrtdemande_dkim  = dependency.dns.outputs.cic_trvapply_vrtdemande_dkim
   notification_canada_ca_dkim   = dependency.dns.outputs.notification_canada_ca_dkim
+  notification_canada_ca_receiving_dkim   = dependency.dns.outputs.notification_canada_ca_receiving_dkim
 }
 
 terraform {

--- a/env/staging/ses_validation_dns_entries/terragrunt.hcl
+++ b/env/staging/ses_validation_dns_entries/terragrunt.hcl
@@ -22,6 +22,10 @@ dependency "dns" {
   mock_outputs_merge_with_state           = true
   mock_outputs = {
     lambda_ses_receiving_emails_image_arn = ""
+    notification_canada_ca_receiving_dkim = []
+    notification_canada_ca_dkim = []
+    cic_trvapply_vrtdemande_dkim = []
+    custom_sending_domains_dkim = []
   }
 }
 


### PR DESCRIPTION
# Summary | Résumé

The SES Receiving service did not have its DKIM automated.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/58

# Test instructions | Instructions pour tester la modification

TF Apply works

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.