### PR TITLE
staging oidc test

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -13,9 +13,11 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  id-token: write   # This is required for requesting the OIDC JWT
+  contents: read    # This is required for actions/checkout      
+
 env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: ca-central-1
   TF_VAR_base_domain: ${{secrets.PRODUCTION_BASE_DOMAIN}}
   TF_VAR_alt_base_domain: ${{secrets.PRODUCTION_ALT_BASE_DOMAIN}}  
@@ -83,6 +85,13 @@ jobs:
             TERRAFORM_VERSION: 1.6.2
             TERRAGRUNT_VERSION: 0.44.4
             TF_SUMMARIZE_VERSION: 0.2.3        
+
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::296255494825:role/notification-terraform-apply
+          role-session-name: NotifyTerraformApply
+          aws-region: "ca-central-1"
 
       - name: Inject token authentication
         run: |

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -16,9 +16,11 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  id-token: write   # This is required for requesting the OIDC JWT
+  contents: read    # This is required for actions/checkout      
+
 env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: ca-central-1
   TF_VAR_base_domain: ${{secrets.STAGING_BASE_DOMAIN}}
   TF_VAR_alt_base_domain: ${{secrets.STAGING_ALT_BASE_DOMAIN}}
@@ -84,6 +86,13 @@ jobs:
             TERRAFORM_VERSION: 1.6.2
             TERRAGRUNT_VERSION: 0.44.4
             TF_SUMMARIZE_VERSION: 0.2.3
+
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role-session-name: NotifyTerraformApply
+          aws-region: "ca-central-1"
 
       - name: Apply aws/common
         run: |

--- a/.github/workflows/terragrunt_plan_production.yml
+++ b/.github/workflows/terragrunt_plan_production.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::296255494825:role/notification-terraform-apply
+          role-to-assume: arn:aws:iam::296255494825:role/notification-terraform-plan
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"
 

--- a/.github/workflows/terragrunt_plan_production.yml
+++ b/.github/workflows/terragrunt_plan_production.yml
@@ -5,10 +5,12 @@ on:
     paths:
       - ".github/workflows/infrastructure_version.txt"
 
+permissions:
+  id-token: write   # This is required for requesting the OIDC JWT
+  contents: read    # This is required for actions/checkout      
+
 env:
   TARGET_ENV_PATH: production
-  AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: ca-central-1
   TERRAFORM_VERSION: 0.14.4
   TERRAGRUNT_VERSION: 0.35.13
@@ -69,6 +71,13 @@ jobs:
             TERRAFORM_VERSION: 1.6.2
             TERRAGRUNT_VERSION: 0.44.4
             TF_SUMMARIZE_VERSION: 0.2.3           
+
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::296255494825:role/notification-terraform-apply
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"
 
       - name: Set INFRASTRUCTURE_VERSION
         run: |

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -12,8 +12,6 @@ on:
 
 env:
   TARGET_ENV_PATH: staging
-  AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: ca-central-1
   TERRAFORM_VERSION: 0.14.4
   TERRAGRUNT_VERSION: 0.35.13
@@ -76,7 +74,23 @@ jobs:
             CONFTEST_VERSION: 0.30.0 
             TERRAFORM_VERSION: 1.6.2
             TERRAGRUNT_VERSION: 0.44.4
-            TF_SUMMARIZE_VERSION: 0.2.3           
+            TF_SUMMARIZE_VERSION: 0.2.3
+
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"
+
+      - name: Terragrunt plan common
+        uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
+        with:
+          directory: "env/staging/common"
+          comment-delete: "true"
+          comment-title: "Staging: common"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
 
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: filter

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -83,9 +83,18 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"
+
+      - name: Terragrunt plan common
+        uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
+        with:
+          directory: "env/staging/common"
+          comment-delete: "true"
+          comment-title: "Staging: common"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
 
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: filter

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -10,6 +10,10 @@ on:
       - "env/terragrunt.hcl"
       - ".github/workflows/terragrunt_plan_staging.yml"
 
+permissions:
+  id-token: write   # This is required for requesting the OIDC JWT
+  contents: read    # This is required for actions/checkout
+  
 env:
   TARGET_ENV_PATH: staging
   AWS_REGION: ca-central-1

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -13,7 +13,7 @@ on:
 permissions:
   id-token: write   # This is required for requesting the OIDC JWT
   contents: read    # This is required for actions/checkout
-  
+
 env:
   TARGET_ENV_PATH: staging
   AWS_REGION: ca-central-1
@@ -86,15 +86,6 @@ jobs:
           role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"
-
-      - name: Terragrunt plan common
-        uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
-        with:
-          directory: "env/staging/common"
-          comment-delete: "true"
-          comment-title: "Staging: common"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          terragrunt: "true"
 
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: filter

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -87,15 +87,6 @@ jobs:
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"
 
-      - name: Terragrunt plan common
-        uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
-        with:
-          directory: "env/staging/common"
-          comment-delete: "true"
-          comment-title: "Staging: common"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          terragrunt: "true"
-
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: filter
         with:


### PR DESCRIPTION
# Summary | Résumé

Convert our github actions for terraform to use OIDC authentication instead of access keys. 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/36

# Test instructions | Instructions pour tester la modification

TF Apply/Plan work in staging and prod

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.