### PR TITLE
feat: enable RDS Sentinel forwarding in Production

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -53,7 +53,7 @@ env:
   TF_VAR_pr_bot_app_id: ${{ secrets.NOTIFY_PR_BOT_APP_ID }}
   TF_VAR_pr_bot_private_key: ${{ secrets.NOTIFY_PR_BOT_PRIVATE_KEY }}
   TF_VAR_budget_sre_bot_webhook: ${{ secrets.PRODUCTION_BUDGET_SRE_BOT_WEBHOOK }}
-  TF_VAR_enable_sentinel_forwarding: false
+  TF_VAR_enable_sentinel_forwarding: true
 
 jobs:
   terraform-apply:

--- a/.github/workflows/terragrunt_plan_production.yml
+++ b/.github/workflows/terragrunt_plan_production.yml
@@ -48,7 +48,7 @@ env:
   TF_VAR_pr_bot_app_id: ${{ secrets.NOTIFY_PR_BOT_APP_ID }}
   TF_VAR_pr_bot_private_key: ${{ secrets.NOTIFY_PR_BOT_PRIVATE_KEY }}
   TF_VAR_budget_sre_bot_webhook: ${{ secrets.PRODUCTION_BUDGET_SRE_BOT_WEBHOOK }}
-  TF_VAR_enable_sentinel_forwarding: false
+  TF_VAR_enable_sentinel_forwarding: true
 
 jobs:
   terragrunt-plan-production:

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -178,11 +178,6 @@ variable "route_53_zone_arn" {
   default     = "/hostedzone/Z04028033PLSHVOO9ZJ1Z"
 }
 
-variable "enable_sentinel_forwarding" {
-  type        = bool
-  description = "Flag to enable or disable log forwarding to sentinel."
-  default     = false
-}
 variable "enable_delete_protection" {
   type        = bool
   description = "Flag to enable or disable delete protection on resources."


### PR DESCRIPTION
# Summary
Send RDS postgresql logs that match the potentially malicious filters to Sentinel.  Alarms will then be created that alert us to one of these queries having been run.

Also removes an `eks` module variable that is no longer used.

## Related Issues | Cartes liées

- https://github.com/cds-snc/platform-core-services/issues/508

# Test instructions | Instructions pour tester la modification

Create a log entry in the postgresql CloudWatch log group that [matches the filters](https://github.com/cds-snc/notification-terraform/blob/d5a54704feef28f700b2f6c7abae1fc53c02bcac/aws/rds/sentinel.tf#L2) and expect it to be forwarded to Sentinel.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.