### PR TITLE
adding sender id to SNS

### DIFF
--- a/aws/common/sns.tf
+++ b/aws/common/sns.tf
@@ -134,6 +134,8 @@ resource "aws_sns_sms_preferences" "update-sms-prefs" {
   delivery_status_success_sampling_rate = 100
   monthly_spend_limit                   = var.sns_monthly_spend_limit
   usage_report_s3_bucket                = module.sns_sms_usage_report_bucket.s3_bucket_id
+  default_sender_id                     = "CANADA-CA"
+  default_sms_type                      = "Transactional"
 }
 
 resource "aws_sns_sms_preferences" "update-sms-prefs-us-west-2" {
@@ -143,6 +145,8 @@ resource "aws_sns_sms_preferences" "update-sms-prefs-us-west-2" {
   delivery_status_success_sampling_rate = 100
   monthly_spend_limit                   = var.sns_monthly_spend_limit_us_west_2
   usage_report_s3_bucket                = module.sns_sms_usage_report_bucket_us_west_2.s3_bucket_id
+  default_sender_id                     = "CANADA-CA"
+  default_sms_type                      = "Transactional"
 }
 
 resource "aws_sns_topic_subscription" "sns_alert_ok_us_west_2_to_lambda" {


### PR DESCRIPTION
# Summary | Résumé

Adding the sender id to AWS SNS for SMS. This is required to unblock SMS messages to the UK.


## Related Issues | Cartes liées

* https://cds-snc.freshdesk.com/a/tickets/17921

# Test instructions | Instructions pour tester la modification

TF Apply works. We would need a test number in GB to actually test if it is successful. 

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.