### PR TITLE
Deleting budget event rules

### DIFF
--- a/scripts/deleteEnvironment.sh
+++ b/scripts/deleteEnvironment.sh
@@ -107,5 +107,12 @@ aws logs delete-query-definition --query-definition-id $(aws logs describe-query
 aws iam delete-saml-provider --saml-provider-arn arn:aws:iam::$ACCOUNT_ID:saml-provider/client-vpn
 
 aws iam delete-user --user-name ecr-user
+
+aws events remove-targets --rule dailyBudgetSpend --ids $(aws events list-targets-by-rule --rule dailyBudgetSpend --query 'Targets[].Id' --output text)
+aws events delete-rule --name dailyBudgetSpend
+
+aws events remove-targets --rule weeklyBudgetSpend --ids $(aws events list-targets-by-rule --rule weeklyBudgetSpend --query 'Targets[].Id' --output text)
+aws events delete-rule --name weeklyBudgetSpend
+
 echo "Done."
 echo "Account $ACCOUNT_ID has been cleaned up."


### PR DESCRIPTION
# Summary | Résumé

The reason the create failed is because the event bridge rules were not getting killed by awsnuke. Adding to the script to forcibly delete them.

We never hit this issue until now because there is a max number of event bridge rule targets that we hit. 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/352

## Test instructions | Instructions pour tester la modification

Run delete environment and then try and create

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [x] This PR does not break existing functionality.
* [x] This PR does not violate GCNotify's privacy policies.
* [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [x] This PR does not significantly alter performance.
* [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
