### PR TITLE
Production K8s Node Upgrade 1.30.4-20240917

### DIFF
--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -1,3 +1,5 @@
+#PRODUCTION EKS VERSIONS: K8s Node Upgrade 1.30.4-20240917
+
 terraform {
   source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/eks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//eks"}"
 }


### PR DESCRIPTION
# Summary | Résumé

Upgrading Production to latest K8s worker node version
This change reflects an update to a comment in our hcl file because for the time being versions are updated in 1password (which would not show as changes in git).


## Related Issues | Cartes liées

Chore

# Test instructions | Instructions pour tester la modification

TF Apply works

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.