### PR TITLE
Add warning/critical levels to bounce rate graphs

### DIFF
--- a/aws/common/dashboards_email.tf
+++ b/aws/common/dashboards_email.tf
@@ -401,17 +401,44 @@ resource "aws_cloudwatch_dashboard" "email-bounce_rate" {
             "type": "metric",
             "properties": {
                 "metrics": [
-                    [ "AWS/SES", "Reputation.BounceRate", { "stat": "Average", "region": "${var.region}" } ]
+                    [ { "expression": "m1 * 100", "label": "AWS Reputation Bounce Rate Score", "id": "e1", "region": ${var.region} } ],
+                    [ "AWS/SES", "Reputation.BounceRate", { "region": ${var.region}, "id": "m1", "visible": false } ]
                 ],
                 "legend": {
                     "position": "hidden"
                 },
-                "region": "${var.region}",
+                "region": ${var.region},
                 "liveData": false,
                 "title": "SES reputation bounce rate",
                 "view": "timeSeries",
                 "stacked": false,
-                "period": 900
+                "period": 900,
+                "yAxis": {
+                    "left": {
+                        "max": 10,
+                        "min": 0,
+                        "label": "%",
+                        "showUnits": false
+                    }
+                },
+                "annotations": {
+                    "horizontal": [
+                        {
+                            "label": "critical",
+                            "value": 7
+                        },
+                        {
+                            "label": "warning",
+                            "value": 5
+                        },
+                        {
+                            "color": "#d62728",
+                            "label": "AWS cutoff",
+                            "value": 10
+                        }
+                    ]
+                },
+                "stat": "Average"
             }
         },
         {
@@ -422,13 +449,13 @@ resource "aws_cloudwatch_dashboard" "email-bounce_rate" {
             "type": "metric",
             "properties": {
                 "metrics": [
-                    [ { "expression": "100 * m1 / m2", "label": "Notify bounce rate", "id": "e1", "region": "${var.region}", "period": 900 } ],
-                    [ "AWS/SES", "Bounce", { "color": "#1f77b4", "region": "${var.region}", "id": "m1", "visible": false } ],
-                    [ ".", "Send", { "id": "m2", "region": "${var.region}", "yAxis": "right", "label": "Total sent", "visible": false } ]
+                    [ { "expression": "100 * m1 / (m2 + 1)", "label": "Notify bounce rate", "id": "e1", "region": ${var.region}, "period": 900 } ],
+                    [ "AWS/SES", "Bounce", { "color": "#1f77b4", "region": ${var.region}, "id": "m1", "visible": false } ],
+                    [ ".", "Send", { "id": "m2", "region": ${var.region}, "yAxis": "right", "label": "Total sent", "visible": false } ]
                 ],
                 "view": "timeSeries",
                 "stacked": false,
-                "region": "${var.region}",
+                "region": ${var.region},
                 "stat": "Sum",
                 "period": 900,
                 "title": "Notify bounce rate",
@@ -436,11 +463,24 @@ resource "aws_cloudwatch_dashboard" "email-bounce_rate" {
                     "left": {
                         "label": "%",
                         "min": 0,
-                        "showUnits": false
+                        "showUnits": false,
+                        "max": 15
                     }
                 },
                 "legend": {
                     "position": "hidden"
+                },
+                "annotations": {
+                    "horizontal": [
+                        {
+                            "label": "service critical",
+                            "value": 10
+                        },
+                        {
+                            "label": "service warning",
+                            "value": 5
+                        }
+                    ]
                 }
             }
         },


### PR DESCRIPTION
# Summary | Résumé

Spiff up the bounce rate graphs with levels where our alarms go off.

[Mocked up in production here](https://ca-central-1.console.aws.amazon.com/cloudwatch/home?region=ca-central-1#dashboards/dashboard/SJA-TEMP-BounceRate).

![image](https://github.com/user-attachments/assets/ede034b8-71f5-45c4-8cd4-e25333489cb8)

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
