### PR TITLE
Added organization name to the `services` quicksight data set

### DIFF
--- a/aws/quicksight/dataset_services.tf
+++ b/aws/quicksight/dataset_services.tf
@@ -12,7 +12,7 @@ resource "aws_quicksight_data_set" "services" {
       name            = "services"
       sql_query       = <<EOF
         select s.id, s.created_at, s.updated_at, s.active, count_as_live, 
-               go_live_at, restricted, s.name, organisation_id, o.name,
+               go_live_at, restricted, s.name, organisation_id, o.name as organisation_name,
                message_limit, rate_limit, sms_daily_limit
           from services s inner join organisation o on s.organisation_id = o.id
       EOF

--- a/aws/quicksight/dataset_services.tf
+++ b/aws/quicksight/dataset_services.tf
@@ -7,54 +7,65 @@ resource "aws_quicksight_data_set" "services" {
 
   physical_table_map {
     physical_table_map_id = "services"
-    relational_table {
+    custom_sql {
       data_source_arn = aws_quicksight_data_source.rds.arn
       name            = "services"
-      input_columns {
+      sql_query       = <<EOF
+        select s.id, s.created_at, s.updated_at, s.active, count_as_live, 
+               go_live_at, restricted, s.name, organisation_id, o.name,
+               message_limit, rate_limit, sms_daily_limit
+          from services s inner join organisation o on s.organisation_id = o.id
+      EOF
+
+      columns {
         name = "id"
         type = "STRING"
       }
-      input_columns {
+      columns {
         name = "created_at"
         type = "DATETIME"
       }
-      input_columns {
+      columns {
         name = "updated_at"
         type = "DATETIME"
       }
-      input_columns {
+      columns {
         name = "active"
         type = "BOOLEAN"
       }
-      input_columns {
+      columns {
         name = "count_as_live"
         type = "BOOLEAN"
       }
-      input_columns {
+      columns {
         name = "go_live_at"
         type = "DATETIME"
       }
-      input_columns {
+      columns {
         name = "restricted"
         type = "STRING"
       }
-      input_columns {
+      columns {
         name = "name"
         type = "STRING"
       }
-      input_columns {
+      columns {
         name = "organisation_id"
         type = "STRING"
       }
-      input_columns {
+      columns {
+        name = "organisation_name"
+        type = "STRING"
+      }
+      columns {
         name = "message_limit"
         type = "INTEGER"
       }
-      input_columns {
+      columns {
         name = "rate_limit"
         type = "INTEGER"
       }
-      input_columns {
+      columns {
         name = "sms_daily_limit"
         type = "INTEGER"
       }


### PR DESCRIPTION
# Summary | Résumé

Added the `organization_name` field to the Quicksight `services` dataset.

## Related Issues | Cartes liées

No related card, minor improvement task.

# Test instructions | Instructions pour tester la modification

Verify that the dataset was properly refreshed in the staging environment.

# Release Instructions | Instructions pour le déploiement

Verify that the dataset was properly refreshed in the production environment.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.