### PR TITLE
left outer join template_categories

### DIFF
--- a/aws/quicksight/dataset_notifications.tf
+++ b/aws/quicksight/dataset_notifications.tf
@@ -72,7 +72,7 @@ resource "aws_quicksight_data_set" "notifications" {
             tc.sms_process_type as tc_sms_process_type, 
             tc.sms_sending_vehicle as tc_sms_sending_vehicle
           from templates t
-          join template_categories tc on tc.id = t.template_category_id
+          left outer join template_categories tc on tc.id = t.template_category_id
         )
         select
           notification_id, notification_created_at, notification_sent_at, notification_status,


### PR DESCRIPTION
# Summary | Résumé

Currently templates can have a null category_id. This was causing us to lose templates in the notifications dataset sql query and so we were also losing notifications in the end. Here we do a `left outer join` instead of a `join` to include all templates.

## Related Issues | Cartes liées

[Slack discussion](https://gcdigital.slack.com/archives/C064F5U7EN6/p1723040541940809)

# Test instructions | Instructions pour tester la modification

Verify that in production quicksight the number of total rows in the notifications dataset is no longer lower than before August 6.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.