### PR TITLE
Converting AWS SES Identities to SES V2

### DIFF
--- a/aws/dns/outputs.tf
+++ b/aws/dns/outputs.tf
@@ -1,8 +1,3 @@
-output "ses_verification" {
-  description = "Verification TXT record for SES"
-  value       = aws_ses_domain_identity.notification-canada-ca.verification_token
-}
-
 output "dkim_verification_token" {
   description = "DKIM CNAME record for SES"
   value       = aws_ses_domain_dkim.notification-canada-ca.dkim_tokens

--- a/aws/dns/ses.tf
+++ b/aws/dns/ses.tf
@@ -19,8 +19,10 @@ locals {
 
 }
 
-resource "aws_ses_domain_identity" "notification-canada-ca" {
-  domain = var.domain
+
+
+resource "aws_sesv2_email_identity" "notification-canada-ca" {
+  email_identity = var.domain
 }
 
 resource "aws_ses_domain_dkim" "notification-canada-ca" {
@@ -33,40 +35,40 @@ resource "aws_ses_domain_dkim" "notification-canada-ca" {
 resource "aws_ses_identity_notification_topic" "notification-canada-ca-bounce-topic" {
   topic_arn                = var.notification_canada_ca_ses_callback_arn
   notification_type        = "Bounce"
-  identity                 = aws_ses_domain_identity.notification-canada-ca.domain
+  identity                 = aws_sesv2_email_identity.notification-canada-ca.email_identity
   include_original_headers = false
 }
 
 resource "aws_ses_identity_notification_topic" "notification-canada-ca-delivery-topic" {
   topic_arn                = var.notification_canada_ca_ses_callback_arn
   notification_type        = "Delivery"
-  identity                 = aws_ses_domain_identity.notification-canada-ca.domain
+  identity                 = aws_sesv2_email_identity.notification-canada-ca.email_identity
   include_original_headers = false
 }
 
 resource "aws_ses_identity_notification_topic" "notification-canada-ca-complaint-topic" {
   topic_arn                = var.notification_canada_ca_ses_callback_arn
   notification_type        = "Complaint"
-  identity                 = aws_ses_domain_identity.notification-canada-ca.domain
+  identity                 = aws_sesv2_email_identity.notification-canada-ca.email_identity
   include_original_headers = false
 }
 
 resource "aws_ses_domain_mail_from" "notification-canada-ca" {
-  domain           = aws_ses_domain_identity.notification-canada-ca.domain
-  mail_from_domain = "bounce.${aws_ses_domain_identity.notification-canada-ca.domain}"
+  domain           = aws_sesv2_email_identity.notification-canada-ca.email_identity
+  mail_from_domain = "bounce.${aws_sesv2_email_identity.notification-canada-ca.email_identity}"
 }
 
 ###
 # Receiving emails
 ###
 
-resource "aws_ses_domain_identity" "notification-canada-ca-receiving" {
+resource "aws_sesv2_email_identity" "notification-canada-ca-receiving" {
   # Email receiving with SES is available in only 3 regions
   # so we use us-east-1
   # https://docs.aws.amazon.com/general/latest/gr/ses.html
   provider = aws.us-east-1
 
-  domain = var.domain
+  email_identity = var.domain
 }
 
 resource "aws_ses_domain_dkim" "notification-canada-ca-receiving" {
@@ -98,9 +100,9 @@ resource "aws_ses_active_receipt_rule_set" "main" {
 # `ses_custom_sending_domains`.
 ###
 
-resource "aws_ses_domain_identity" "cic-trvapply-vrtdemande" {
-  count  = var.env == "production" ? 1 : 0
-  domain = "trvapply-vrtdemande.apps.cic.gc.ca"
+resource "aws_sesv2_email_identity" "cic-trvapply-vrtdemande" {
+  count          = var.env == "production" ? 1 : 0
+  email_identity = "trvapply-vrtdemande.apps.cic.gc.ca"
 }
 
 resource "aws_ses_domain_dkim" "cic-trvapply-vrtdemande" {
@@ -112,7 +114,7 @@ resource "aws_ses_identity_notification_topic" "cic-trvapply-vrtdemande-bounce-t
   count                    = var.env == "production" ? 1 : 0
   topic_arn                = var.notification_canada_ca_ses_callback_arn
   notification_type        = "Bounce"
-  identity                 = aws_ses_domain_identity.cic-trvapply-vrtdemande[0].domain
+  identity                 = aws_sesv2_email_identity.cic-trvapply-vrtdemande[0].email_identity
   include_original_headers = false
 }
 
@@ -120,7 +122,7 @@ resource "aws_ses_identity_notification_topic" "cic-trvapply-vrtdemande-delivery
   count                    = var.env == "production" ? 1 : 0
   topic_arn                = var.notification_canada_ca_ses_callback_arn
   notification_type        = "Delivery"
-  identity                 = aws_ses_domain_identity.cic-trvapply-vrtdemande[0].domain
+  identity                 = aws_sesv2_email_identity.cic-trvapply-vrtdemande[0].email_identity
   include_original_headers = false
 }
 
@@ -128,13 +130,13 @@ resource "aws_ses_identity_notification_topic" "cic-trvapply-vrtdemande-complain
   count                    = var.env == "production" ? 1 : 0
   topic_arn                = var.notification_canada_ca_ses_callback_arn
   notification_type        = "Complaint"
-  identity                 = aws_ses_domain_identity.cic-trvapply-vrtdemande[0].domain
+  identity                 = aws_sesv2_email_identity.cic-trvapply-vrtdemande[0].email_identity
   include_original_headers = false
 }
 
-resource "aws_ses_domain_identity" "custom_sending_domains" {
-  for_each = var.ses_custom_sending_domains
-  domain   = each.value
+resource "aws_sesv2_email_identity" "custom_sending_domains" {
+  for_each       = var.ses_custom_sending_domains
+  email_identity = each.value
 }
 
 resource "aws_ses_domain_dkim" "custom_sending_domains" {
@@ -146,7 +148,7 @@ resource "aws_ses_identity_notification_topic" "custom_sending_domains_bounce_to
   for_each                 = var.ses_custom_sending_domains
   topic_arn                = var.notification_canada_ca_ses_callback_arn
   notification_type        = "Bounce"
-  identity                 = aws_ses_domain_identity.custom_sending_domains[each.value].domain
+  identity                 = aws_sesv2_email_identity.custom_sending_domains[each.value].email_identity
   include_original_headers = false
 }
 
@@ -154,7 +156,7 @@ resource "aws_ses_identity_notification_topic" "custom_sending_domains_delivery_
   for_each                 = var.ses_custom_sending_domains
   topic_arn                = var.notification_canada_ca_ses_callback_arn
   notification_type        = "Delivery"
-  identity                 = aws_ses_domain_identity.custom_sending_domains[each.value].domain
+  identity                 = aws_sesv2_email_identity.custom_sending_domains[each.value].email_identity
   include_original_headers = false
 }
 
@@ -162,14 +164,14 @@ resource "aws_ses_identity_notification_topic" "custom_sending_domains_complaint
   for_each                 = var.ses_custom_sending_domains
   topic_arn                = var.notification_canada_ca_ses_callback_arn
   notification_type        = "Complaint"
-  identity                 = aws_ses_domain_identity.custom_sending_domains[each.value].domain
+  identity                 = aws_sesv2_email_identity.custom_sending_domains[each.value].email_identity
   include_original_headers = false
 }
 
 resource "aws_ses_domain_mail_from" "custom_sending_domains" {
   for_each         = var.ses_custom_sending_domains
-  domain           = aws_ses_domain_identity.custom_sending_domains[each.value].domain
-  mail_from_domain = "bounce.${aws_ses_domain_identity.custom_sending_domains[each.value].domain}"
+  domain           = aws_sesv2_email_identity.custom_sending_domains[each.value].email_identity
+  mail_from_domain = "bounce.${aws_sesv2_email_identity.custom_sending_domains[each.value].email_identity}"
 }
 
 


### PR DESCRIPTION
# Summary | Résumé

We were running into problems validating the DKIM records on our SES email identities. As per AWS support, they have moved to AWS SES v2 for ses creation, and our Terraform code was stuck in a mismatch between v1 for creation and v2 for authentication. 

This converts our SES domain identities to SES V2. Tested working in dev.

NOTE: This will likely cause downtime (to be verified on merge to main in staging) - since we will be recreating the SES identities. Additionally this will likely fail on the first time as TF Apply will delete and recreate the identities too quickly and AWS will say there are duplicates. A re-run will fix the issue.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/443

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

- [ ] TF Apply Works
- [ ] Can still send emails

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
