### PR TITLE
Add service_id to cloudwatch queries for callback failures

### DIFF
--- a/aws/eks/cloudwatch_queries.tf
+++ b/aws/eks/cloudwatch_queries.tf
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_query_definition" "celery-errors" {
   query_string = <<QUERY
 fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as pod_name, @logStream
 | filter kubernetes.container_name like /^celery/
-| filter @message like /ERROR\/.*Worker/ or @message like /ERROR\/MainProcess/ 
+| filter @message like /ERROR\/.*Worker/ or @message like /ERROR\/MainProcess/
 | sort @timestamp desc
 | limit 20
 QUERY
@@ -284,7 +284,7 @@ resource "aws_cloudwatch_query_definition" "callback-max-retry-failures-by-servi
 fields @timestamp, @service_id, @callback_url, @notification_id
 | filter kubernetes.container_name like /^celery/
 | filter @message like /send_delivery_status_to_service has retried the max num of times for callback url/
-| parse @message 'Retry: send_delivery_status_to_service has retried the max num of times for callback url * and notification_id: * for service: *' as @callback_url, @notification_id, @service_id
+| parse @message 'Retry: send_delivery_status_to_service has retried the max num of times for callback url * and notification_id: * service: *' as @callback_url, @notification_id, @service_id
 | sort @timestamp desc
 | stats count(@service_id) by @service_id, bin(30m)
 | limit 10000
@@ -303,7 +303,7 @@ resource "aws_cloudwatch_query_definition" "callback-failures" {
 fields @timestamp, @notification_id, @url, @error
 | filter kubernetes.container_name like /^celery/
 | filter @message like /send_delivery_status_to_service request failed for notification_id:/
-| parse @message 'send_delivery_status_to_service request failed for notification_id: * and url: * exc: *' as @notification_id, @url, @error
+| parse @message 'send_delivery_status_to_service request failed for notification_id: * and url: * service: * exc: *' as @notification_id, @url, @service_id, @error
 | limit 10000
 QUERY
 }


### PR DESCRIPTION
# Summary | Résumé

This PR adds the `service_id` to our callback failure cloudwatch queries as part of a change to the overall logging for callback failures.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-api/pull/2301

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
