### PR TITLE
Using AWS read only IAM for account link

### DIFF
--- a/aws/newrelic/aws_integration.tf
+++ b/aws/newrelic/aws_integration.tf
@@ -67,7 +67,7 @@ EOF
 resource "aws_iam_role_policy_attachment" "newrelic_aws_policy_attach" {
   count      = var.env == "staging" ? 1 : 0
   role       = aws_iam_role.newrelic_aws_role[0].name
-  policy_arn = aws_iam_policy.newrelic_aws_permissions[0].arn
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }
 
 resource "newrelic_cloud_aws_link_account" "newrelic_cloud_integration_push" {

--- a/aws/newrelic/data.tf
+++ b/aws/newrelic/data.tf
@@ -2,8 +2,8 @@ data "newrelic_entity" "notification-api-lambda" {
   name     = "api-lambda"
   provider = newrelic
   tag {
-    key   = "env"
-    value = var.env
+    key   = "aws.accountId"
+    value = var.account_id
   }
 }
 

--- a/aws/newrelic/variables.tf
+++ b/aws/newrelic/variables.tf
@@ -3,11 +3,13 @@ variable "new_relic_account_id" {
   description = "New Relic Account ID"
   sensitive   = true
 }
+
 variable "new_relic_api_key" {
   type        = string
   description = "New Relic API Key"
   sensitive   = true
 }
+
 variable "new_relic_slack_webhook_url" {
   type        = string
   description = "Slack Webhook URL"


### PR DESCRIPTION
# Summary | Résumé

Forcing new relic AWS Account link to use the global AWS read only Policy.

## Related Issues | Cartes liées

Troubleshooting newrelic staging

# Test instructions | Instructions pour tester la modification

TF Apply works
See if api-lambda for staging appears as an entity in NR

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.