### PR TITLE
fix: enable Blazer DB instance automated backups

### DIFF
--- a/aws/database-tools/rds.tf
+++ b/aws/database-tools/rds.tf
@@ -28,6 +28,9 @@ resource "aws_db_instance" "database-tools" {
   storage_encrypted   = true
   deletion_protection = var.enable_delete_protection
 
+  backup_retention_period = 7
+  backup_window           = "02:00-04:00"
+
   vpc_security_group_ids = [var.database-tools-db-securitygroup]
   db_subnet_group_name   = aws_db_subnet_group.database-tools-rds-subnet.name
 


### PR DESCRIPTION
# Summary
Enable 7 days of automated backups for the Blazer DB instance.

This change came up from an AWS cadence call Trusted Advisor review.

# Test instructions | Instructions pour tester la modification

After PR has merged, expect to see the DB instances backup configuration updated in the AWS console.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.