### PR TITLE
update prod terragrunt

### DIFF
--- a/env/production/pinpoint_to_sqs_sms_callbacks/terragrunt.hcl
+++ b/env/production/pinpoint_to_sqs_sms_callbacks/terragrunt.hcl
@@ -20,6 +20,13 @@ dependency "common" {
     sns_alert_ok_arn                             = ""
     sqs_deliver_receipts_queue_arn               = ""
     sns_monthly_spend_limit                      = 1
+    celery_queue_prefix                          = ""
+    sqs_send_sms_high_queue_delay_warning_arn    = ""
+    sqs_send_sms_high_queue_delay_critical_arn   = ""
+    sqs_send_sms_medium_queue_delay_warning_arn  = ""
+    sqs_send_sms_medium_queue_delay_critical_arn = ""
+    sqs_send_sms_low_queue_delay_warning_arn     = ""
+    sqs_send_sms_low_queue_delay_critical_arn    = ""
   }
 }
 
@@ -46,4 +53,11 @@ inputs = {
   pinpoint_to_sqs_sms_callbacks_ecr_repository_url   = dependency.ecr.outputs.pinpoint_to_sqs_sms_callbacks_ecr_repository_url
   pinpoint_to_sqs_sms_callbacks_ecr_arn              = dependency.ecr.outputs.pinpoint_to_sqs_sms_callbacks_ecr_arn
   sms_monthly_spend_limit                            = dependency.common.outputs.sns_monthly_spend_limit
+  celery_queue_prefix                                = dependency.common.outputs.celery_queue_prefix
+  sqs_send_sms_high_queue_delay_warning_arn          = dependency.common.outputs.sqs_send_sms_high_queue_delay_warning_arn
+  sqs_send_sms_high_queue_delay_critical_arn         = dependency.common.outputs.sqs_send_sms_high_queue_delay_critical_arn
+  sqs_send_sms_medium_queue_delay_warning_arn        = dependency.common.outputs.sqs_send_sms_medium_queue_delay_warning_arn
+  sqs_send_sms_medium_queue_delay_critical_arn       = dependency.common.outputs.sqs_send_sms_medium_queue_delay_critical_arn
+  sqs_send_sms_low_queue_delay_warning_arn           = dependency.common.outputs.sqs_send_sms_low_queue_delay_warning_arn
+  sqs_send_sms_low_queue_delay_critical_arn          = dependency.common.outputs.sqs_send_sms_low_queue_delay_critical_arn
 }


### PR DESCRIPTION
# Summary | Résumé

Make changes to prod terragrunt file as were done [in staging](https://github.com/cds-snc/notification-terraform/pull/1369/files#diff-13b06e795a7bb17a16b83f23767884bd1176dadeeacf7a35e99f7a30baf4606c).

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/368

# Test instructions | Instructions pour tester la modification

None

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.