### PR TITLE
Destroy google cidr event targets

### DIFF
--- a/scripts/deleteEnvironment.sh
+++ b/scripts/deleteEnvironment.sh
@@ -114,5 +114,9 @@ aws events delete-rule --name dailyBudgetSpend
 aws events remove-targets --rule weeklyBudgetSpend --ids $(aws events list-targets-by-rule --rule weeklyBudgetSpend --query 'Targets[].Id' --output text)
 aws events delete-rule --name weeklyBudgetSpend
 
+aws events remove-targets --rule google_cidr_testing --ids $(aws events list-targets-by-rule --rule google_cidr_testing --query 'Targets[].Id' --output text)
+aws events delete-rule --name google_cidr_testing
+
+
 echo "Done."
 echo "Account $ACCOUNT_ID has been cleaned up."


### PR DESCRIPTION
# Summary | Résumé

Like the budget event targets, the google cidr event rule was also erroring out. 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/352

## Test instructions | Instructions pour tester la modification

Delete/Create dev environment.

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [x] This PR does not break existing functionality.
* [x] This PR does not violate GCNotify's privacy policies.
* [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [x] This PR does not significantly alter performance.
* [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
