### PR TITLE
OIDC in staging take 2

### DIFF
--- a/.github/actions/setup-terraform/action.yml
+++ b/.github/actions/setup-terraform/action.yml
@@ -3,6 +3,11 @@ name: "setup-terraform"
 on:
   workflow_call:
 
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
 runs:
   using: "composite"
   steps:
@@ -21,3 +26,10 @@ runs:
           TERRAFORM_VERSION: 1.6.2
           TERRAGRUNT_VERSION: 0.44.4
           TF_SUMMARIZE_VERSION: 0.2.3                    
+
+    - name: Configure credentials to Notify account using OIDC
+      uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+      with:
+        role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+        role-session-name: NotifyTerraformPlan
+        aws-region: "ca-central-1"

--- a/.github/actions/setup-terraform/action.yml
+++ b/.github/actions/setup-terraform/action.yml
@@ -2,6 +2,17 @@ name: "setup-terraform"
 
 on:
   workflow_call:
+    inputs:
+      role_to_assume:
+        description: 'The roll to assume when configuring AWS credentials'
+        default: 'arn:aws:iam::239043911459:role/notification-terraform-apply'
+        required: false
+        type: string
+      role_session_name:
+        description: 'The name of the session when configuring AWS credentials'
+        default: 'NotifyTerraformPlan'
+        required: false
+        type: string
 
 permissions:
   id-token: write
@@ -30,6 +41,6 @@ runs:
     - name: Configure credentials to Notify account using OIDC
       uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
       with:
-        role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-        role-session-name: NotifyTerraformPlan
+        role-to-assume: ${{ inputs.role_to_assume }}
+        role-session-name: ${{ inputs.role_session_name }}
         aws-region: "ca-central-1"

--- a/.github/actions/setup-terraform/action.yml
+++ b/.github/actions/setup-terraform/action.yml
@@ -2,7 +2,11 @@ name: "setup-terraform"
 
 on:
   workflow_call:
-  
+
+permissions:
+  id-token: write   # This is required for requesting the OIDC JWT
+  contents: write    # This is required for actions/checkout
+
 runs:
   using: "composite"
   steps:

--- a/.github/actions/setup-terraform/action.yml
+++ b/.github/actions/setup-terraform/action.yml
@@ -3,10 +3,6 @@ name: "setup-terraform"
 on:
   workflow_call:
 
-permissions:
-  id-token: write   # This is required for requesting the OIDC JWT
-  contents: write    # This is required for actions/checkout
-
 runs:
   using: "composite"
   steps:
@@ -25,10 +21,3 @@ runs:
           TERRAFORM_VERSION: 1.6.2
           TERRAGRUNT_VERSION: 0.44.4
           TF_SUMMARIZE_VERSION: 0.2.3                    
-
-    - name: Configure credentials to Notify account using OIDC
-      uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-      with:
-        role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
-        role-session-name: NotifyTerraformPlan
-        aws-region: "ca-central-1"

--- a/.github/actions/setup-terraform/action.yml
+++ b/.github/actions/setup-terraform/action.yml
@@ -5,13 +5,11 @@ on:
     inputs:
       role_to_assume:
         description: The roll to assume when configuring AWS credentials
-        default: arn:aws:iam::239043911459:role/notification-terraform-apply
-        required: false
+        required: true
         type: string
       role_session_name:
         description: The name of the session when configuring AWS credentials
-        default: NotifyTerraformPlan
-        required: false
+        required: true
         type: string
 
 permissions:

--- a/.github/actions/setup-terraform/action.yml
+++ b/.github/actions/setup-terraform/action.yml
@@ -4,13 +4,13 @@ on:
   workflow_call:
     inputs:
       role_to_assume:
-        description: 'The roll to assume when configuring AWS credentials'
-        default: 'arn:aws:iam::239043911459:role/notification-terraform-apply'
+        description: The roll to assume when configuring AWS credentials
+        default: arn:aws:iam::239043911459:role/notification-terraform-apply
         required: false
         type: string
       role_session_name:
-        description: 'The name of the session when configuring AWS credentials'
-        default: 'NotifyTerraformPlan'
+        description: The name of the session when configuring AWS credentials
+        default: NotifyTerraformPlan
         required: false
         type: string
 

--- a/.github/actions/setup-terraform/action.yml
+++ b/.github/actions/setup-terraform/action.yml
@@ -2,7 +2,7 @@ name: "setup-terraform"
 
 on:
   workflow_call:
