### PR TITLE
chore: apply RDS updates during maintenance window

### DIFF
--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -28,7 +28,7 @@ resource "aws_rds_cluster_instance" "notification-canada-ca-instances" {
   # https://github.com/hashicorp/terraform-provider-aws/issues/3015#issuecomment-520667166
   preferred_maintenance_window = "wed:04:00-wed:04:30"
   auto_minor_version_upgrade   = false
-  apply_immediately            = true
+  apply_immediately            = false
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"


### PR DESCRIPTION
# Summary
Update the RDS instances to only apply updates during their maintenance window.  This is being done in preparation for the `pgAudit` release in production so that we can control the instance restarts.

This is being set to `false` for all environments to confirm it works as expected before releasing to production.

## Related Issues | Cartes liées

* https://github.com/cds-snc/platform-core-services/issues/508

# Test instructions | Instructions pour tester la modification

Once merged, confirm that no RDS instance restarts occur.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.