### PR TITLE
First step of restoring old static site

### DIFF
--- a/aws/system_status_static_site/main.tf
+++ b/aws/system_status_static_site/main.tf
@@ -5,13 +5,16 @@ variable "billing_tag_value" {
 }
 
 module "system_status_static_site" {
-  source = "github.com/cds-snc/terraform-modules//simple_static_website?ref=v9.3.1"
+  source = "github.com/cds-snc/terraform-modules//simple_static_website?ref=v9.0.2"
 
+  count = var.status_cert_created ? 1 : 0
+
+  acm_certificate_arn                = aws_acm_certificate.system_status_static_site_root_certificate.arn
   domain_name_source                 = var.env == "production" ? "status.notification.canada.ca" : "status.${var.env}.notification.cdssandbox.xyz"
   billing_tag_value                  = var.billing_tag_value
   hosted_zone_id                     = var.route_53_zone_arn
   s3_bucket_name                     = "notification-canada-ca-${var.env}-system-status"
-  force_destroy_s3_bucket            = var.env == "staging" ? true : var.force_destroy_s3
+  force_destroy_s3_bucket            = var.force_destroy_s3
   cloudfront_query_string_forwarding = true
 
   providers = {
@@ -19,4 +22,41 @@ module "system_status_static_site" {
     aws.us-east-1 = aws.us-east-1
     aws.dns       = aws.dns
   }
+}
+
+
+resource "aws_acm_certificate" "system_status_static_site_root_certificate" {
+  # Cloudfront requires client certificate to be created in us-east-1
+
+  provider          = aws.us-east-1
+  domain_name       = var.env == "production" ? "status.notification.canada.ca" : "status.${var.env}.notification.cdssandbox.xyz"
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+}
+
+# This can't happen in production because we don't own the DNS zone. A PR will have to be done to cds-snc/dns with the validation records obtained from the above.
+
+resource "aws_acm_certificate_validation" "system_status_static_site" {
+  count                   = var.env != "production" ? 1 : 0
+  provider                = aws.us-east-1
+  certificate_arn         = aws_acm_certificate.system_status_static_site_root_certificate.arn
+  validation_record_fqdns = [aws_route53_record.system_status_static_site[0].fqdn]
+}
+
+resource "aws_route53_record" "system_status_static_site" {
+  count           = var.env != "production" ? 1 : 0
+  provider        = aws.dns
+  allow_overwrite = true
+  name            = tolist(aws_acm_certificate.system_status_static_site_root_certificate.domain_validation_options)[0].resource_record_name
+  records         = [tolist(aws_acm_certificate.system_status_static_site_root_certificate.domain_validation_options)[0].resource_record_value]
+  type            = tolist(aws_acm_certificate.system_status_static_site_root_certificate.domain_validation_options)[0].resource_record_type
+  zone_id         = var.route_53_zone_arn
+  ttl             = 60
 }

--- a/aws/system_status_static_site/outputs.tf
+++ b/aws/system_status_static_site/outputs.tf
@@ -1,14 +1,14 @@
 output "system_status_static_site_bucket_name" {
-  value       = module.system_status_static_site.s3_bucket_arn
+  value       = var.status_cert_created ? module.system_status_static_site[0].s3_bucket_arn : ""
   description = "name of the s3 bucket for the system status static site"
 }
 
 output "system_status_static_site_bucket_id" {
-  value       = module.system_status_static_site.s3_bucket_id
+  value       = var.status_cert_created ? module.system_status_static_site[0].s3_bucket_id : ""
   description = "id of the s3 bucket for the system status static site"
 }
 
 output "system_status_static_site_bucket_region" {
-  value       = module.system_status_static_site.s3_bucket_region
+  value       = var.status_cert_created ? module.system_status_static_site[0].s3_bucket_region : ""
   description = "aws region of the s3 bucket for the system status static site"
 }

--- a/aws/system_status_static_site/variables.tf
+++ b/aws/system_status_static_site/variables.tf
@@ -4,6 +4,12 @@ variable "route_53_zone_arn" {
   default     = "/hostedzone/Z04028033PLSHVOO9ZJ1Z"
 }
 
+variable "status_cert_created" {
+  type        = bool
+  description = "This flag must be set to false on a new environment creation in production, so that we can generate the certificate first."
+  default     = false
+}
+
 variable "force_destroy_s3" {
   type        = bool
   description = "Force destroy the s3 bucket. Not advised for production."

--- a/env/staging/system_status_static_site/.terraform.lock.hcl
+++ b/env/staging/system_status_static_site/.terraform.lock.hcl
@@ -1,0 +1,64 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.52.0"
+  constraints = ">= 4.9.0, ~> 5.0"
+  hashes = [
+    "h1:LEJSEOCO8LPIO6uxJDYrFXdr+Y9hSmTWVcSgG6EdGvw=",
+    "zh:22c4599d47cd59e5519c52afc528fa2aec43b4434f369870ee2806daa071449d",
+    "zh:3c2edc482662a654f84db4cd3f2cdd8f200147207d053d2e95082744b7814e6d",
+    "zh:57edc36f908c64de37e92a978f3d675604315a725268da936fcd1e270199db47",
+    "zh:79e7afd5fb161f2eb2b7f8e7fd5cbb7f56a2c64f141b56f511ec69337ad3e96b",
+    "zh:82c6ae9a7f971b6ee8c476b6eb7f1be9d24ddd183cbf025f52628084ddb3a5ae",
+    "zh:92faecc0a8f573f57f37d24415862380a40341eb13d66beb738dd0873899a58e",
+    "zh:963d3c0e1aa22c872cd96f04ceb41c388137b972f714efbde989221bf7f6f723",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:af6d3bb94aa8a84d740e3731d2379cc5e12aa48d5db0f7489c4639f3814a22d7",
+    "zh:b9f7aceeaf5daf71394eab9bf0f9f56fdc762cac90e4d62e63aa3fcdf6c1c127",
+    "zh:c3dcfc2569edae4f36b798c76da7f7633e7bf322505d447d7c370a56c2a30dd2",
+    "zh:c8abb21c5ceba857f0eaff9e531d781dc655f8cdfae1cf056066daae72546a7f",
+    "zh:d92004a6a2a770d2542fd9c01b685418ab8d7ab422cf2cdce35dde789bc8593c",
+    "zh:dc794660b1d6d8f26a917e0ffab1875aa75144736875efaa60f29c72bf02afbf",
+    "zh:df931c4905e35ae43d558f6cda15f05710a7a24ecbb94533f8822e7572126512",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.6.2"
+  hashes = [
+    "h1:R5qdQjKzOU16TziCN1vR3Exr/B+8WGK80glLTT4ZCPk=",
+    "zh:0ef01a4f81147b32c1bea3429974d4d104bbc4be2ba3cfa667031a8183ef88ec",
+    "zh:1bcd2d8161e89e39886119965ef0f37fcce2da9c1aca34263dd3002ba05fcb53",
+    "zh:37c75d15e9514556a5f4ed02e1548aaa95c0ecd6ff9af1119ac905144c70c114",
+    "zh:4210550a767226976bc7e57d988b9ce48f4411fa8a60cd74a6b246baf7589dad",
+    "zh:562007382520cd4baa7320f35e1370ffe84e46ed4e2071fdc7e4b1a9b1f8ae9b",
+    "zh:5efb9da90f665e43f22c2e13e0ce48e86cae2d960aaf1abf721b497f32025916",
+    "zh:6f71257a6b1218d02a573fc9bff0657410404fb2ef23bc66ae8cd968f98d5ff6",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9647e18f221380a85f2f0ab387c68fdafd58af6193a932417299cdcae4710150",
+    "zh:bb6297ce412c3c2fa9fec726114e5e0508dd2638cad6a0cb433194930c97a544",
+    "zh:f83e925ed73ff8a5ef6e3608ad9225baa5376446349572c2449c0c0b3cf184b7",
+    "zh:fbef0781cb64de76b1df1ca11078aecba7800d82fd4a956302734999cfd9a4af",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.0.5"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:yLqz+skP3+EbU3yyvw8JqzflQTKDQGsC9QyZAg+S4dg=",
+    "zh:01cfb11cb74654c003f6d4e32bbef8f5969ee2856394a96d127da4949c65153e",
+    "zh:0472ea1574026aa1e8ca82bb6df2c40cd0478e9336b7a8a64e652119a2fa4f32",
+    "zh:1a8ddba2b1550c5d02003ea5d6cdda2eef6870ece86c5619f33edd699c9dc14b",
+    "zh:1e3bb505c000adb12cdf60af5b08f0ed68bc3955b0d4d4a126db5ca4d429eb4a",
+    "zh:6636401b2463c25e03e68a6b786acf91a311c78444b1dc4f97c539f9f78de22a",
+    "zh:76858f9d8b460e7b2a338c477671d07286b0d287fd2d2e3214030ae8f61dd56e",
+    "zh:a13b69fb43cb8746793b3069c4d897bb18f454290b496f19d03c3387d1c9a2dc",
+    "zh:a90ca81bb9bb509063b736842250ecff0f886a91baae8de65c8430168001dad9",
+    "zh:c4de401395936e41234f1956ebadbd2ed9f414e6908f27d578614aaa529870d4",
+    "zh:c657e121af8fde19964482997f0de2d5173217274f6997e16389e7707ed8ece8",
+    "zh:d68b07a67fbd604c38ec9733069fbf23441436fecf554de6c75c032f82e1ef19",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/env/staging/system_status_static_site/terragrunt.hcl
+++ b/env/staging/system_status_static_site/terragrunt.hcl
@@ -9,5 +9,5 @@ include {
 inputs = {
   env                                    = "staging"
   billing_tag_value                      = "notification-canada-ca-staging"
-  status_cert_created                    = true
+  status_cert_created                    = false
 }


### PR DESCRIPTION
# Summary | Résumé

Reverting to the old static site code. This PR will cause the deletion of the new site, and then a new PR will need to be created to create with the old code once the ACM cert is created. This double PR thing is the whole reason why we changed this code in the first place.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/58

# Test instructions | Instructions pour tester la modification

TF Apply works

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.