### PR TITLE
fixing rds kms

### DIFF
--- a/aws/rds/kms.tf
+++ b/aws/rds/kms.tf
@@ -22,9 +22,9 @@ resource "aws_kms_key" "rds_snapshot" {
             "Effect": "Allow",
             "Principal": {
                 "AWS": [
+                    "arn:aws:iam::${var.account_id}:role/aws-reserved/sso.amazonaws.com/ca-central-1/AWSReservedSSO_AWSAdministratorAccess_4085b2fdb6f29f43",
                     "arn:aws:iam::${var.account_id}:role/notification-terraform-apply",
-                    "arn:aws:iam::${var.account_id}:role/notification-terraform-plan",
-                    "arn:aws:iam::${var.account_id}:role/aws-reserved/sso.amazonaws.com/ca-central-1/AWSReservedSSO_AWSAdministratorAccess_e6e62a284c3c35fc"
+                    "arn:aws:iam::${var.account_id}:role/notification-terraform-plan"
                 ]
             },
             "Action": [
@@ -50,7 +50,12 @@ resource "aws_kms_key" "rds_snapshot" {
             "Sid": "Allow use of the key",
             "Effect": "Allow",
             "Principal": {
-                "AWS": "arn:aws:iam::800095993820:root"
+                "AWS": [
+                    "arn:aws:iam::${var.account_id}:role/aws-reserved/sso.amazonaws.com/ca-central-1/AWSReservedSSO_AWSAdministratorAccess_4085b2fdb6f29f43",
+                    "arn:aws:iam::${var.account_id}:role/notification-terraform-apply",
+                    "arn:aws:iam::${var.account_id}:role/notification-terraform-plan",
+                    "arn:aws:iam::800095993820:root"
+                ]
             },
             "Action": [
                 "kms:Encrypt",
@@ -65,7 +70,12 @@ resource "aws_kms_key" "rds_snapshot" {
             "Sid": "Allow attachment of persistent resources",
             "Effect": "Allow",
             "Principal": {
-                "AWS": "arn:aws:iam::800095993820:root"
+                "AWS": [
+                    "arn:aws:iam::${var.account_id}:role/aws-reserved/sso.amazonaws.com/ca-central-1/AWSReservedSSO_AWSAdministratorAccess_4085b2fdb6f29f43",
+                    "arn:aws:iam::${var.account_id}:role/notification-terraform-apply",
+                    "arn:aws:iam::${var.account_id}:role/notification-terraform-plan",
+                    "arn:aws:iam::800095993820:root"
+                ]
             },
             "Action": [
                 "kms:CreateGrant",


### PR DESCRIPTION
# Summary | Résumé

Fixing KMS policy that worked in dev but not staging.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/406

# Test instructions | Instructions pour tester la modification

TF apply works

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.