### PR TITLE
removing the auto-deploy of github arc image on prod workflow

### DIFF
--- a/.github/workflows/build_github_arc_docker_production.yml
+++ b/.github/workflows/build_github_arc_docker_production.yml
@@ -52,10 +52,6 @@ jobs:
       run: |
         docker push $DOCKER_SLUG:latest && docker push $DOCKER_SLUG:$INFRASTRUCTURE_VERSION
 
-    - name: Deploy
-      run: |
-        ./scripts/callManifestsRollout.sh -s app=arc,tier=scaleset -t $INFRASTRUCTURE_VERSION -n github-arc-ss 
-
 # TODO: Helmfile rollout
 
     - name: Generate docker SBOM


### PR DESCRIPTION
# Summary | Résumé

The callmanifestsrollout.sh is currently hard-coded to staging because we don't want to auto-deploy to prod (we want to go through regular version release process). As a result, when running the prod build arc-controller workflow, we were actually applying the config changes to staging and not production. Removing the callManifests build step here. 

## Related Issues | Cartes liées

* Github arc controller not working in staging

# Test instructions | Instructions pour tester la modification

Run this workflow and verify the changes DID NOT get applied to staging

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.