### PR TITLE
setting contents permission to write

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -15,7 +15,7 @@ defaults:
 
 permissions:
   id-token: write   # This is required for requesting the OIDC JWT
-  contents: read    # This is required for actions/checkout      
+  contents: write    # This is required for actions/checkout      
 
 env:
   AWS_REGION: ca-central-1

--- a/.github/workflows/terragrunt_plan_production.yml
+++ b/.github/workflows/terragrunt_plan_production.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   id-token: write   # This is required for requesting the OIDC JWT
-  contents: read    # This is required for actions/checkout      
+  contents: write    # This is required for actions/checkout      
 
 env:
   TARGET_ENV_PATH: production

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -12,7 +12,7 @@ on:
 
 permissions:
   id-token: write   # This is required for requesting the OIDC JWT
-  contents: read    # This is required for actions/checkout
+  contents: write    # This is required for actions/checkout
 
 env:
   TARGET_ENV_PATH: staging


### PR DESCRIPTION
# Summary | Résumé

Setting the content permission to write for all GHA for terraform

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/36

# Test instructions | Instructions pour tester la modification

TF Plan/Apply works

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.