### PR TITLE
Custom kms

### DIFF
--- a/aws/rds/kms.tf
+++ b/aws/rds/kms.tf
@@ -1,9 +1,9 @@
 resource "aws_kms_key" "rds_snapshot" {
-  count = var.env == "staging" ? 1 : 0 
+  count                   = var.env == "staging" ? 1 : 0
   description             = "A KMS key for encrypting RDS snapshots"
   enable_key_rotation     = true
   deletion_window_in_days = 7
-  policy = <<POLICY
+  policy                  = <<POLICY
 {
     "Id": "key-consolepolicy-3",
     "Version": "2012-10-17",


### PR DESCRIPTION
# Summary | Résumé

Adding a custom KMS for sharing RDS snapshots between staging and dev.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/406

# Test instructions | Instructions pour tester la modification

TF Apply works

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.