### PR TITLE
Adding karpenter AMI ID to TF

### DIFF
--- a/aws/eks/secrets.tf
+++ b/aws/eks/secrets.tf
@@ -87,3 +87,13 @@ resource "aws_secretsmanager_secret_version" "document_download_api_target_group
   secret_id     = aws_secretsmanager_secret.document_download_api_target_group_arn.id
   secret_string = aws_alb_target_group.notification-canada-ca-document-api.arn
 }
+
+resource "aws_secretsmanager_secret" "eks_karpenter_ami_id" {
+  name                    = "EKS_KARPENTER_AMI_ID"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "eks_karpenter_ami_id" {
+  secret_id     = aws_secretsmanager_secret.eks_karpenter_ami_id.id
+  secret_string = var.eks_karpenter_ami_id
+}

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -315,3 +315,8 @@ variable "subnet_ids" {
   type        = list(string)
   description = "The IDs for the subnets"
 }
+
+variable "eks_karpenter_ami_id" {
+  type        = string
+  description = "The AMI ID for the Karpenter nodes"
+}

--- a/env/dev/eks/terragrunt.hcl
+++ b/env/dev/eks/terragrunt.hcl
@@ -107,6 +107,7 @@ inputs = {
   eks_addon_vpc_cni_version                 = "v1.18.1-eksbuild.3"
   eks_addon_ebs_driver_version              = "v1.31.0-eksbuild.1"
   eks_node_ami_version                      = "1.30.0-20240522"
+  eks_karpenter_ami_id                      = "ami-0db7addbb6bf97a77"
   non_api_waf_rate_limit                    = 500
   api_waf_rate_limit                        = 5000
   sign_in_waf_rate_limit                    = 100

--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -107,6 +107,7 @@ inputs = {
   eks_addon_vpc_cni_version                 = "v1.16.2-eksbuild.1"
   eks_addon_ebs_driver_version              = "v1.27.0-eksbuild.1"
   eks_node_ami_version                      = "1.29.3-20240506"
+  eks_karpenter_ami_id                      = "ami-02aa678d778b79aea"
   non_api_waf_rate_limit                    = 500
   api_waf_rate_limit                        = 30000
   sign_in_waf_rate_limit                    = 100

--- a/env/sandbox/eks/terragrunt.hcl
+++ b/env/sandbox/eks/terragrunt.hcl
@@ -99,6 +99,7 @@ inputs = {
   eks_addon_vpc_cni_version                 = "v1.16.2-eksbuild.1"
   eks_addon_ebs_driver_version              = "v1.27.0-eksbuild.1"
   eks_node_ami_version                      = "1.29.3-20240506"
+  eks_karpenter_ami_id                      = "ami-0db7addbb6bf97a77"
   non_api_waf_rate_limit                    = 500
   api_waf_rate_limit                        = 5000
   sign_in_waf_rate_limit                    = 100

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -114,6 +114,7 @@ inputs = {
   eks_addon_vpc_cni_version                 = "v1.18.1-eksbuild.3"
   eks_addon_ebs_driver_version              = "v1.31.0-eksbuild.1"
   eks_node_ami_version                      = "1.30.0-20240522"
+  eks_karpenter_ami_id                      = "ami-0db7addbb6bf97a77"
   non_api_waf_rate_limit                    = 500
   api_waf_rate_limit                        = 30000
   sign_in_waf_rate_limit                    = 100


### PR DESCRIPTION
# Summary | Résumé

When updating K8s, the karpenter AMI ID must also be set. Using a secret in TF to manage this, which will be retrieved by helmfile's getContext script at deploy time.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/366

# Test instructions | Instructions pour tester la modification

TF Apply works

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.