### PR TITLE
Putting the right version on static site back

### DIFF
--- a/aws/system_status_static_site/main.tf
+++ b/aws/system_status_static_site/main.tf
@@ -5,7 +5,7 @@ variable "billing_tag_value" {
 }
 
 module "system_status_static_site" {
-  source = "github.com/cds-snc/terraform-modules//simple_static_website?ref=v9.0.2"
+  source = "github.com/cds-snc/terraform-modules//simple_static_website?ref=v9.3.1"
 
   count = var.status_cert_created ? 1 : 0
 


### PR DESCRIPTION
# Summary | Résumé

Reverting back to the correct static website module for system status

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/58

# Test instructions | Instructions pour tester la modification

TF Apply works

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.