-
+  
 runs:
   using: "composite"
   steps:
@@ -21,3 +21,10 @@ runs:
           TERRAFORM_VERSION: 1.6.2
           TERRAGRUNT_VERSION: 0.44.4
           TF_SUMMARIZE_VERSION: 0.2.3                    
+
+    - name: Configure credentials to Notify account using OIDC
+      uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+      with:
+        role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+        role-session-name: NotifyTerraformPlan
+        aws-region: "ca-central-1"

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"
 
@@ -109,7 +109,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"        
 
@@ -136,7 +136,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"        
 
@@ -163,7 +163,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"        
 
@@ -190,7 +190,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"
 
@@ -218,7 +218,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"        
 
@@ -245,7 +245,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"        
 
@@ -272,7 +272,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"        
 
@@ -299,7 +299,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"        
 
@@ -326,7 +326,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"        
 
@@ -353,7 +353,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"        
 
@@ -380,7 +380,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"        
 
@@ -407,7 +407,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"        
 
@@ -434,7 +434,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"        
 
@@ -461,7 +461,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"           
 
@@ -488,7 +488,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"
 
@@ -515,7 +515,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"        
 
@@ -542,7 +542,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"        
 
@@ -569,7 +569,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"        
 
@@ -596,7 +596,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"        
 
@@ -623,7 +623,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"        
 
@@ -650,7 +650,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
           role-session-name: NotifyTerraformPlan
           aws-region: "ca-central-1"        
 

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -75,6 +75,13 @@ jobs:
           username: ${{ inputs.username }}
           token: ${{ secrets.envPAT }}
 
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"
+
       - name: Terragrunt apply common
         run: |
           cd env/staging/common
@@ -93,6 +100,13 @@ jobs:
         
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
+
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"        
 
       - name: Terragrunt apply ECR
         run: |
@@ -114,6 +128,13 @@ jobs:
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform
 
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"        
+
       - name: Terragrunt apply ses_receiving_emails
         run: |
           cd env/staging/ses_receiving_emails
@@ -134,6 +155,13 @@ jobs:
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform
 
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"        
+
       - name: Terragrunt apply dns
         run: |
           cd env/staging/dns
@@ -153,6 +181,13 @@ jobs:
         
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform
+
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"
 
       - name: Terragrunt apply ses_validation_dns_entries
         run: |
@@ -175,6 +210,13 @@ jobs:
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform 
 
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"        
+
       - name: Terragrunt apply cloudfront
         run: |
           cd env/staging/cloudfront
@@ -194,6 +236,13 @@ jobs:
         
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform
+
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"        
 
       - name: Terragrunt apply eks
         run: |
@@ -215,6 +264,13 @@ jobs:
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform
 
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"        
+
       - name: Terragrunt apply elasticache
         run: |
           cd env/staging/elasticache
@@ -234,6 +290,13 @@ jobs:
         
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform
+
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"        
 
       - name: Terragrunt apply rds
         run: |
@@ -255,6 +318,13 @@ jobs:
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform
 
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"        
+
       - name: Terragrunt apply lambda-api
         run: |
           cd env/staging/lambda-api
@@ -274,6 +344,13 @@ jobs:
         
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform
+
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"        
 
       - name: Terragrunt apply lambda-admin-pr
         run: |
@@ -295,6 +372,13 @@ jobs:
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform
 
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"        
+
       - name: Terragrunt apply performance-test
         run: |
           cd env/staging/performance-test
@@ -314,6 +398,13 @@ jobs:
         
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform
+
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"        
 
       - name: Terragrunt apply heartbeat
         run: |
@@ -335,6 +426,13 @@ jobs:
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform
 
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"        
+
       - name: Terragrunt apply database-tools
         run: |
           cd env/staging/database-tools
@@ -353,7 +451,14 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
       - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform          
+        uses: ./.github/actions/setup-terraform       
+        
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"           
 
       - name: Terragrunt apply quicksight
         run: |
@@ -375,6 +480,13 @@ jobs:
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform     
 
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"
+
       - name: Terragrunt apply lambda-google-cidr
         run: |
           cd env/staging/lambda-google-cidr
@@ -394,6 +506,13 @@ jobs:
         
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform 
+
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"        
 
       - name: Terragrunt apply ses_to_sqs_email_callbacks
         run: |
@@ -415,6 +534,13 @@ jobs:
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform 
 
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"        
+
       - name: Terragrunt apply sns_to_sqs_sms_callbacks
         run: |
           cd env/staging/sns_to_sqs_sms_callbacks
