### PR TITLE
incident-2024-05-22-release-pipeline-blocked

### DIFF
--- a/.github/workflows/build_github_arc_docker_staging.yml
+++ b/.github/workflows/build_github_arc_docker_staging.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Deploy
       run: |
-        ./scripts/callManifestsRollout.sh -s app=arc,tier=scaleset -t tag=$INFRASTRUCTURE_VERSION -n github-arc-ss 
+        ./scripts/callManifestsRollout.sh -s app=arc,tier=scaleset -t $INFRASTRUCTURE_VERSION -n github-arc-ss 
 
 # TODO: Helmfile rollout
 


### PR DESCRIPTION
# Summary | Résumé
We had an incident where the github runners had a bug in the image name that didnt' show itself until after github went down on May 20th 2024, which caused the pods to rebuild with an erroneous image tag.

## Related Issues | Cartes liées
notification-planning-core/1

# Test instructions | Instructions pour tester la modification

Run this GHA and verify that the images are all set properly

# Release Instructions | Instructions pour le déploiement

None.

