### PR TITLE
feat(WAF): allow `/cache-clear` on the API

### DIFF
--- a/aws/common/waf.tf
+++ b/aws/common/waf.tf
@@ -22,7 +22,7 @@ resource "aws_wafv2_regex_pattern_set" "re_api" {
   }
 
   regular_expression {
-    regex_string = "/notifications.*|/organisation.*|/organisations.*|/platform-stats.*|/provider-details.*|/service.*|/static.*|/user.*|/v2.*"
+    regex_string = "/notifications.*|/organisation.*|/organisations.*|/platform-stats.*|/provider-details.*|/service.*|/static.*|/user.*|/v2.*|/cache-clear"
   }
 
   tags = {


### PR DESCRIPTION
# Summary | Résumé

Allows the route `/cache-clear` on the API.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/1612

# Test instructions | Instructions pour tester la modification

- [ ] Can access `/cache-clear` on the API

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.