### PR TITLE
Use python sanitizer for prod

### DIFF
--- a/.github/workflows/sanitize_production_sms_usage.yml
+++ b/.github/workflows/sanitize_production_sms_usage.yml
@@ -13,8 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: Upgrade pip
+      run: python -m pip install --upgrade pip
+
     - name: Checkout
       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+
+    - name: Install python packages
+      run: pip install -r ./scripts/sanitize_sms_usage_logs/requirements.txt
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
@@ -25,8 +31,8 @@ jobs:
 
     - name: run script
       run: |
-        ./scripts/sanitize_sms_usage_logs.sh ${INPUT_BUCKET_1} ${INPUT_BUCKET_1}-san
-        ./scripts/sanitize_sms_usage_logs.sh ${INPUT_BUCKET_2} ${INPUT_BUCKET_2}-san
+        python ./scripts/sanitize_sms_usage_logs/sanitize_sms_usage_logs.py ${INPUT_BUCKET_1} ${INPUT_BUCKET_1}-san --push
+        python ./scripts/sanitize_sms_usage_logs/sanitize_sms_usage_logs.py ${INPUT_BUCKET_2} ${INPUT_BUCKET_2}-san --push
 
     - name: Notify Slack channel if this job failed
       if: ${{ failure() }}


### PR DESCRIPTION
# Summary | Résumé

- [Switched to a python sanitizer](https://github.com/cds-snc/notification-terraform/pull/1335) for SMS usage to also dedup the data.
- [worked in staging](https://github.com/cds-snc/notification-terraform/actions/runs/9309756308/job/25625855200#step:6:1) :tada:

![image](https://github.com/cds-snc/notification-terraform/assets/8228248/ad159c96-b5ee-483b-8251-5a5a8e50b5eb)

- here we use the python script in production too


## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/325

# Test instructions | Instructions pour tester la modification

none

# Release Instructions | Instructions pour le déploiement

After this merges and starts running we should do a run of the script on the sanitized buckets (writing back to the sanitized buckets) to clean up any old duplicates. Done already on staging and verified that the one old duplicate row we nad in staging was removed.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.