### PR TITLE
Remove Retry: string from pattern

### DIFF
--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -183,7 +183,7 @@ resource "aws_cloudwatch_log_metric_filter" "github-arc-write-alarm" {
 resource "aws_cloudwatch_log_metric_filter" "callback-max-retry-failures" {
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "callback-max-retry-failures"
-  pattern        = "Retry: send_delivery_status_to_service has retried the max num of times for callback url"
+  pattern        = "send_delivery_status_to_service has retried the max num of times for callback url"
   log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs[0].name
 
   metric_transformation {


### PR DESCRIPTION
# Summary | Résumé
Quick PR that removes `Retry:` from the `callback-max-retry-failures` alarm for simplicity's sake.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.