### PR TITLE
setting old permissions back

### DIFF
--- a/aws/newrelic/aws_integration.tf
+++ b/aws/newrelic/aws_integration.tf
@@ -67,7 +67,7 @@ EOF
 resource "aws_iam_role_policy_attachment" "newrelic_aws_policy_attach" {
   count      = var.env == "staging" ? 1 : 0
   role       = aws_iam_role.newrelic_aws_role[0].name
-  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  policy_arn = aws_iam_policy.newrelic_aws_permissions[0].arn
 }
 
 resource "newrelic_cloud_aws_link_account" "newrelic_cloud_integration_push" {


### PR DESCRIPTION
# Summary | Résumé

Reverting account linking IAM in NR to the original since we seem to have lost the lambda


# Test instructions | Instructions pour tester la modification

TF Apply
See if api-lambda for staging exists.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.