### PR TITLE
apply rds instance changes immediately if not on prod

### DIFF
--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -28,7 +28,7 @@ resource "aws_rds_cluster_instance" "notification-canada-ca-instances" {
   # https://github.com/hashicorp/terraform-provider-aws/issues/3015#issuecomment-520667166
   preferred_maintenance_window = "wed:04:00-wed:04:30"
   auto_minor_version_upgrade   = false
-  apply_immediately            = false
+  apply_immediately            = var.env != "production"
 
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"


### PR DESCRIPTION
# Summary | Résumé

set `apply_immediately` to true for non-production rds instances

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/387

# Test instructions | Instructions pour tester la modification

See what happens in plan and apply

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.