@@ -434,6 +560,13 @@ jobs:
         
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform 
+
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"        
 
       - name: Terragrunt apply pinpoint_to_sqs_sms_callbacks
         run: |
@@ -455,6 +588,13 @@ jobs:
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform 
 
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"        
+
       - name: Terragrunt apply system_status
         run: |
           cd env/staging/system_status
@@ -475,6 +615,13 @@ jobs:
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform 
 
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"        
+
       - name: Terragrunt apply aws/system_status_static_site
         run: |
           cd env/staging/system_status_static_site
@@ -494,6 +641,13 @@ jobs:
         
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform 
+
+      - name: Configure credentials to Notify account using OIDC
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-plan
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"        
 
       - name: Terragrunt apply aws/newrelic
         run: |

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -61,6 +61,11 @@ env:
   TF_VAR_budget_sre_bot_webhook: ${{ secrets.STAGING_BUDGET_SRE_BOT_WEBHOOK }}
   TF_VAR_enable_sentinel_forwarding: true
 
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
 jobs:
   
   terragrunt-apply-common:

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -17,8 +17,6 @@ defaults:
     shell: bash
 
 env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: ca-central-1
   TF_VAR_new_relic_api_key: ${{ secrets.PRODUCTION_NEW_RELIC_API_KEY }}
   TF_VAR_new_relic_account_id: ${{ secrets.PRODUCTION_NEW_RELIC_ACCOUNT_ID }}

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -80,13 +80,6 @@ jobs:
           username: ${{ inputs.username }}
           token: ${{ secrets.envPAT }}
 
-      - name: Configure credentials to Notify account using OIDC
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"
-
       - name: Terragrunt apply common
         run: |
           cd env/staging/common
@@ -105,13 +98,6 @@ jobs:
         
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
-
-      - name: Configure credentials to Notify account using OIDC
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"        
 
       - name: Terragrunt apply ECR
         run: |

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -77,8 +77,8 @@ jobs:
 
       - uses: ./.github/actions/setup-terraform
         with:
-          username: ${{ inputs.username }}
-          token: ${{ secrets.envPAT }}
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan
 
       - name: Terragrunt apply common
         run: |
@@ -98,6 +98,9 @@ jobs:
         
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan        
 
       - name: Terragrunt apply ECR
         run: |
@@ -119,13 +122,6 @@ jobs:
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform
 
-      - name: Configure credentials to Notify account using OIDC
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"        
-
       - name: Terragrunt apply ses_receiving_emails
         run: |
           cd env/staging/ses_receiving_emails
@@ -144,14 +140,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform
-
-      - name: Configure credentials to Notify account using OIDC
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"        
+        uses: ./.github/actions/setup-terraform     
 
       - name: Terragrunt apply dns
         run: |
@@ -172,13 +161,6 @@ jobs:
         
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform
-
-      - name: Configure credentials to Notify account using OIDC
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"
 
       - name: Terragrunt apply ses_validation_dns_entries
         run: |
@@ -201,13 +183,6 @@ jobs:
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform 
 
-      - name: Configure credentials to Notify account using OIDC
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"        
-
       - name: Terragrunt apply cloudfront
         run: |
           cd env/staging/cloudfront
@@ -226,14 +201,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
       - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform
-
-      - name: Configure credentials to Notify account using OIDC
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"        
+        uses: ./.github/actions/setup-terraform      
 
       - name: Terragrunt apply eks
         run: |
@@ -255,13 +223,6 @@ jobs:
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform
 
-      - name: Configure credentials to Notify account using OIDC
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"        
-
       - name: Terragrunt apply elasticache
         run: |
           cd env/staging/elasticache
@@ -282,13 +243,6 @@ jobs:
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform
 
-      - name: Configure credentials to Notify account using OIDC
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"        
-
       - name: Terragrunt apply rds
         run: |
           cd env/staging/rds
@@ -307,14 +261,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
       - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform
-
-      - name: Configure credentials to Notify account using OIDC
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"        
+        uses: ./.github/actions/setup-terraform     
 
       - name: Terragrunt apply lambda-api
         run: |
@@ -336,13 +283,6 @@ jobs:
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform
 
-      - name: Configure credentials to Notify account using OIDC
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"        
-
       - name: Terragrunt apply lambda-admin-pr
         run: |
           cd env/staging/lambda-admin-pr
