### PR TITLE
setting staging force destroy on static site to true

### DIFF
--- a/aws/system_status_static_site/main.tf
+++ b/aws/system_status_static_site/main.tf
@@ -11,7 +11,7 @@ module "system_status_static_site" {
   billing_tag_value                  = var.billing_tag_value
   hosted_zone_id                     = var.route_53_zone_arn
   s3_bucket_name                     = "notification-canada-ca-${var.env}-system-status"
-  force_destroy_s3_bucket            = var.force_destroy_s3
+  force_destroy_s3_bucket            = var.env == "staging" ? true : var.force_destroy_s3
   cloudfront_query_string_forwarding = true
 
   providers = {


### PR DESCRIPTION
# Summary | Résumé

Prepping to undo the static site change to retry it. Setting force destroy on the static site s3 bucket to true if in staging.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/58

# Test instructions | Instructions pour tester la modification
- TF Apply works

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.