### PR TITLE
Add warning and critical alarms for callbacks

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -430,6 +430,45 @@ resource "aws_cloudwatch_metric_alarm" "logs-1-bounce-rate-critical" {
   alarm_actions       = [var.sns_alert_warning_arn]
 }
 
+# Callbacks are
+#   retried:        5 times
+#   delay between:  5 minutes
+#
+# If a service has retried the max number of times for > 1 notification, then the callback url is considered problematic
+# We were unable to reach your callback service.
+# Callback URL not reachable for service
+# Callback URL for service: {current_service.id} was reachable but returned status code
+#
+resource "aws_cloudwatch_metric_alarm" "service-callback-too-many-failures-warning" {
+  count               = var.cloudwatch_enabled ? 1 : 0
+  alarm_name          = "service-callback-too-many-failures-warning"
+  alarm_description   = "Services where callbacks have failed x times in x minutes"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = aws_cloudwatch_log_metric_filter.callback-failures.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.callback-failures.metric_transformation[0].namespace
+  period              = 60
+  statistic           = "Sum"
+  threshold           = var.alarm_warning_callback_failure_threshold
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [var.sns_alert_warning_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "service-callback-too-many-retries-critical" {
+  count               = var.cloudwatch_enabled ? 1 : 0
+  alarm_name          = "service-callback-too-many-failures-warning"
+  alarm_description   = "Services where callbacks have failed x times in x minutes"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = aws_cloudwatch_log_metric_filter.callback-failures.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.callback-failures.metric_transformation[0].namespace
+  period              = 60
+  statistic           = "Sum"
+  threshold           = var.alarm_warning_callback_failure_threshold
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [var.sns_alert_critical_arn]
+}
+
 resource "aws_cloudwatch_metric_alarm" "kubernetes-failed-nodes" {
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "kubernetes-failed-nodes"

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -179,3 +179,75 @@ resource "aws_cloudwatch_log_metric_filter" "github-arc-write-alarm" {
     value     = "1"
   }
 }
+
+resource "aws_cloudwatch_log_metric_filter" "callback-failures" {
+  count          = var.cloudwatch_enabled ? 1 : 0
+  name           = "callbacks-failures"
+  pattern        = "send_delivery_status_to_service request failed for notification_id"
+  log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs[0].name
+
+  metric_transformation {
+    name      = "callback-failures"
+    namespace = "LogMetrics"
+    value     = "1"
+    dimensions = {
+      url       = "$.url"
+      error     = "$.Error"
+      exception = "$.exc"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "callback-creation-failure-invalid-url" {
+  count          = var.cloudwatch_enabled ? 1 : 0
+  name           = "callback-creation-failure-invalid-url"
+  pattern        = "Invalid callback URL format"
+  log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs[0].name
+
+  metric_transformation {
+    name      = "callback-creation-failure-invalid-url"
+    namespace = "LogMetrics"
+    value     = "1"
+    dimensions = {
+      service = "$.service"
+      url     = "$.URL"
+      error   = "$.Error"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "callback-creation-failure-endpoint-returned-error" {
+  count          = var.cloudwatch_enabled ? 1 : 0
+  name           = "callback-creation-failure-endpoint-returned-error"
+  pattern        = "URL was reachable but returned status code"
+  log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs[0].name
+
+  metric_transformation {
+    name      = "callback-creation-failure-endpoint-returned-error"
+    namespace = "LogMetrics"
+    value     = "1"
+    dimensions = {
+      service = "$.service"
+      url     = "$.URL"
+      error   = "$.Error"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "callback-creation-failure-endpoint-unreachable" {
+  count          = var.cloudwatch_enabled ? 1 : 0
+  name           = "callback-creation-failure-endpoint-unreachable"
+  pattern        = "Callback URL not reachable URL"
+  log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs[0].name
+
+  metric_transformation {
+    name      = "callback-creation-failure-endpoint-unreachable"
+    namespace = "LogMetrics"
+    value     = "1"
+    dimensions = {
+      service = "$.service"
+      url     = "$.URL"
+      error   = "$.Error"
+    }
+  }
+}

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -320,3 +320,13 @@ variable "eks_karpenter_ami_id" {
   type        = string
   description = "The AMI ID for the Karpenter nodes"
 }
+
+variable "alarm_warning_callback_failure_threshold" {
+  description = "Warning alarm threshold for number of callback failures in 5 minutes"
+  type        = number
+}
+
+variable "alarm_critical_callback_failure_threshold" {
+  description = "Warning alarm threshold for number of callback failures in 5 minutes"
+  type        = number
+}

--- a/env/dev/eks/terragrunt.hcl
+++ b/env/dev/eks/terragrunt.hcl
@@ -19,7 +19,7 @@ dependency "common" {
       "subnet-001e585d12cce4d1e",
       "subnet-08de34a9e1a7458dc",
       "subnet-0af8b8402f1d605ff",
-    ]        
+    ]
     vpc_public_subnets = [
       "subnet-0cecd9e634daf82d3",
       "subnet-0c7d18c0c51b28b61",
@@ -37,7 +37,7 @@ dependency "common" {
       "10.0.32.0/19",
       "10.0.64.0/19",
       "10.0.96.0/19",
-    ]        
+    ]
     sns_alert_warning_arn                     = ""
     sns_alert_critical_arn                    = ""
     sns_alert_general_arn                     = ""
@@ -126,7 +126,9 @@ inputs = {
   internal_dns_name                         = dependency.dns.outputs.internal_dns_name
   subnet_ids                                = dependency.common.outputs.subnet_ids
   subnet_cidr_blocks                        = dependency.common.outputs.subnet_cidr_blocks
-  
+  alarm_warning_callback_failure_threshold  = "1" # Todo: proper thresholds
+  alarm_critical_callback_failure_threshold = "1" # Todo: proper thresholds
+
 }
 
 terraform {

--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -23,7 +23,7 @@ dependency "common" {
       "subnet-0cecd9e634daf82d3",
       "subnet-0c7d18c0c51b28b61",
       "subnet-0c91f7c6b8211904b",
-    ]   
+    ]
     vpc_private_subnets = [
       "subnet-001e585d12cce4d1e",
       "subnet-08de34a9e1a7458dc",
@@ -33,7 +33,7 @@ dependency "common" {
       "subnet-0cecd9e634daf82d3",
       "subnet-0c7d18c0c51b28b61",
       "subnet-0c91f7c6b8211904b",
-    ]     
+    ]
     subnet_cidr_blocks = [
       "10.0.0.0/24",
       "10.0.1.0/24",
@@ -41,7 +41,7 @@ dependency "common" {
       "10.0.32.0/19",
       "10.0.64.0/19",
       "10.0.96.0/19",
-    ]            
+    ]
     ip_blocklist_arn                          = ""
     re_admin_arn                              = ""
     re_admin_arn2                             = ""
@@ -88,7 +88,7 @@ inputs = {
   primary_worker_desired_size               = 5
   primary_worker_instance_types             = ["r5.large"]
   secondary_worker_instance_types           = ["r5.large"]
-  node_upgrade                              = false  
+  node_upgrade                              = false
   primary_worker_max_size                   = 8
   primary_worker_min_size                   = 3
   vpc_id                                    = dependency.common.outputs.vpc_id
@@ -117,7 +117,7 @@ inputs = {
   re_api_arn                                = dependency.common.outputs.re_api_arn
   re_document_download_arn                  = dependency.common.outputs.re_document_download_arn
   re_documentation_arn                      = dependency.common.outputs.re_documentation_arn
-  notification_base_url_regex_arn           = dependency.common.outputs.notification_base_url_regex_arn  
+  notification_base_url_regex_arn           = dependency.common.outputs.notification_base_url_regex_arn
   private-links-vpc-endpoints-securitygroup = dependency.common.outputs.private-links-vpc-endpoints-securitygroup
   private-links-gateway-prefix-list-ids     = dependency.common.outputs.private-links-gateway-prefix-list-ids
   sqs_send_email_low_queue_name             = dependency.common.outputs.sqs_send_email_low_queue_name
@@ -132,5 +132,7 @@ inputs = {
   internal_dns_name                         = dependency.dns.outputs.internal_dns_name
   subnet_ids                                = dependency.common.outputs.subnet_ids
   subnet_cidr_blocks                        = dependency.common.outputs.subnet_cidr_blocks
+  alarm_warning_callback_failure_threshold  = "1" # Todo: proper thresholds
+  alarm_critical_callback_failure_threshold = "1" # Todo: proper thresholds
 
 }

--- a/env/sandbox/eks/terragrunt.hcl
+++ b/env/sandbox/eks/terragrunt.hcl
@@ -19,7 +19,7 @@ dependency "common" {
       "subnet-001e585d12cce4d1e",
       "subnet-08de34a9e1a7458dc",
       "subnet-0af8b8402f1d605ff",
-    ]  
+    ]
     vpc_public_subnets = [
       "subnet-0cecd9e634daf82d3",
       "subnet-0c7d18c0c51b28b61",
@@ -52,8 +52,8 @@ dependency "dns" {
   mock_outputs_allowed_terraform_commands = ["validate"]
   mock_outputs = {
     internal_dns_certificate_arn = ""
-    internal_dns_zone_id = ""
-    internal_dns_name = ""
+    internal_dns_zone_id         = ""
+    internal_dns_name            = ""
   }
 }
 
@@ -85,7 +85,7 @@ inputs = {
   vpc_private_subnets                       = dependency.common.outputs.vpc_private_subnets
   vpc_private_subnets_k8s                   = dependency.common.outputs.vpc_private_subnets_k8s
   subnet_cidr_blocks                        = dependency.common.outputs.subnet_cidr_blocks
-  subnet_ids                                = dependency.common.outputs.subnet_ids 
+  subnet_ids                                = dependency.common.outputs.subnet_ids
   vpc_public_subnets                        = dependency.common.outputs.vpc_public_subnets
   sns_alert_warning_arn                     = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                    = dependency.common.outputs.sns_alert_critical_arn
@@ -116,7 +116,9 @@ inputs = {
   internal_dns_certificate_arn              = dependency.dns.outputs.internal_dns_certificate_arn
   internal_dns_zone_id                      = dependency.dns.outputs.internal_dns_zone_id
   internal_dns_name                         = dependency.dns.outputs.internal_dns_name
-  
+  alarm_warning_callback_failure_threshold  = "1" # Todo: proper thresholds
+  alarm_critical_callback_failure_threshold = "1" # Todo: proper thresholds
+
 }
 
 terraform {

--- a/env/scratch/eks/terragrunt.hcl
+++ b/env/scratch/eks/terragrunt.hcl
@@ -85,6 +85,8 @@ inputs = {
   notification_base_url_regex_arn           = dependency.common.outputs.notification_base_url_regex_arn
   private-links-vpc-endpoints-securitygroup = dependency.common.outputs.private-links-vpc-endpoints-securitygroup
   private-links-gateway-prefix-list-ids     = dependency.common.outputs.private-links-gateway-prefix-list-ids
+  alarm_warning_callback_failure_threshold  = "1" # Todo: proper thresholds
+  alarm_critical_callback_failure_threshold = "1" # Todo: proper thresholds
 }
 
 terraform {

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -19,7 +19,7 @@ dependency "common" {
       "subnet-001e585d12cce4d1e",
       "subnet-08de34a9e1a7458dc",
       "subnet-0af8b8402f1d605ff",
-    ]    
+    ]
     vpc_public_subnets = [
       "subnet-0cecd9e634daf82d3",
       "subnet-0c7d18c0c51b28b61",
@@ -37,7 +37,7 @@ dependency "common" {
       "10.0.32.0/19",
       "10.0.64.0/19",
       "10.0.96.0/19",
-    ]    
+    ]
     sns_alert_warning_arn                     = ""
     sns_alert_critical_arn                    = ""
     sns_alert_general_arn                     = ""
@@ -69,8 +69,8 @@ dependency "dns" {
   mock_outputs_merge_with_state           = true
   mock_outputs = {
     internal_dns_certificate_arn = ""
-    internal_dns_zone_id = "ZQSVJUPU6J1EY"
-    internal_dns_name = "staging.notification.internal.com"
+    internal_dns_zone_id         = "ZQSVJUPU6J1EY"
+    internal_dns_name            = "staging.notification.internal.com"
   }
 }
 
@@ -133,12 +133,14 @@ inputs = {
   sqs_send_sms_low_queue_name               = dependency.common.outputs.sqs_send_sms_low_queue_name
   sqs_send_sms_medium_queue_name            = dependency.common.outputs.sqs_send_sms_medium_queue_name
   sqs_send_sms_high_queue_name              = dependency.common.outputs.sqs_send_sms_high_queue_name
-  celery_queue_prefix                       = "eks-notification-canada-ca" 
+  celery_queue_prefix                       = "eks-notification-canada-ca"
   internal_dns_certificate_arn              = dependency.dns.outputs.internal_dns_certificate_arn
   internal_dns_zone_id                      = dependency.dns.outputs.internal_dns_zone_id
   internal_dns_name                         = dependency.dns.outputs.internal_dns_name
   subnet_ids                                = dependency.common.outputs.subnet_ids
-  subnet_cidr_blocks                        = dependency.common.outputs.subnet_cidr_blocks  
+  subnet_cidr_blocks                        = dependency.common.outputs.subnet_cidr_blocks
+  alarm_warning_callback_failure_threshold  = "1" # Todo: proper thresholds
+  alarm_critical_callback_failure_threshold = "1" # Todo: proper thresholds
 }
 
 


### PR DESCRIPTION
# Summary | Résumé
This PR adds new alarms to warn when a service's callbacks consistently fail, consistently meeting a threshold (tbd) over a period of time.

## Related Issues | Cartes liées

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.