### PR TITLE
Enabling new relic metrics stream

### DIFF
--- a/aws/newrelic/aws_integration.tf
+++ b/aws/newrelic/aws_integration.tf
@@ -202,7 +202,7 @@ EOF
 
 resource "aws_cloudwatch_metric_stream" "newrelic_metric_stream" {
   # Disabled for now
-  count         = 0
+  count         = var.enable_new_relic && var.env == "staging" ? 1 : 0
   name          = "newrelic-metric-stream-${var.env}"
   role_arn      = aws_iam_role.metric_stream_to_firehose[0].arn
   firehose_arn  = aws_kinesis_firehose_delivery_stream.newrelic_firehose_stream[0].arn


### PR DESCRIPTION
# Summary | Résumé

Enabling new relic metrics stream in staging to see if we can get a cost estimate.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/390

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

TF Apply works
Verify that the metric stream is created aws cloudwatch
Verify that New relic is receiving metrics

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
