### PR TITLE
base domain

### DIFF
--- a/aws/eks/dns.tf
+++ b/aws/eks/dns.tf
@@ -44,7 +44,7 @@ resource "aws_route53_record" "notificatio-root-WC" {
 resource "aws_route53_record" "doc-notification-canada-ca-cname" {
   provider = aws.dns
   zone_id  = var.route_53_zone_arn
-  name     = "doc.notification.canada.ca"
+  name     = "doc.${var.domain}"
   type     = "CNAME"
   records = [
     aws_alb.notification-canada-ca.dns_name
@@ -55,7 +55,7 @@ resource "aws_route53_record" "doc-notification-canada-ca-cname" {
 resource "aws_route53_record" "document-notification-canada-ca-cname" {
   provider = aws.dns
   zone_id  = var.route_53_zone_arn
-  name     = "document.notification.canada.ca"
+  name     = "document.${var.domain}"
   type     = "CNAME"
   records = [
     aws_alb.notification-canada-ca.dns_name
@@ -66,7 +66,7 @@ resource "aws_route53_record" "document-notification-canada-ca-cname" {
 resource "aws_route53_record" "api-document-notification-canada-ca-cname" {
   provider = aws.dns
   zone_id  = var.route_53_zone_arn
-  name     = "api.document.notification.canada.ca"
+  name     = "api.document.${var.domain}"
   type     = "CNAME"
   records = [
     aws_alb.notification-canada-ca.dns_name
@@ -77,7 +77,7 @@ resource "aws_route53_record" "api-document-notification-canada-ca-cname" {
 resource "aws_route53_record" "documentation-notification-canada-ca-cname" {
   provider = aws.dns
   zone_id  = var.route_53_zone_arn
-  name     = "documentation.notification.canada.ca"
+  name     = "documentation.${var.domain}"
   type     = "CNAME"
   records = [
     aws_alb.notification-canada-ca.dns_name


### PR DESCRIPTION
# Summary | Résumé

Replacing hard-coded notification.canada.ca with the base domain. Duh.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/36

# Test instructions | Instructions pour tester la modification

TF APPLY WORK THIS TIME

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.