### PR TITLE
bump up throtted queue alarms

### DIFF
--- a/aws/common/cloudwatch_alarms_sms.tf
+++ b/aws/common/cloudwatch_alarms_sms.tf
@@ -378,7 +378,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-throttled-sms-stuck-in-queue-warning
   namespace           = "AWS/SQS"
   period              = 60
   statistic           = "Average"
-  threshold           = 60 * 30
+  threshold           = 60 * 45
   treat_missing_data  = "missing"
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
   dimensions = {
@@ -396,7 +396,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-throttled-sms-stuck-in-queue-critica
   namespace                 = "AWS/SQS"
   period                    = 60
   statistic                 = "Average"
-  threshold                 = 60 * 45
+  threshold                 = 60 * 60
   treat_missing_data        = "missing"
   alarm_actions             = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   insufficient_data_actions = [aws_sns_topic.notification-canada-ca-alert-warning.arn]


### PR DESCRIPTION
# Summary | Résumé

We are having more flow SMS flow through this queue, and the warning is starting to get triggered by normal activity.

Bumping up the alarm thresholds for now. We should consider a long term solution though.

## Related Issues | Cartes liées

https://gcdigital.slack.com/archives/CV38DBNVA/p1721761810285639

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.