### PR TITLE
fix clickops callback error query

### DIFF
--- a/aws/eks/cloudwatch_queries.tf
+++ b/aws/eks/cloudwatch_queries.tf
@@ -284,8 +284,8 @@ resource "aws_cloudwatch_query_definition" "callback-errors-by-url" {
 fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as pod_name, @logStream
 | filter kubernetes.container_name like /^celery/
 | filter @message like /send_delivery_status_to_service request failed for notification_id/
-| parse log / to url: (?<url>.*) service: (?<service>.*) exc:.*/
-| stats count() as failed_callbacks by url, service
+| parse log "to url: * service: * exc:" as @url, @service_id
+| stats count() as failed_callbacks by @url, @service_id
 | order by failed_callbacks desc
 QUERY
 }

--- a/aws/eks/cloudwatch_queries.tf
+++ b/aws/eks/cloudwatch_queries.tf
@@ -272,6 +272,24 @@ fields @timestamp, @service_id, @bounce_type
 QUERY
 }
 
+resource "aws_cloudwatch_query_definition" "callback-errors-by-url" {
+  count = var.cloudwatch_enabled ? 1 : 0
+  name  = "Callbacks / Callback errors by URL"
+
+  log_group_names = [
+    local.eks_application_log_group
+  ]
+
+  query_string = <<QUERY
+fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as pod_name, @logStream
+| filter kubernetes.container_name like /^celery/
+| filter @message like /send_delivery_status_to_service request failed for notification_id/
+| parse log / to url: (?<url>.*) service: (?<service>.*) exc:.*/
+| stats count() as failed_callbacks by url, service
+| order by failed_callbacks desc
+QUERY
+}
+
 resource "aws_cloudwatch_query_definition" "callback-max-retry-failures-by-service" {
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Callbacks / Callbacks that exceeded MaxRetries by service"


### PR DESCRIPTION
# Summary | Résumé

We have a clickops query in production, "Failed callbacks" that isn't working. This PR fixes it and adds it to terraform.


## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

[Run the query](https://ca-central-1.console.aws.amazon.com/cloudwatch/home?region=ca-central-1#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-3600~timeType~'RELATIVE~tz~'LOCAL~unit~'seconds~editorString~'fields*20*40timestamp*2c*20log*2c*20kubernetes.container_name*20as*20app*2c*20kubernetes.pod_name*20as*20pod_name*2c*20*40logStream*0a*7c*20filter*20kubernetes.container_name*20like*20*2f*5ecelery*2f*0a*7c*20filter*20*40message*20like*20*2fsend_delivery_status_to_service*20request*20failed*20for*20notification_id*2f*0a*7c*20parse*20log*20*22to*20url*3a*20*2a*20service*3a*20*2a*20exc*3a*22*20as*20*40url*2c*20*40service_id*0a*7c*20stats*20count*28*29*20as*20failed_callbacks*20by*20*40url*2c*20*40service_id*0a*7c*20order*20by*20failed_callbacks*20desc~queryId~'6c6802e4-814e-4f84-b4e7-bd747e67d37f~source~(~'*2faws*2fcontainerinsights*2fnotification-canada-ca-production-eks-cluster*2fapplication))).
## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [x] This PR does not break existing functionality.
* [x] This PR does not violate GCNotify's privacy policies.
* [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [x] This PR does not significantly alter performance.
* [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
