### PR TITLE
fixing dev config

### DIFF
--- a/env/dev_config.tfvars
+++ b/env/dev_config.tfvars
@@ -40,7 +40,7 @@ notification_queue_prefix              = "eks-notification-canada-ca"
 
 # ENVIRONMENT
 enable_new_relic           = true
-create_cbs_bucket          = false
+create_cbs_bucket          = true
 force_destroy_s3           = true
 force_delete_ecr           = true
 force_destroy_athena       = true
@@ -77,7 +77,7 @@ slack_channel_critical_topic            = "notification-dev-ops"
 slack_channel_general_topic             = "notification-dev-ops"
 
 ## MONITORING
-athena_workgroup_name                  = "primary"
+athena_workgroup_name                  = "dev"
 cloudwatch_opsgenie_alarm_webhook      = ""
 aws_config_recorder_name               = "aws-controltower-BaselineConfigRecorder"
 sentinel_layer_version                 = "165"


### PR DESCRIPTION
# Summary | Résumé

There were a couple misconfigured values after the separation of the secrets and env-vars. That were causing dev to fail to build

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/352
* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/433

## Test instructions | Instructions pour tester la modification

Create Dev Env script should work.

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