@@ -361,14 +301,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
       - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform
-
-      - name: Configure credentials to Notify account using OIDC
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"        
+        uses: ./.github/actions/setup-terraform      
 
       - name: Terragrunt apply performance-test
         run: |
@@ -390,13 +323,6 @@ jobs:
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform
 
-      - name: Configure credentials to Notify account using OIDC
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"        
-
       - name: Terragrunt apply heartbeat
         run: |
           cd env/staging/heartbeat
@@ -415,14 +341,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
       - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform
-
-      - name: Configure credentials to Notify account using OIDC
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"        
+        uses: ./.github/actions/setup-terraform      
 
       - name: Terragrunt apply database-tools
         run: |
@@ -442,14 +361,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
       - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform       
-        
-      - name: Configure credentials to Notify account using OIDC
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"           
+        uses: ./.github/actions/setup-terraform             
 
       - name: Terragrunt apply quicksight
         run: |
@@ -471,13 +383,6 @@ jobs:
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform     
 
-      - name: Configure credentials to Notify account using OIDC
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"
-
       - name: Terragrunt apply lambda-google-cidr
         run: |
           cd env/staging/lambda-google-cidr
@@ -496,14 +401,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
       - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform 
-
-      - name: Configure credentials to Notify account using OIDC
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"        
+        uses: ./.github/actions/setup-terraform     
 
       - name: Terragrunt apply ses_to_sqs_email_callbacks
         run: |
@@ -523,14 +421,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
       - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform 
-
-      - name: Configure credentials to Notify account using OIDC
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"        
+        uses: ./.github/actions/setup-terraform     
 
       - name: Terragrunt apply sns_to_sqs_sms_callbacks
         run: |
@@ -550,14 +441,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
       - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform 
-
-      - name: Configure credentials to Notify account using OIDC
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"        
+        uses: ./.github/actions/setup-terraform   
 
       - name: Terragrunt apply pinpoint_to_sqs_sms_callbacks
         run: |
@@ -577,14 +461,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
       - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform 
-
-      - name: Configure credentials to Notify account using OIDC
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"        
+        uses: ./.github/actions/setup-terraform  
 
       - name: Terragrunt apply system_status
         run: |
@@ -604,14 +481,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
       - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform 
-
-      - name: Configure credentials to Notify account using OIDC
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"        
+        uses: ./.github/actions/setup-terraform      
 
       - name: Terragrunt apply aws/system_status_static_site
         run: |
@@ -631,14 +501,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
       - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform 
-
-      - name: Configure credentials to Notify account using OIDC
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"        
+        uses: ./.github/actions/setup-terraform    
 
       - name: Terragrunt apply aws/newrelic
         run: |

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -78,7 +78,7 @@ jobs:
       - uses: ./.github/actions/setup-terraform
         with:
           role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role_session_name: NotifyTerraformPlan
+          role_session_name: NotifyTerraformApply
 
       - name: Terragrunt apply common
         run: |
@@ -100,7 +100,7 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role_session_name: NotifyTerraformPlan        
+          role_session_name: NotifyTerraformApply        
 
       - name: Terragrunt apply ECR
         run: |
@@ -123,7 +123,7 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role_session_name: NotifyTerraformPlan        
+          role_session_name: NotifyTerraformApply        
 
       - name: Terragrunt apply ses_receiving_emails
         run: |
@@ -146,7 +146,7 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role_session_name: NotifyTerraformPlan            
+          role_session_name: NotifyTerraformApply            
 
       - name: Terragrunt apply dns
         run: |
@@ -169,7 +169,7 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role_session_name: NotifyTerraformPlan        
+          role_session_name: NotifyTerraformApply        
 
       - name: Terragrunt apply ses_validation_dns_entries
         run: |
@@ -193,7 +193,7 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role_session_name: NotifyTerraformPlan        
+          role_session_name: NotifyTerraformApply        
 
       - name: Terragrunt apply cloudfront
         run: |
@@ -216,7 +216,7 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role_session_name: NotifyTerraformPlan           
+          role_session_name: NotifyTerraformApply           
 
       - name: Terragrunt apply eks
         run: |
@@ -239,7 +239,7 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role_session_name: NotifyTerraformPlan        
+          role_session_name: NotifyTerraformApply        
 
       - name: Terragrunt apply elasticache
         run: |
@@ -262,7 +262,7 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role_session_name: NotifyTerraformPlan        
+          role_session_name: NotifyTerraformApply        
 
       - name: Terragrunt apply rds
         run: |
