### PR TITLE
Remove dimensions from metric_filter

### DIFF
--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -190,10 +190,5 @@ resource "aws_cloudwatch_log_metric_filter" "callback-max-retry-failures" {
     name      = "callback-max-retry-failures"
     namespace = "LogMetrics"
     value     = "1"
-    dimensions = {
-      url             = "$.url"
-      notification_id = "$.notification_id"
-      service_id      = "$.service"
-    }
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Quick PR to remove the dimensions from the log_metric_filter, `callback-max-retry-failures`.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.