### PR TITLE
Aligning weighted DNS entry for API with what is currently in prod

### DIFF
--- a/aws/lambda-api/dns.tf
+++ b/aws/lambda-api/dns.tf
@@ -24,8 +24,8 @@ resource "aws_route53_record" "api-weighted-100-notification-A" {
   set_identifier = "lambda"
 
   alias {
-    name                   = aws_api_gateway_domain_name.api_lambda.regional_domain_name
-    zone_id                = aws_api_gateway_domain_name.api_lambda.regional_zone_id
+    name                   = aws_api_gateway_domain_name.api.regional_domain_name
+    zone_id                = aws_api_gateway_domain_name.api.regional_zone_id
     evaluate_target_health = true
   }
 


### PR DESCRIPTION
# Summary | Résumé

Aligning the API lambda DNS to point to itself instead of directly to the api gateway... this is how it's done in current prod. 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/36

# Test instructions | Instructions pour tester la modification

TF Apply works
Verify "real" and "fake" DNS zones look the same.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.