@@ -285,7 +285,7 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role_session_name: NotifyTerraformPlan        
+          role_session_name: NotifyTerraformApply        
 
       - name: Terragrunt apply lambda-api
         run: |
@@ -308,7 +308,7 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role_session_name: NotifyTerraformPlan        
+          role_session_name: NotifyTerraformApply        
 
       - name: Terragrunt apply lambda-admin-pr
         run: |
@@ -331,7 +331,7 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role_session_name: NotifyTerraformPlan           
+          role_session_name: NotifyTerraformApply           
 
       - name: Terragrunt apply performance-test
         run: |
@@ -354,7 +354,7 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role_session_name: NotifyTerraformPlan        
+          role_session_name: NotifyTerraformApply        
 
       - name: Terragrunt apply heartbeat
         run: |
@@ -377,7 +377,7 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role_session_name: NotifyTerraformPlan          
+          role_session_name: NotifyTerraformApply          
 
       - name: Terragrunt apply database-tools
         run: |
@@ -400,7 +400,7 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role_session_name: NotifyTerraformPlan                  
+          role_session_name: NotifyTerraformApply                  
 
       - name: Terragrunt apply quicksight
         run: |
@@ -423,7 +423,7 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role_session_name: NotifyTerraformPlan        
+          role_session_name: NotifyTerraformApply        
 
       - name: Terragrunt apply lambda-google-cidr
         run: |
@@ -446,7 +446,7 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role_session_name: NotifyTerraformPlan        
+          role_session_name: NotifyTerraformApply        
 
       - name: Terragrunt apply ses_to_sqs_email_callbacks
         run: |
@@ -469,7 +469,7 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role_session_name: NotifyTerraformPlan        
+          role_session_name: NotifyTerraformApply        
 
       - name: Terragrunt apply sns_to_sqs_sms_callbacks
         run: |
@@ -492,7 +492,7 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role_session_name: NotifyTerraformPlan        
+          role_session_name: NotifyTerraformApply        
 
       - name: Terragrunt apply pinpoint_to_sqs_sms_callbacks
         run: |
@@ -515,7 +515,7 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role_session_name: NotifyTerraformPlan        
+          role_session_name: NotifyTerraformApply        
 
       - name: Terragrunt apply system_status
         run: |
@@ -538,7 +538,7 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role_session_name: NotifyTerraformPlan         
+          role_session_name: NotifyTerraformApply         
 
       - name: Terragrunt apply aws/system_status_static_site
         run: |
@@ -561,7 +561,7 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
-          role_session_name: NotifyTerraformPlan         
+          role_session_name: NotifyTerraformApply        
 
       - name: Terragrunt apply aws/newrelic
         run: |

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -119,8 +119,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
+      - name: setup-terraform
         uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan        
 
       - name: Terragrunt apply ses_receiving_emails
         run: |
@@ -139,8 +142,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform     
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan            
 
       - name: Terragrunt apply dns
         run: |
@@ -159,8 +165,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
+      - name: setup-terraform
         uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan        
 
       - name: Terragrunt apply ses_validation_dns_entries
         run: |
@@ -180,8 +189,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform 
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan        
 
       - name: Terragrunt apply cloudfront
         run: |
@@ -200,8 +212,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform      
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan           
 
       - name: Terragrunt apply eks
         run: |
@@ -220,8 +235,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
+      - name: setup-terraform
         uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan        
 
       - name: Terragrunt apply elasticache
         run: |
@@ -240,8 +258,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
+      - name: setup-terraform
         uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan        
 
       - name: Terragrunt apply rds
         run: |
@@ -260,8 +281,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform     
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan        
 
       - name: Terragrunt apply lambda-api
         run: |
@@ -280,8 +304,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
+      - name: setup-terraform
         uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan        
 
       - name: Terragrunt apply lambda-admin-pr
         run: |
@@ -300,8 +327,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform      
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan           
 
       - name: Terragrunt apply performance-test
         run: |
@@ -320,8 +350,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
+      - name: setup-terraform
         uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan        
 
       - name: Terragrunt apply heartbeat
         run: |
@@ -340,8 +373,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform      
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan          
 
       - name: Terragrunt apply database-tools
         run: |
@@ -360,8 +396,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform             
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan                  
 
       - name: Terragrunt apply quicksight
         run: |
