### PR TITLE
task: add new routes for template categories admin

### DIFF
--- a/aws/common/waf.tf
+++ b/aws/common/waf.tf
@@ -98,7 +98,7 @@ resource "aws_wafv2_regex_pattern_set" "re_admin2" {
   # https://docs.aws.amazon.com/waf/latest/developerguide/waf-regex-pattern-set-managing.html
 
   regular_expression {
-    regex_string = "/sitemap|/plandesite|/agree-terms|/getting-started|/decouvrir-notification-gc"
+    regex_string = "/sitemap|/plandesite|/agree-terms|/getting-started|/decouvrir-notification-gc|/template-categories.*"
   }
 
   tags = {


### PR DESCRIPTION
# Summary | Résumé

Adds new routes for the template category admin:
- `/template-categories`
- `/template-categories/<template_category_id>`

## Related Issues | Cartes liées
* https://github.com/cds-snc/notification-planning/issues/1588

# Test instructions | Instructions pour tester la modification
- Ensure new routes are accessible

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.