### PR TITLE
Tweak pool creation script to enable international sms sending

### DIFF
--- a/aws/pinpoint_to_sqs_sms_callbacks/create_pinpoint_pools.sh
+++ b/aws/pinpoint_to_sqs_sms_callbacks/create_pinpoint_pools.sh
@@ -49,14 +49,16 @@ if [ $shortcodePoolExists == true ]; then
 else
     echo "Creating shortcode pool"
     number1=$(aws pinpoint-sms-voice-v2 request-phone-number --iso-country-code CA --message-type TRANSACTIONAL --number-capabilities SMS --number-type LONG_CODE | jq -r ".PhoneNumberId")
-    aws pinpoint-sms-voice-v2 create-pool --origination-identity $number1 --iso-country-code CA --message-type TRANSACTIONAL --tags Key=Name,Value=shortcode-pool
+    poolId=$(aws pinpoint-sms-voice-v2 create-pool --origination-identity $number1 --iso-country-code CA --message-type TRANSACTIONAL --tags Key=Name,Value=shortcode-pool | jq -r ".PoolId")
+    aws pinpoint-sms-voice-v2 update-pool --pool-id $poolId --shared-routes-enabled
 fi
 if [ $defaultPoolExists == true ]; then
     echo "Default pool already exists"
 else
     echo "Creating default pool"
     number2=$(aws pinpoint-sms-voice-v2 request-phone-number --iso-country-code CA --message-type TRANSACTIONAL --number-capabilities SMS --number-type LONG_CODE  | jq -r ".PhoneNumberId")
-    aws pinpoint-sms-voice-v2 create-pool --origination-identity $number2 --iso-country-code CA --message-type TRANSACTIONAL --tags Key=Name,Value=default-pool
+    poolId=$(aws aws pinpoint-sms-voice-v2 create-pool --origination-identity $number2 --iso-country-code CA --message-type TRANSACTIONAL --tags Key=Name,Value=default-pool | jq -r ".PoolId")
+    aws pinpoint-sms-voice-v2 update-pool --pool-id $poolId --shared-routes-enabled
 fi
 
 # # Create a configuration set and assign destinations


### PR DESCRIPTION
# Summary | Résumé

By default new Pinpoint pools are not allowed to send to countries that we do not have a number for. This PR enables tells AWS to use one of their own international phone numbers if we do not have one.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/370

# Test instructions | Instructions pour tester la modification

Run and create your own pools (change the names of the pools in the script). The pools should have shared routes enabled in the console.

# Release Instructions | Instructions pour le déploiement

We will have to manually update the existing pools in staging and production.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.