### PR TITLE
Move out a couple account ids

### DIFF
--- a/.github/workflows/check_rds_cluster_update.yml
+++ b/.github/workflows/check_rds_cluster_update.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Configure AWS credentials using OIDC
       uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
       with:
-        role-to-assume: arn:aws:iam::239043911459:role/notification-terraform-apply
+        role-to-assume: arn:aws:iam::${{ secrets.STAGING_ACCOUNT_ID }}:role/notification-terraform-apply
         role-session-name: RDSClusterUpdateCheck
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
 

--- a/.github/workflows/terragrunt_destroy_environment.yml
+++ b/.github/workflows/terragrunt_destroy_environment.yml
@@ -35,7 +35,7 @@ jobs:
       - name: setup-terraform
         uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::800095993820:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::${{ secrets.DEV_ACCOUNT_ID}}:role/notification-terraform-apply
           role_session_name: NotifyTerraformDestroy            
 
       - name: Install AWS nuke

--- a/aws/common/file_scanning.tf
+++ b/aws/common/file_scanning.tf
@@ -1,13 +1,9 @@
-locals {
-  scan_files_account = var.env == "production" ? "806545929748" : "127893201980"
-}
-
 module "s3_scan_objects" {
   source = "github.com/cds-snc/terraform-modules//S3_scan_object?ref=v6.1.5"
 
   s3_upload_bucket_name   = "notification-canada-ca-${var.env}-document-download-scan-files"
-  s3_scan_object_role_arn = "arn:aws:iam::${local.scan_files_account}:role/s3-scan-object"
-  scan_files_role_arn     = "arn:aws:iam::${local.scan_files_account}:role/scan-files-api"
+  s3_scan_object_role_arn = "arn:aws:iam::${var.scan_files_account_id}:role/s3-scan-object"
+  scan_files_role_arn     = "arn:aws:iam::${var.scan_files_account_id}:role/scan-files-api"
 
   billing_tag_value = var.billing_tag_value
 }

--- a/aws/ec2/ec2.tf
+++ b/aws/ec2/ec2.tf
@@ -10,8 +10,9 @@ data "aws_ami" "ubuntu" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
-
-  owners = ["099720109477"] # Canonical
+  # Canonical Owner ID
+  # https://documentation.ubuntu.com/aws/en/latest/aws-how-to/instances/find-ubuntu-images/#ownership-verification
+  owners = ["099720109477"]
 }
 
 # Create EC2 instance

--- a/aws/eks/sentinel.tf
+++ b/aws/eks/sentinel.tf
@@ -12,7 +12,7 @@ module "sentinel_forwarder" {
   function_name     = "sentinel-cloud-watch-forwarder"
   billing_tag_value = "notification-canada-ca-${var.env}"
 
-  layer_arn = "arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:${var.sentinel_layer_version}"
+  layer_arn = "arn:aws:lambda:ca-central-1:${var.sentinel_sre_aws_account_id}:layer:aws-sentinel-connector-layer:${var.sentinel_layer_version}"
 
   customer_id = var.sentinel_customer_id
   shared_key  = var.sentinel_shared_key

--- a/aws/lambda-api/ecr_user.tf
+++ b/aws/lambda-api/ecr_user.tf
@@ -70,6 +70,8 @@ data "aws_iam_policy_document" "ecr" {
     actions = [
       "lambda:GetLayerVersion"
     ]
+    # New Relic Python Lambda layers
+    # https://layers.newrelic-external.com/
     resources = ["arn:aws:lambda:ca-central-1:451483290750:layer:NewRelicPython*:*"]
   }
 }

--- a/aws/newrelic/aws_integration.tf
+++ b/aws/newrelic/aws_integration.tf
@@ -7,7 +7,7 @@ data "aws_iam_policy_document" "newrelic_assume_policy" {
     principals {
       type = "AWS"
       // This is the unique identifier for New Relic account on AWS, there is no need to change this
-      identifiers = [754728514883]
+      identifiers = [var.new_relic_aws_account_id]
     }
 
     condition {

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -127,6 +127,11 @@ variable "elb_account_ids" {
   sensitive = true
 }
 
+variable "scan_files_account_id" {
+  type      = string
+  sensitive = true
+}
+
 variable "cbs_satellite_bucket_name" {
   type = string
 }

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -516,7 +516,8 @@ variable "sentinel_layer_version" {
 }
 
 variable "sentinel_sre_aws_account_id" {
-  type = string
+  type      = string
+  sensitive = true
 }
 
 variable "heartbeat_api_key" {

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -456,6 +456,11 @@ variable "cloudwatch_opsgenie_alarm_webhook" {
   sensitive = true
 }
 
+variable "new_relic_aws_account_id" {
+  type      = string
+  sensitive = true
+}
+
 variable "new_relic_license_key" {
   type      = string
   sensitive = true

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -510,6 +510,10 @@ variable "sentinel_layer_version" {
   type = string
 }
 
+variable "sentinel_sre_aws_account_id" {
+  type = string
+}
+
 variable "heartbeat_api_key" {
   type      = string
   sensitive = true


### PR DESCRIPTION
# Summary | Résumé

Move a few more account ids into variables rather than being hard coded.

Added `scan_files_account_id`, `new_relic_aws_account_id`, and `sentinel_sre_aws_account_id` to 1Password for dev / staging / production.

`STAGING_ACCOUNT_ID` and `DEV_ACCOUNT_ID` and already in out GitHub serets.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/410

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

Make sure the plans and applies pass!

## Release Instructions | Instructions pour le déploiement

Make sure the plans and applies pass!

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
