### PR TITLE
Adding missing DNS entries

### DIFF
--- a/aws/eks/dns.tf
+++ b/aws/eks/dns.tf
@@ -12,6 +12,20 @@ resource "aws_route53_record" "notification-root" {
   }
 }
 
+resource "aws_route53_record" "notification-www-root" {
+
+  provider = aws.dns
+  zone_id  = var.route_53_zone_arn
+  name     = "www.${var.domain}"
+  type     = "CNAME"
+
+  records  = [
+    aws_alb.notification-canada-ca.dns_name
+  ]
+  ttl      = "300"
+}
+
+
 resource "aws_route53_record" "notificatio-root-WC" {
 
   provider = aws.dns
@@ -25,6 +39,50 @@ resource "aws_route53_record" "notificatio-root-WC" {
     evaluate_target_health = false
   }
 
+}
+
+resource "aws_route53_record" "doc-notification-canada-ca-cname" {
+  provider  = aws.dns
+  zone_id   = var.route_53_zone_arn
+  name      = "doc.notification.canada.ca"
+  type      = "CNAME"
+  records   = [
+    aws_alb.notification-canada-ca.dns_name
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "document-notification-canada-ca-cname" {
+  provider  = aws.dns
+  zone_id   = var.route_53_zone_arn
+  name      = "document.notification.canada.ca"
+  type      = "CNAME"
+  records   = [
+    aws_alb.notification-canada-ca.dns_name
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "api-document-notification-canada-ca-cname" {
+  provider  = aws.dns
+  zone_id   = var.route_53_zone_arn
+  name      = "api.document.notification.canada.ca"
+  type      = "CNAME"
+  records   = [
+    aws_alb.notification-canada-ca.dns_name
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "documentation-notification-canada-ca-cname" {
+  provider  = aws.dns
+  zone_id   = var.route_53_zone_arn
+  name      = "documentation.notification.canada.ca"
+  type      = "CNAME"
+  records   = [
+    aws_alb.notification-canada-ca.dns_name
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "notification-alt-root" {
@@ -109,3 +167,4 @@ resource "aws_route53_record" "wildcard_CNAME" {
   ttl     = "60"
   records = [var.internal_dns_name]
 }
+

--- a/aws/eks/dns.tf
+++ b/aws/eks/dns.tf
@@ -19,10 +19,10 @@ resource "aws_route53_record" "notification-www-root" {
   name     = "www.${var.domain}"
   type     = "CNAME"
 
-  records  = [
+  records = [
     aws_alb.notification-canada-ca.dns_name
   ]
-  ttl      = "300"
+  ttl = "300"
 }
 
 
@@ -42,44 +42,44 @@ resource "aws_route53_record" "notificatio-root-WC" {
 }
 
 resource "aws_route53_record" "doc-notification-canada-ca-cname" {
-  provider  = aws.dns
-  zone_id   = var.route_53_zone_arn
-  name      = "doc.notification.canada.ca"
-  type      = "CNAME"
-  records   = [
+  provider = aws.dns
+  zone_id  = var.route_53_zone_arn
+  name     = "doc.notification.canada.ca"
+  type     = "CNAME"
+  records = [
     aws_alb.notification-canada-ca.dns_name
   ]
   ttl = "300"
 }
 
 resource "aws_route53_record" "document-notification-canada-ca-cname" {
-  provider  = aws.dns
-  zone_id   = var.route_53_zone_arn
-  name      = "document.notification.canada.ca"
-  type      = "CNAME"
-  records   = [
+  provider = aws.dns
+  zone_id  = var.route_53_zone_arn
+  name     = "document.notification.canada.ca"
+  type     = "CNAME"
+  records = [
     aws_alb.notification-canada-ca.dns_name
   ]
   ttl = "300"
 }
 
 resource "aws_route53_record" "api-document-notification-canada-ca-cname" {
-  provider  = aws.dns
-  zone_id   = var.route_53_zone_arn
-  name      = "api.document.notification.canada.ca"
-  type      = "CNAME"
-  records   = [
+  provider = aws.dns
+  zone_id  = var.route_53_zone_arn
+  name     = "api.document.notification.canada.ca"
+  type     = "CNAME"
+  records = [
     aws_alb.notification-canada-ca.dns_name
   ]
   ttl = "300"
 }
 
 resource "aws_route53_record" "documentation-notification-canada-ca-cname" {
-  provider  = aws.dns
-  zone_id   = var.route_53_zone_arn
-  name      = "documentation.notification.canada.ca"
-  type      = "CNAME"
-  records   = [
+  provider = aws.dns
+  zone_id  = var.route_53_zone_arn
+  name     = "documentation.notification.canada.ca"
+  type     = "CNAME"
+  records = [
     aws_alb.notification-canada-ca.dns_name
   ]
   ttl = "300"


### PR DESCRIPTION
# Summary | Résumé

We had some missing DNS entries for production, I've added them here, and propagated the equivalent ones in dev. This will also add them to staging.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/36

# Test instructions | Instructions pour tester la modification

TF Apply works
Verify that the records are the same in SRE AWS DNS

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.