### PR TITLE
remove lambda admin pr prod

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -287,28 +287,6 @@ jobs:
           cd env/production/lambda-api
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
-  terragrunt-apply-lambda-admin-pr:
-    if: |
-      always() &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled')
-    runs-on: ubuntu-latest  
-    needs: [terragrunt-apply-common,terragrunt-apply-elasticache,terragrunt-apply-ecr]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-        
-      - name: setup-terraform
-        uses: ./.github/actions/setup-terraform
-        with:
-          role_to_assume: arn:aws:iam::296255494825:role/notification-terraform-apply
-          role_session_name: NotifyTerraformApply
-
-      - name: Terragrunt apply lambda-admin-pr
-        run: |
-          cd env/production/lambda-admin-pr
-          terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-heartbeat:
     if: |
@@ -547,7 +525,7 @@ jobs:
         !contains(needs.*.result, 'failure') &&
         !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
-    needs: [terragrunt-apply-common,terragrunt-apply-ecr,terragrunt-apply-dns,terragrunt-apply-ses_validation_dns_entries,terragrunt-apply-cloudfront,terragrunt-apply-eks,terragrunt-apply-elasticache,terragrunt-apply-rds,terragrunt-apply-lambda-api,terragrunt-apply-lambda-admin-pr,terragrunt-apply-heartbeat,terragrunt-apply-database-tools,terragrunt-apply-quicksight,terragrunt-apply-lambda-google-cidr,terragrunt-apply-ses_to_sqs_email_callbacks,terragrunt-apply-sns_to_sqs_sms_callbacks,terragrunt-apply-pinpoint_to_sqs_sms_callbacks,terragrunt-apply-system_status,terragrunt-apply-ses_receiving_emails,terragrunt-apply-system_status_static_site,terragrunt-apply-newrelic]
+    needs: [terragrunt-apply-common,terragrunt-apply-ecr,terragrunt-apply-dns,terragrunt-apply-ses_validation_dns_entries,terragrunt-apply-cloudfront,terragrunt-apply-eks,terragrunt-apply-elasticache,terragrunt-apply-rds,terragrunt-apply-lambda-api,terragrunt-apply-heartbeat,terragrunt-apply-database-tools,terragrunt-apply-quicksight,terragrunt-apply-lambda-google-cidr,terragrunt-apply-ses_to_sqs_email_callbacks,terragrunt-apply-sns_to_sqs_sms_callbacks,terragrunt-apply-pinpoint_to_sqs_sms_callbacks,terragrunt-apply-system_status,terragrunt-apply-ses_receiving_emails,terragrunt-apply-system_status_static_site,terragrunt-apply-newrelic]
     steps:
       - name: bump-version-and-push-tag
         uses: mathieudutour/github-tag-action@bcb832838e1612ff92089d914bccc0fd39458223 # v4.6

--- a/.github/workflows/terragrunt_plan_production.yml
+++ b/.github/workflows/terragrunt_plan_production.yml
@@ -324,33 +324,6 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"
 
-  terragrunt-plan-lambda-admin-pr:
-    if: |
-      always() &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled')
-    runs-on: ubuntu-latest  
-    needs: [terragrunt-plan-common,terragrunt-plan-elasticache,terragrunt-plan-ecr]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-        
-      - name: setup-terraform
-        uses: ./.github/actions/setup-terraform
-        with:
-          role_to_assume: arn:aws:iam::296255494825:role/notification-terraform-plan
-          role_session_name: NotifyTerraformPlan
-
-      - name: Terragrunt plan lambda-admin-pr
-        uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
-        with:
-          directory: "env/production/lambda-admin-pr"
-          comment-delete: "true"
-          comment-title: "Production: lambda-admin-pr"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          terragrunt: "true"
-
   terragrunt-plan-heartbeat:
     if: |
       always() &&


### PR DESCRIPTION
# Summary | Résumé

Same deal as perf-test

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/36

# Test instructions | Instructions pour tester la modification

TF PLAN

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.