### PR TITLE
Fix alarms with missing data

### DIFF
--- a/aws/pinpoint_to_sqs_sms_callbacks/cloudwatch_alarms.tf
+++ b/aws/pinpoint_to_sqs_sms_callbacks/cloudwatch_alarms.tf
@@ -97,7 +97,6 @@ resource "aws_cloudwatch_metric_alarm" "total-sms-spending-warning" {
       namespace   = "AWS/SNS"
       period      = 300
       stat        = "Maximum"
-      unit        = "Count"
     }
   }
 
@@ -108,7 +107,6 @@ resource "aws_cloudwatch_metric_alarm" "total-sms-spending-warning" {
       namespace   = "AWS/SMSVoice"
       period      = 300
       stat        = "Maximum"
-      unit        = "Count"
     }
   }
 }
@@ -137,7 +135,6 @@ resource "aws_cloudwatch_metric_alarm" "total-sms-spending-critical" {
       namespace   = "AWS/SNS"
       period      = 300
       stat        = "Maximum"
-      unit        = "Count"
     }
   }
 
@@ -148,7 +145,6 @@ resource "aws_cloudwatch_metric_alarm" "total-sms-spending-critical" {
       namespace   = "AWS/SMSVoice"
       period      = 300
       stat        = "Maximum"
-      unit        = "Count"
     }
   }
 }
@@ -218,7 +214,6 @@ resource "aws_cloudwatch_metric_alarm" "pinpoint-sms-success-rate-critical" {
       namespace   = aws_cloudwatch_log_metric_filter.pinpoint-sms-successes[0].metric_transformation[0].namespace
       period      = 60 * 60 * 12
       stat        = "Sum"
-      unit        = "Count"
     }
   }
 
@@ -229,7 +224,6 @@ resource "aws_cloudwatch_metric_alarm" "pinpoint-sms-success-rate-critical" {
       namespace   = aws_cloudwatch_log_metric_filter.pinpoint-sms-failures[0].metric_transformation[0].namespace
       period      = 60 * 60 * 12
       stat        = "Sum"
-      unit        = "Count"
     }
   }
 }

--- a/aws/pinpoint_to_sqs_sms_callbacks/cloudwatch_alarms.tf
+++ b/aws/pinpoint_to_sqs_sms_callbacks/cloudwatch_alarms.tf
@@ -178,7 +178,6 @@ resource "aws_cloudwatch_metric_alarm" "pinpoint-sms-success-rate-warning" {
       namespace   = aws_cloudwatch_log_metric_filter.pinpoint-sms-successes[0].metric_transformation[0].namespace
       period      = 60 * 60 * 12
       stat        = "Sum"
-      unit        = "Count"
     }
   }
 
@@ -189,7 +188,6 @@ resource "aws_cloudwatch_metric_alarm" "pinpoint-sms-success-rate-warning" {
       namespace   = aws_cloudwatch_log_metric_filter.pinpoint-sms-failures[0].metric_transformation[0].namespace
       period      = 60 * 60 * 12
       stat        = "Sum"
-      unit        = "Count"
     }
   }
 }


### PR DESCRIPTION
# Summary | Résumé


The [pinpoint-sms-success-rate-warning](https://ca-central-1.console.aws.amazon.com/cloudwatch/home?region=ca-central-1#alarmsV2:alarm/pinpoint-sms-success-rate-warning) alarm doesn't have any data (see discussion [here](https://gcdigital.slack.com/archives/CV38DBNVA/p1725374505997579)) 

Looking at the alarm in Metrics and removing the `unit` parameter caused the graph to have data. This is an optional field so I believe deleting it should be fine (especially if it fixes the metrics / alarms!)

Also fixed the  `total-sms-spending-*` alarms - the Pinpoint spending was not appearing (`AWS/SMSVoice`). Removing the `unit`s fixed these.

## Related Issues | Cartes liées

Didn't make one 😬 

# Test instructions | Instructions pour tester la modification

Check that data appears. Should have signifcant spending in `total-sms-spending-warning` (with the Pinpoint now counted). Can view the alarm in metrics and plot all the metrics used in the calculations.

# Release Instructions | Instructions pour le déploiement

Other metrics might be affected similarly... 


# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.