### PR TITLE
Switching to proper role for staging plan

### DIFF
--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -174,7 +174,7 @@ jobs:
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan common
@@ -202,7 +202,7 @@ jobs:
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan ECR
@@ -230,7 +230,7 @@ jobs:
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan ses_receiving_emails
@@ -259,7 +259,7 @@ jobs:
       - name: setup-terraform 
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan dns
@@ -287,7 +287,7 @@ jobs:
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan ses_validation_dns_entries
@@ -316,7 +316,7 @@ jobs:
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan cloudfront
@@ -344,7 +344,7 @@ jobs:
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan eks
@@ -372,7 +372,7 @@ jobs:
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan elasticache
@@ -400,7 +400,7 @@ jobs:
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan rds
@@ -428,7 +428,7 @@ jobs:
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan lambda-api
@@ -456,7 +456,7 @@ jobs:
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan lambda-admin-pr
@@ -484,7 +484,7 @@ jobs:
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan performance-test
@@ -512,7 +512,7 @@ jobs:
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan heartbeat
@@ -540,7 +540,7 @@ jobs:
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan database-tools
@@ -568,7 +568,7 @@ jobs:
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan quicksight
@@ -596,7 +596,7 @@ jobs:
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan lambda-google-cidr
@@ -624,7 +624,7 @@ jobs:
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan ses_to_sqs_email_callbacks
@@ -652,7 +652,7 @@ jobs:
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan sns_to_sqs_sms_callbacks
@@ -680,7 +680,7 @@ jobs:
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan pinpoint_to_sqs_sms_callbacks
@@ -708,7 +708,7 @@ jobs:
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan system_status
@@ -736,7 +736,7 @@ jobs:
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan aws/system_status_static_site
@@ -765,7 +765,7 @@ jobs:
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::239043911459:role/notification-terraform-plan
           role_session_name: NotifyTerraformPlan  
 
       - name: Terragrunt plan aws/newrelic


### PR DESCRIPTION
# Summary | Résumé

For some reason I had staging TF Plan using the TF apply role.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/36

# Test instructions | Instructions pour tester la modification

TF Plan/Apply works

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.