@@ -380,8 +419,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform     
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan        
 
       - name: Terragrunt apply lambda-google-cidr
         run: |
@@ -400,8 +442,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform     
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan        
 
       - name: Terragrunt apply ses_to_sqs_email_callbacks
         run: |
@@ -420,8 +465,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform     
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan        
 
       - name: Terragrunt apply sns_to_sqs_sms_callbacks
         run: |
@@ -440,8 +488,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform   
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan        
 
       - name: Terragrunt apply pinpoint_to_sqs_sms_callbacks
         run: |
@@ -460,8 +511,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform  
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan        
 
       - name: Terragrunt apply system_status
         run: |
@@ -480,8 +534,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform      
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan         
 
       - name: Terragrunt apply aws/system_status_static_site
         run: |
@@ -500,8 +557,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform    
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan         
 
       - name: Terragrunt apply aws/newrelic
         run: |

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -170,10 +170,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-      - uses: ./.github/actions/setup-terraform
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
         with:
-          username: ${{ inputs.username }}
-          token: ${{ secrets.envPAT }}
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan common
         uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
@@ -199,6 +200,9 @@ jobs:
         
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan ECR
         uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
@@ -222,8 +226,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
+      - name: setup-terraform
         uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan ses_receiving_emails
         uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
@@ -247,14 +254,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-      - name: echo-value
-        env:
-          RESULT: ${{ needs.terragrunt-filter.outputs.dns }}
-        run: |
-          echo $RESULT
-
-      - name: setup-terraform 
+      - name: setup-terraform
         uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan dns
         uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
@@ -278,8 +282,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
+      - name: setup-terraform
         uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan ses_validation_dns_entries
         uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
@@ -304,8 +311,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform 
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan cloudfront
         uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
@@ -329,8 +339,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
+      - name: setup-terraform
         uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan eks
         uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
@@ -354,8 +367,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
+      - name: setup-terraform
         uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan elasticache
         uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
@@ -379,8 +395,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
+      - name: setup-terraform
         uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan  
+
       - name: Terragrunt plan rds
         uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
         with:
@@ -403,8 +423,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
+      - name: setup-terraform
         uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan lambda-api
         uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
@@ -428,8 +451,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
+      - name: setup-terraform
         uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan lambda-admin-pr
         uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
@@ -453,8 +479,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
+      - name: setup-terraform
         uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan performance-test
         uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
@@ -478,8 +507,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
+      - name: setup-terraform
         uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan heartbeat
         uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
@@ -503,8 +535,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
+      - name: setup-terraform
         uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan database-tools
         uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
@@ -528,8 +563,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform          
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan quicksight
         uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
@@ -553,8 +591,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform     
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan lambda-google-cidr
         uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
@@ -578,8 +619,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform 
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan ses_to_sqs_email_callbacks
         uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
@@ -603,8 +647,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform 
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan sns_to_sqs_sms_callbacks
         uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
@@ -628,8 +675,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform 
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan pinpoint_to_sqs_sms_callbacks
         uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
@@ -653,8 +703,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform 
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan system_status
         uses: cds-snc/terraform-plan@v3
@@ -678,8 +731,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform 
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan aws/system_status_static_site
         uses: cds-snc/terraform-plan@v3
@@ -704,8 +760,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         
-      - name: setup-terraform 
-        uses: ./.github/actions/setup-terraform 
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan aws/newrelic
         uses: cds-snc/terraform-plan@v3

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -10,10 +10,12 @@ on:
       - "env/terragrunt.hcl"
       - ".github/workflows/terragrunt_plan_staging.yml"
 
+permissions:
+  id-token: write   # This is required for requesting the OIDC JWT
+  contents: write    # This is required for actions/checkout     
+
 env:
   TARGET_ENV_PATH: staging
-  AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: ca-central-1
   TF_VAR_new_relic_api_key: ${{ secrets.PRODUCTION_NEW_RELIC_API_KEY }}
   TF_VAR_new_relic_account_id: ${{ secrets.PRODUCTION_NEW_RELIC_ACCOUNT_ID }}

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   id-token: write   # This is required for requesting the OIDC JWT
   contents: write    # This is required for actions/checkout     
+  pull-requests: write
 
 env:
   TARGET_ENV_PATH: staging


### PR DESCRIPTION
# Summary | Résumé

Did some investigation with OIDC in staging - looks like it needs pull_request permissions as well in order to work. 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/36

# Test instructions | Instructions pour tester la modification

TF Apply and plan in staging work

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.