### PR TITLE
NR re-enable pulling in staging

### DIFF
--- a/aws/newrelic/aws_integration.tf
+++ b/aws/newrelic/aws_integration.tf
@@ -216,7 +216,7 @@ resource "newrelic_cloud_aws_link_account" "newrelic_cloud_integration_pull" {
 }
 
 resource "newrelic_cloud_aws_integrations" "newrelic_cloud_integration_pull" {
-  count             = 0
+  count             = var.env == "staging" ? 1 : 0
   account_id        = var.new_relic_account_id
   linked_account_id = newrelic_cloud_aws_link_account.newrelic_cloud_integration_pull[0].id
   billing {}
@@ -259,7 +259,6 @@ resource "newrelic_cloud_aws_integrations" "newrelic_cloud_integration_pull" {
   efs {}
   elasticbeanstalk {}
   elasticsearch {}
-  elb {}
   emr {}
   iam {}
   iot {}


### PR DESCRIPTION
# Summary | Résumé

Troubleshooting why we can't see api-lambda in staging anymore.

# Test instructions | Instructions pour tester la modification

TF Apply and verify that api-lambda shows up.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.