### PR TITLE
Xray Take 2

### DIFF
--- a/aws/eks/iam.tf
+++ b/aws/eks/iam.tf
@@ -459,7 +459,7 @@ POLICY
 
 #XRAY IAM
 resource "aws_iam_role" "nodes_k8s_role" {
-  name = "nodes.k8s.cluster.${var.env}"
+  name = "nodes.k8s.cluster.local"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -475,7 +475,7 @@ resource "aws_iam_role" "nodes_k8s_role" {
 }
 
 resource "aws_iam_instance_profile" "nodes_k8s_instance_profile" {
-  name = "nodes.k8s.cluster.${var.env}"
+  name = "nodes.k8s.cluster.local"
   role = aws_iam_role.nodes_k8s_role.name
 }
 
@@ -492,7 +492,7 @@ resource "aws_iam_policy" "xray_policy" {
           "xray:PutTelemetryRecords"
         ]
         Resource = [
-          "arn:aws:iam::${var.account_id}:instance-profile/nodes.k8s.cluster.${var.env}"
+          "arn:aws:iam::${var.account_id}:instance-profile/nodes.k8s.cluster.local"
         ]
       }
     ]

--- a/aws/eks/iam.tf
+++ b/aws/eks/iam.tf
@@ -482,12 +482,12 @@ resource "aws_iam_instance_profile" "nodes_k8s_instance_profile" {
 resource "aws_iam_policy" "xray_policy" {
   name        = "XRayPolicy"
   description = "Policy to allow XRay tracing"
-  policy      = jsonencode({
+  policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
-        Effect   = "Allow"
-        Action   = [
+        Effect = "Allow"
+        Action = [
           "xray:PutTraceSegments",
           "xray:PutTelemetryRecords"
         ]

--- a/aws/eks/iam.tf
+++ b/aws/eks/iam.tf
@@ -456,3 +456,50 @@ resource "aws_iam_policy" "ebs_driver" {
 }
 POLICY
 }
+
+#XRAY IAM
+resource "aws_iam_role" "nodes_k8s_role" {
+  name = "nodes.k8s.cluster.${var.env}"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_instance_profile" "nodes_k8s_instance_profile" {
+  name = "nodes.k8s.cluster.${var.env}"
+  role = aws_iam_role.nodes_k8s_role.name
+}
+
+resource "aws_iam_policy" "xray_policy" {
+  name        = "XRayPolicy"
+  description = "Policy to allow XRay tracing"
+  policy      = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = [
+          "xray:PutTraceSegments",
+          "xray:PutTelemetryRecords"
+        ]
+        Resource = [
+          "arn:aws:iam::${var.account_id}:instance-profile/nodes.k8s.cluster.${var.env}"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "attach_xray_policy" {
+  role       = aws_iam_role.eks-worker-role.name
+  policy_arn = aws_iam_policy.xray_policy.arn
+}


### PR DESCRIPTION
# Summary | Résumé

Adding the IAM work for K8s/EKS to allow XRay to connect and monitor our clusters.  This wont work yet without a Daemon pod deployed.

## Related Issues | Cartes liées

[Tracing / correlate requests through the Notify components (AWS X-Ray)](https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/319)

# Test instructions | Instructions pour tester la modification

Watch the Terraform Plans and Applys.  We can't know if this actually works until we have a daemon.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.