### PR TITLE
Adding filter for newrelic

### DIFF
--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -80,6 +80,7 @@ jobs:
       lambda-google-cidr: ${{ steps.filter.outputs.lambda-google-cidr }}
       system_status: ${{ steps.filter.outputs.system_status }}      
       system_status_static_site: ${{ steps.filter.outputs.system_status_static_site }}      
+      new_relic: ${{ steps.filter.outputs.newrelic }}
 
     steps:
 
@@ -691,6 +692,7 @@ jobs:
   terragrunt-plan-newrelic:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.newrelic == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest  


### PR DESCRIPTION
# Summary | Résumé

Fixing a bug in the terragrunt staging plan where newrelic would always run because we weren't applying the filter.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/143

# Test instructions | Instructions pour tester la modification

TF Plan works

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.