### PR TITLE
Incident / Rebuild arc runner in prod

### DIFF
--- a/.github/workflows/build_github_arc_docker_production.yml
+++ b/.github/workflows/build_github_arc_docker_production.yml
@@ -1,0 +1,73 @@
+name: "Build and Push Github ARC Image"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "aws/ecr/github-runner/**"
+
+env:
+  AWS_REGION: ca-central-1
+  DOCKER_ORG:  ${{ secrets.PRODUCTION_ECR_URL }}
+  DOCKER_SLUG: ${{ secrets.PRODUCTION_ECR_URL }}/notify/github_arc_runner
+  WORKFLOW_PAT: ${{ secrets.WORKFLOW_GITHUB_PAT }}
+
+permissions:
+  id-token: write   # This is required for requesting the OIDC JWT
+  contents: read    # This is required for actions/checkout
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Build and push
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    
+    - name: Configure credentials to CDS public ECR using OIDC
+      uses: aws-actions/configure-aws-credentials@master
+      with:
+        role-to-assume: arn:aws:iam::${{ secrets.PRODUCTION_ACCOUNT_ID }}:role/github_docker_push
+        role-session-name: NotifyTerraformGitHubActions
+        aws-region: ca-central-1
+  
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v2
+
+    - name: Set INFRASTRUCTURE_VERSION
+      run: |
+        INFRASTRUCTURE_VERSION=`cat ./.github/workflows/infrastructure_version.txt`
+        echo "INFRASTRUCTURE_VERSION=$INFRASTRUCTURE_VERSION" >> $GITHUB_ENV
+
+    - name: Build
+      run: |
+        docker build \
+        -t $DOCKER_SLUG:$INFRASTRUCTURE_VERSION \
+        -t $DOCKER_SLUG:latest \
+        -f aws/ecr/github-runner/Dockerfile . 
+
+    - name: Push
+      run: |
+        docker push $DOCKER_SLUG:latest && docker push $DOCKER_SLUG:$INFRASTRUCTURE_VERSION
+
+    - name: Deploy
+      run: |
+        ./scripts/callManifestsRollout.sh -s app=arc,tier=scaleset -t $INFRASTRUCTURE_VERSION -n github-arc-ss 
+
+# TODO: Helmfile rollout
+
+    - name: Generate docker SBOM
+      uses: cds-snc/security-tools/.github/actions/generate-sbom@eecd7a02a0294b379411c126b61e5c29e253676a # v2.1.4
+      with:
+        docker_image: "${{ env.DOCKER_SLUG }}:latest"
+        dockerfile_path: "ci/Dockerfile"
+        sbom_name: "notification-github-runner"
+        token: "${{ secrets.GITHUB_TOKEN }}"
+
+    - name: Notify Slack channel if this job failed
+      if: ${{ failure() }}
+      run: |
+        json="{'text':'<!here> Docker Build for Github ARC is failing in <https://github.com/cds-snc/notification-terraform/actions/runs/${GITHUB_RUN_ID}|notification-terraform> !'}"
+        curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.GHA_FAIL_SLACK_WEBHOOK }}

--- a/.github/workflows/build_github_arc_docker_production.yml
+++ b/.github/workflows/build_github_arc_docker_production.yml
@@ -65,9 +65,3 @@ jobs:
         dockerfile_path: "ci/Dockerfile"
         sbom_name: "notification-github-runner"
         token: "${{ secrets.GITHUB_TOKEN }}"
-
-    - name: Notify Slack channel if this job failed
-      if: ${{ failure() }}
-      run: |
-        json="{'text':'<!here> Docker Build for Github ARC is failing in <https://github.com/cds-snc/notification-terraform/actions/runs/${GITHUB_RUN_ID}|notification-terraform> !'}"
-        curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.GHA_FAIL_SLACK_WEBHOOK }}

--- a/.github/workflows/build_github_arc_docker_production.yml
+++ b/.github/workflows/build_github_arc_docker_production.yml
@@ -1,4 +1,4 @@
-name: "Build and Push Github ARC Image"
+name: "Build and Push Github ARC Image (Production)"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build_github_arc_docker_staging.yml
+++ b/.github/workflows/build_github_arc_docker_staging.yml
@@ -1,4 +1,4 @@
-name: "Build and Push Github ARC Image"
+name: "Build and Push Github ARC Image (Staging)"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build_github_arc_docker_staging.yml
+++ b/.github/workflows/build_github_arc_docker_staging.yml
@@ -65,9 +65,3 @@ jobs:
         dockerfile_path: "ci/Dockerfile"
         sbom_name: "notification-github-runner"
         token: "${{ secrets.GITHUB_TOKEN }}"
-
-    - name: Notify Slack channel if this job failed
-      if: ${{ failure() }}
-      run: |
-        json="{'text':'<!here> Docker Build for Github ARC is failing in <https://github.com/cds-snc/notification-terraform/actions/runs/${GITHUB_RUN_ID}|notification-terraform> !'}"
-        curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.GHA_FAIL_SLACK_WEBHOOK }}

--- a/.github/workflows/workflow_failure.yml
+++ b/.github/workflows/workflow_failure.yml
@@ -5,6 +5,8 @@ on:
     workflows:
       - "Merge to main (Production)"
       - "Merge to main (Staging)"
+      - "Build and Push Github ARC Image (Production)"
+      - "Build and Push Github ARC Image (Staging)"
     types:
       - completed
 


### PR DESCRIPTION
# Summary | Résumé

Production is using an old arc runner from when we started this arc runner stuff. Staging rebuilds the runner when we touch the related bits of our code. This new action will rebuild the runner in prod as well.


## Related Issues | Cartes liées

Incident [Release pipeline broken](https://docs.google.com/document/d/166y9L8nLJDzWWYwgvZEPO4G9VsBC_K13FBf9BhMnwOo)

# Test instructions | Instructions pour tester la modification

Delete the ephemoral broken runners in prod and see if that kicks of working runners, for example:
```
kubectl delete EphemeralRunner/github-arc-ss-production-k8ww6-runner-9lsjg -n github-arc-controller
```


# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.