### PR TITLE
Adding production xray false for API lambda

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -59,6 +59,7 @@ env:
   TF_VAR_pr_bot_private_key: ${{ secrets.NOTIFY_PR_BOT_PRIVATE_KEY }}
   TF_VAR_budget_sre_bot_webhook: ${{ secrets.PRODUCTION_BUDGET_SRE_BOT_WEBHOOK }}
   TF_VAR_enable_sentinel_forwarding: true
+  TF_VAR_aws_xray_sdk_enabled: false
 
 jobs:
 

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -61,6 +61,7 @@ env:
   TF_VAR_pr_bot_private_key: ${{ secrets.NOTIFY_PR_BOT_PRIVATE_KEY }}
   TF_VAR_budget_sre_bot_webhook: ${{ secrets.STAGING_BUDGET_SRE_BOT_WEBHOOK }}
   TF_VAR_enable_sentinel_forwarding: true
+  TF_VAR_aws_xray_sdk_enabled: true
 
 permissions:
   id-token: write

--- a/.github/workflows/terragrunt_plan_production.yml
+++ b/.github/workflows/terragrunt_plan_production.yml
@@ -55,6 +55,7 @@ env:
   TF_VAR_pr_bot_private_key: ${{ secrets.NOTIFY_PR_BOT_PRIVATE_KEY }}
   TF_VAR_budget_sre_bot_webhook: ${{ secrets.PRODUCTION_BUDGET_SRE_BOT_WEBHOOK }}
   TF_VAR_enable_sentinel_forwarding: true
+  TF_VAR_aws_xray_sdk_enabled: false
 
 jobs:
   terragrunt-plan-common:

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -61,6 +61,7 @@ env:
   TF_VAR_pr_bot_private_key: ${{ secrets.NOTIFY_PR_BOT_PRIVATE_KEY }}
   TF_VAR_budget_sre_bot_webhook: ${{ secrets.STAGING_BUDGET_SRE_BOT_WEBHOOK }}
   TF_VAR_enable_sentinel_forwarding: true
+  TF_VAR_aws_xray_sdk_enabled: true
 
 jobs:
   terragrunt-filter:

--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -45,6 +45,7 @@ resource "aws_lambda_function" "api" {
       NEW_RELIC_DISTRIBUTED_TRACING_ENABLED = var.new_relic_distribution_tracing_enabled
       NEW_RELIC_EXTENSION_LOGS_ENABLED      = true
       NEW_RELIC_LAMBDA_EXTENSION_ENABLED    = true
+      AWS_XRAY_SDK_ENABLED                  = var.aws_xray_sdk_enabled
 
     }
   }

--- a/aws/lambda-api/variables.tf
+++ b/aws/lambda-api/variables.tf
@@ -164,3 +164,9 @@ variable "alb_arn_suffix" {
   type        = string
   description = "Suffix of the EKS ALB ARN. Used for dashboards."
 }
+
+variable "aws_xray_sdk_enabled" {
+  type        = bool
+  description = "Boolean value to decide whether or not to enable AWS X-Ray SDK"
+  default     = false
+}


### PR DESCRIPTION
# Summary | Résumé

Turning off the SDK via env variable for API Lambda.  This is done via Terraform... :/ 

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/400

# Test instructions | Instructions pour tester la modification
 Check the production Xray board to see if API lambdas are turned off

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.