### PR TITLE
Pinpoint cloudwatch log groups always enabled

### DIFF
--- a/aws/pinpoint_to_sqs_sms_callbacks/cloudwatch_logs.tf
+++ b/aws/pinpoint_to_sqs_sms_callbacks/cloudwatch_logs.tf
@@ -3,7 +3,6 @@
 #
 
 resource "aws_cloudwatch_log_group" "pinpoint_deliveries" {
-  count             = var.cloudwatch_enabled ? 1 : 0
   name              = "sns/${var.region}/${var.account_id}/PinpointDirectPublishToPhoneNumber"
   retention_in_days = var.sensitive_log_retention_period_days
   tags = {
@@ -12,7 +11,6 @@ resource "aws_cloudwatch_log_group" "pinpoint_deliveries" {
 }
 
 resource "aws_cloudwatch_log_group" "pinpoint_deliveries_failures" {
-  count             = var.cloudwatch_enabled ? 1 : 0
   name              = "sns/${var.region}/${var.account_id}/PinpointDirectPublishToPhoneNumber/Failure"
   retention_in_days = var.sensitive_log_retention_period_days
   tags = {
@@ -56,7 +54,7 @@ resource "aws_cloudwatch_log_metric_filter" "pinpoint-sms-blocked-as-spam" {
   name  = "pinpoint-sms-blocked-as-spam"
   # See https://docs.aws.amazon.com/sms-voice/latest/userguide/configuration-sets-event-format.html
   pattern        = "{ $.messageStatus = \"SPAM\" }"
-  log_group_name = aws_cloudwatch_log_group.pinpoint_deliveries_failures[0].name
+  log_group_name = aws_cloudwatch_log_group.pinpoint_deliveries_failures.name
 
   metric_transformation {
     name          = "pinpoint-sms-blocked-as-spam"
@@ -71,7 +69,7 @@ resource "aws_cloudwatch_log_metric_filter" "pinpoint-sms-phone-carrier-unavaila
   name  = "pinpoint-sms-phone-carrier-unavailable"
   # See https://docs.aws.amazon.com/sms-voice/latest/userguide/configuration-sets-event-format.html
   pattern        = "{ $.messageStatus = \"CARRIER_UNREACHABLE\" }"
-  log_group_name = aws_cloudwatch_log_group.pinpoint_deliveries_failures[0].name
+  log_group_name = aws_cloudwatch_log_group.pinpoint_deliveries_failures.name
 
   metric_transformation {
     name          = "pinpoint-sms-phone-carrier-unavailable"
@@ -87,7 +85,7 @@ resource "aws_cloudwatch_log_metric_filter" "pinpoint-sms-rate-exceeded" {
   # https://docs.aws.amazon.com/sns/latest/dg/channels-sms-originating-identities-long-codes.html
   # Canadian long code numbers are limited at 1 SMS per second/number
   pattern        = "{ $.messageStatusDescription = \"Rate exceeded.\" }"
-  log_group_name = aws_cloudwatch_log_group.pinpoint_deliveries_failures[0].name
+  log_group_name = aws_cloudwatch_log_group.pinpoint_deliveries_failures.name
 
   metric_transformation {
     name          = "pinpoint-sms-rate-exceeded"
@@ -101,7 +99,7 @@ resource "aws_cloudwatch_log_metric_filter" "pinpoint-sms-successes" {
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "pinpoint-sms-successes"
   pattern        = "{ ($.isFinal IS TRUE) && ( ($.messageStatus = \"SUCCESSFUL\") || ($.messageStatus = \"DELIVERED\") ) }"
-  log_group_name = aws_cloudwatch_log_group.pinpoint_deliveries[0].name
+  log_group_name = aws_cloudwatch_log_group.pinpoint_deliveries.name
 
   metric_transformation {
     name          = "pinpoint-sms-successes"
@@ -115,7 +113,7 @@ resource "aws_cloudwatch_log_metric_filter" "pinpoint-sms-failures" {
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "pinpoint-sms-failures"
   pattern        = "{ ($.isFinal IS TRUE) && ( ($.messageStatus != \"SUCCESSFUL\") && ($.messageStatus != \"DELIVERED\") ) }"
-  log_group_name = aws_cloudwatch_log_group.pinpoint_deliveries_failures[0].name
+  log_group_name = aws_cloudwatch_log_group.pinpoint_deliveries_failures.name
 
   metric_transformation {
     name          = "pinpoint-sms-failures"
@@ -127,7 +125,7 @@ resource "aws_cloudwatch_log_metric_filter" "pinpoint-sms-failures" {
 
 resource "aws_cloudwatch_log_metric_filter" "pinpoint-sms-failures-carriers" {
   count          = var.cloudwatch_enabled ? 1 : 0
-  log_group_name = aws_cloudwatch_log_group.pinpoint_deliveries_failures[0].name
+  log_group_name = aws_cloudwatch_log_group.pinpoint_deliveries_failures.name
 
   name    = "pinpoint-sms-failures-carriers"
   pattern = "{ ($.isFinal IS TRUE) && ($.carrierName != \"\" && ( ($.messageStatus != \"SUCCESSFUL\") && ($.messageStatus != \"DELIVERED\") )) }"

--- a/aws/pinpoint_to_sqs_sms_callbacks/cloudwatch_queries.tf
+++ b/aws/pinpoint_to_sqs_sms_callbacks/cloudwatch_queries.tf
@@ -3,7 +3,7 @@ resource "aws_cloudwatch_query_definition" "pinpoint-sms-blocked-as-spam" {
   name  = "SMS (Pinpoint) / Block as spam"
 
   log_group_names = [
-    aws_cloudwatch_log_group.pinpoint_deliveries_failures[0].name
+    aws_cloudwatch_log_group.pinpoint_deliveries_failures.name
   ]
 
   query_string = <<QUERY
@@ -24,8 +24,8 @@ resource "aws_cloudwatch_query_definition" "pinpoint-sms-carrier-dwell-times" {
   name  = "SMS (Pinpoint) / Carrier dwell times"
 
   log_group_names = [
-    aws_cloudwatch_log_group.pinpoint_deliveries[0].name,
-    aws_cloudwatch_log_group.pinpoint_deliveries_failures[0].name,
+    aws_cloudwatch_log_group.pinpoint_deliveries.name,
+    aws_cloudwatch_log_group.pinpoint_deliveries_failures.name,
   ]
 
   query_string = <<QUERY
@@ -42,8 +42,8 @@ resource "aws_cloudwatch_query_definition" "pinpoint-sms-failures-by-carrier" {
   name  = "SMS (Pinpoint) / Failures by carrier"
 
   log_group_names = [
-    aws_cloudwatch_log_group.pinpoint_deliveries[0].name,
-    aws_cloudwatch_log_group.pinpoint_deliveries_failures[0].name,
+    aws_cloudwatch_log_group.pinpoint_deliveries.name,
+    aws_cloudwatch_log_group.pinpoint_deliveries_failures.name,
   ]
 
   query_string = <<QUERY
@@ -59,7 +59,7 @@ resource "aws_cloudwatch_query_definition" "pinpoint-sms-get-failures" {
   name  = "SMS (Pinpoint) / Get failures"
 
   log_group_names = [
-    aws_cloudwatch_log_group.pinpoint_deliveries_failures[0].name
+    aws_cloudwatch_log_group.pinpoint_deliveries_failures.name
   ]
 
   query_string = <<QUERY
@@ -78,8 +78,8 @@ resource "aws_cloudwatch_query_definition" "pinpoint-sms-international-sending-s
   name  = "SMS (Pinpoint) / International sending status"
 
   log_group_names = [
-    aws_cloudwatch_log_group.pinpoint_deliveries[0].name,
-    aws_cloudwatch_log_group.pinpoint_deliveries_failures[0].name
+    aws_cloudwatch_log_group.pinpoint_deliveries.name,
+    aws_cloudwatch_log_group.pinpoint_deliveries_failures.name
   ]
 
   query_string = <<QUERY
@@ -100,8 +100,8 @@ resource "aws_cloudwatch_query_definition" "pinpoint-sms-get-sms-logs-by-dest-ph
   name  = "SMS (Pinpoint) / Get SMS logs by destination phone number"
 
   log_group_names = [
-    aws_cloudwatch_log_group.pinpoint_deliveries[0].name,
-    aws_cloudwatch_log_group.pinpoint_deliveries_failures[0].name
+    aws_cloudwatch_log_group.pinpoint_deliveries.name,
+    aws_cloudwatch_log_group.pinpoint_deliveries_failures.name
   ]
 
   query_string = <<QUERY
@@ -120,8 +120,8 @@ resource "aws_cloudwatch_query_definition" "pinpoint-sms-get-sms-logs-by-orig-ph
   name  = "SMS (Pinpoint) / Get SMS logs by origination phone number"
 
   log_group_names = [
-    aws_cloudwatch_log_group.pinpoint_deliveries[0].name,
-    aws_cloudwatch_log_group.pinpoint_deliveries_failures[0].name
+    aws_cloudwatch_log_group.pinpoint_deliveries.name,
+    aws_cloudwatch_log_group.pinpoint_deliveries_failures.name
   ]
 
   query_string = <<QUERY
@@ -140,8 +140,8 @@ resource "aws_cloudwatch_query_definition" "pinpoint-sms-get-logs" {
   name  = "SMS (Pinpoint) / Logs"
 
   log_group_names = [
-    aws_cloudwatch_log_group.pinpoint_deliveries[0].name,
-    aws_cloudwatch_log_group.pinpoint_deliveries_failures[0].name
+    aws_cloudwatch_log_group.pinpoint_deliveries.name,
+    aws_cloudwatch_log_group.pinpoint_deliveries_failures.name
   ]
 
   query_string = <<QUERY
@@ -160,8 +160,8 @@ resource "aws_cloudwatch_query_definition" "pinpoint-sms-success-vs-unreachable"
   name  = "SMS (Pinpoint) / Success vs Unreachable"
 
   log_group_names = [
-    aws_cloudwatch_log_group.pinpoint_deliveries[0].name,
-    aws_cloudwatch_log_group.pinpoint_deliveries_failures[0].name
+    aws_cloudwatch_log_group.pinpoint_deliveries.name,
+    aws_cloudwatch_log_group.pinpoint_deliveries_failures.name
   ]
 
   query_string = <<QUERY

--- a/aws/pinpoint_to_sqs_sms_callbacks/iam.tf
+++ b/aws/pinpoint_to_sqs_sms_callbacks/iam.tf
@@ -51,8 +51,8 @@ data "aws_iam_policy_document" "pinpoint_logs" {
       "logs:PutLogEvents"
     ]
     resources = [
-      "${aws_cloudwatch_log_group.pinpoint_deliveries[0].arn}:*",
-      "${aws_cloudwatch_log_group.pinpoint_deliveries_failures[0].arn}:*"
+      "${aws_cloudwatch_log_group.pinpoint_deliveries.arn}:*",
+      "${aws_cloudwatch_log_group.pinpoint_deliveries_failures.arn}:*"
     ]
   }
 }

--- a/aws/pinpoint_to_sqs_sms_callbacks/lambda.tf
+++ b/aws/pinpoint_to_sqs_sms_callbacks/lambda.tf
@@ -30,13 +30,13 @@ resource "aws_lambda_permission" "allow_cloudwatch_logs_pinpoint_successes" {
   action        = "lambda:InvokeFunction"
   function_name = module.pinpoint_to_sqs_sms_callbacks.function_name
   principal     = "logs.${var.region}.amazonaws.com"
-  source_arn    = "${aws_cloudwatch_log_group.pinpoint_deliveries[0].arn}:*"
+  source_arn    = "${aws_cloudwatch_log_group.pinpoint_deliveries.arn}:*"
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "pinpoint_deliveries_ca_central_to_lambda" {
   count           = var.cloudwatch_enabled ? 1 : 0
   name            = "pinpoint_deliveries_ca_central"
-  log_group_name  = aws_cloudwatch_log_group.pinpoint_deliveries[0].name
+  log_group_name  = aws_cloudwatch_log_group.pinpoint_deliveries.name
   filter_pattern  = ""
   destination_arn = module.pinpoint_to_sqs_sms_callbacks.function_arn
 }
@@ -46,13 +46,13 @@ resource "aws_lambda_permission" "allow_cloudwatch_logs_pinpoint_failures" {
   action        = "lambda:InvokeFunction"
   function_name = module.pinpoint_to_sqs_sms_callbacks.function_name
   principal     = "logs.${var.region}.amazonaws.com"
-  source_arn    = "${aws_cloudwatch_log_group.pinpoint_deliveries_failures[0].arn}:*"
+  source_arn    = "${aws_cloudwatch_log_group.pinpoint_deliveries_failures.arn}:*"
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "pinpoint_deliveries_failures_ca_central_to_lambda" {
   count           = var.cloudwatch_enabled ? 1 : 0
   name            = "pinpoint_deliveries_failures_ca_central"
-  log_group_name  = aws_cloudwatch_log_group.pinpoint_deliveries_failures[0].name
+  log_group_name  = aws_cloudwatch_log_group.pinpoint_deliveries_failures.name
   filter_pattern  = ""
   destination_arn = module.pinpoint_to_sqs_sms_callbacks.function_arn
 }

--- a/aws/pinpoint_to_sqs_sms_callbacks/pools.tf
+++ b/aws/pinpoint_to_sqs_sms_callbacks/pools.tf
@@ -2,6 +2,6 @@ resource "null_resource" "create_pools" {
   depends_on = [aws_iam_role.pinpoint_logs, aws_cloudwatch_log_group.pinpoint_deliveries, aws_cloudwatch_log_group.pinpoint_deliveries_failures]
 
   provisioner "local-exec" {
-    command = "./create_pinpoint_pools.sh ${aws_iam_role.pinpoint_logs.arn} ${aws_cloudwatch_log_group.pinpoint_deliveries[0].arn} ${aws_cloudwatch_log_group.pinpoint_deliveries_failures[0].arn}"
+    command = "./create_pinpoint_pools.sh ${aws_iam_role.pinpoint_logs.arn} ${aws_cloudwatch_log_group.pinpoint_deliveries.arn} ${aws_cloudwatch_log_group.pinpoint_deliveries_failures.arn}"
   }
 }


### PR DESCRIPTION
# Summary | Résumé

The pinpoint cloudwatch log groups need to be created regardless of whether or not cloudwatch is enabled globally.  They are required by the create pools script. 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/352

## Test instructions | Instructions pour tester la modification

TF Apply works
Create Dev Env works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [x] This PR does not break existing functionality.
* [x] This PR does not violate GCNotify's privacy policies.
* [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [x] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
