### PR TITLE
Athena Loadbalancer Query Update

### DIFF
--- a/aws/common/sql/alb_log_create_table.sql.tmpl
+++ b/aws/common/sql/alb_log_create_table.sql.tmpl
@@ -1,7 +1,7 @@
 -- Inspired from the following links:
 -- https://docs.aws.amazon.com/athena/latest/ug/application-load-balancer-logs.html
 -- https://github.com/yutachaos/terraform-aws-athena-alb-logs
-CREATE EXTERNAL TABLE IF NOT EXISTS alb_access_logs (
+CREATE EXTERNAL TABLE IF NOT EXISTS `${database_name}.${table_name}` (
             type string,
             time string,
             elb string,
@@ -43,4 +43,4 @@ CREATE EXTERNAL TABLE IF NOT EXISTS alb_access_logs (
             'serialization.format' = '1',
             'input.regex' = 
         '([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*):([0-9]*) ([^ ]*)[:-]([0-9]*) ([-.0-9]*) ([-.0-9]*) ([-.0-9]*) (|[-0-9]*) (-|[-0-9]*) ([-0-9]*) ([-0-9]*) \"([^ ]*) (.*) (- |[^ ]*)\" \"([^\"]*)\" ([A-Z0-9-_]+) ([A-Za-z0-9.-]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^\"]*)\" ([-.0-9]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^ ]*)\" \"([^\s]+?)\" \"([^\s]+)\" \"([^ ]*)\" \"([^ ]*)\" ?([^ ]*)?')
-            LOCATION 's3://DOC-EXAMPLE-BUCKET/access-log-folder-path/'
+            LOCATION '${bucket_location}';

--- a/aws/common/sql/alb_log_create_table.sql.tmpl
+++ b/aws/common/sql/alb_log_create_table.sql.tmpl
@@ -1,44 +1,46 @@
 -- Inspired from the following links:
 -- https://docs.aws.amazon.com/athena/latest/ug/application-load-balancer-logs.html
 -- https://github.com/yutachaos/terraform-aws-athena-alb-logs
-CREATE EXTERNAL TABLE IF NOT EXISTS `${database_name}.${table_name}` (
-               type string,
-               time string,
-               elb string,
-               client_ip string,
-               client_port int,
-               target_ip string,
-               target_port int,
-               request_processing_time double,
-               target_processing_time double,
-               response_processing_time double,
-               elb_status_code int,
-               target_status_code string,
-               received_bytes bigint,
-               sent_bytes bigint,
-               request_verb string,
-               request_url string,
-               request_proto string,
-               user_agent string,
-               ssl_cipher string,
-               ssl_protocol string,
-               target_group_arn string,
-               trace_id string,
-               domain_name string,
-               chosen_cert_arn string,
-               matched_rule_priority string,
-               request_creation_time string,
-               actions_executed string,
-               redirect_url string,
-               lambda_error_reason string,
-               target_port_list string,
-               target_status_code_list string,
-               classification string,
-               classification_reason string
+CREATE EXTERNAL TABLE IF NOT EXISTS alb_access_logs (
+            type string,
+            time string,
+            elb string,
+            client_ip string,
+            client_port int,
+            target_ip string,
+            target_port int,
+            request_processing_time double,
+            target_processing_time double,
+            response_processing_time double,
+            elb_status_code int,
+            target_status_code string,
+            received_bytes bigint,
+            sent_bytes bigint,
+            request_verb string,
+            request_url string,
+            request_proto string,
+            user_agent string,
+            ssl_cipher string,
+            ssl_protocol string,
+            target_group_arn string,
+            trace_id string,
+            domain_name string,
+            chosen_cert_arn string,
+            matched_rule_priority string,
+            request_creation_time string,
+            actions_executed string,
+            redirect_url string,
+            lambda_error_reason string,
+            target_port_list string,
+            target_status_code_list string,
+            classification string,
+            classification_reason string,
+            traceability_id string,
+            unknown_fields string
             )
             ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.RegexSerDe'
             WITH SERDEPROPERTIES (
-               'serialization.format' = '1',
-               'input.regex' = 
-               '([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*):([0-9]*) ([^ ]*)[:-]([0-9]*) ([-.0-9]*) ([-.0-9]*) ([-.0-9]*) (|[-0-9]*) (-|[-0-9]*) ([-0-9]*) ([-0-9]*) \"([^ ]*) (.*) (- |[^ ]*)\" \"([^\"]*)\" ([A-Z0-9-_]+) ([A-Za-z0-9.-]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^\"]*)\" ([-.0-9]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^ ]*)\" \"([^\s]+?)\" \"([^\s]+)\" \"([^ ]*)\" \"([^ ]*)\"')
-            LOCATION '${bucket_location}';
+            'serialization.format' = '1',
+            'input.regex' = 
+        '([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*):([0-9]*) ([^ ]*)[:-]([0-9]*) ([-.0-9]*) ([-.0-9]*) ([-.0-9]*) (|[-0-9]*) (-|[-0-9]*) ([-0-9]*) ([-0-9]*) \"([^ ]*) (.*) (- |[^ ]*)\" \"([^\"]*)\" ([A-Z0-9-_]+) ([A-Za-z0-9.-]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^\"]*)\" ([-.0-9]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^ ]*)\" \"([^\s]+?)\" \"([^\s]+)\" \"([^ ]*)\" \"([^ ]*)\" ?([^ ]*)?')
+            LOCATION 's3://DOC-EXAMPLE-BUCKET/access-log-folder-path/'


### PR DESCRIPTION
# Summary | Résumé

Updating the athena query for the loadbalancer logs so that it reflects the proper and most recent information.

## Related Issues | Cartes liées

none.

# Test instructions | Instructions pour tester la modification

Try the alb partitioned logs tables in athena and verify that it pulls the proper most recent records. 
# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.