### PR TITLE
Disable the ai code reviewer

### DIFF
--- a/.github/workflows/ai-code-scanner.yml
+++ b/.github/workflows/ai-code-scanner.yml
@@ -1,10 +1,11 @@
 name: AI Code Review
 
-on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
+# Disabled the AI code reviewer for now
+# on:
+#   pull_request:
+#     types:
+#       - opened
+#       - synchronize
 
 jobs:
   ai_code_review:


### PR DESCRIPTION
# Summary | Résumé

We removed the API key at the moment for cost reason. Hence this disables the ai code reviewer. We might try it one more week after slight changes to the action and changing region to be more cost effective. Stay tuned.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1
* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/1

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [x] This PR does not break existing functionality.
* [x] This PR does not violate GCNotify's privacy policies.
* [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [x] This PR does not significantly alter performance.
* [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
