### PR TITLE
allowing gha to write to contents for bump version

### DIFF
--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -18,7 +18,7 @@ defaults:
 
 permissions:
   id-token: write   # This is required for requesting the OIDC JWT
-  contents: read    # This is required for actions/checkout      
+  contents: write    # This is required for actions/checkout      
 
 env:
   AWS_REGION: ca-central-1


### PR DESCRIPTION
# Summary | Résumé

Fixing permissions for bump and push tag.

