### PR TITLE
Added new cwli query to track sender IDs for international SMS

### DIFF
--- a/aws/pinpoint_to_sqs_sms_callbacks/cloudwatch_queries.tf
+++ b/aws/pinpoint_to_sqs_sms_callbacks/cloudwatch_queries.tf
@@ -95,6 +95,34 @@ fields @timestamp, @message
 QUERY
 }
 
+resource "aws_cloudwatch_query_definition" "pinpoint-sms-international-sending-status-sender-id" {
+  count = var.cloudwatch_enabled ? 1 : 0
+  name  = "SMS (Pinpoint) / International sending status (with Sender IDs)"
+
+  log_group_names = [
+    aws_cloudwatch_log_group.pinpoint_deliveries.name,
+    aws_cloudwatch_log_group.pinpoint_deliveries_failures.name
+  ]
+
+  query_string = <<QUERY
+fields @timestamp, @message
+| parse @message /"isoCountryCode":"(?<Country>[^"]+)"/
+| parse @message /"eventType":"(?<EventType>[^"]+)"/
+| parse @message /"isFinal":(?<Is_Final>\w+)/
+| filter Is_Final = "true"
+| parse originationPhoneNumber /(?<longCode>\+\d{11})/
+| parse originationPhoneNumber /(?<senderId>^[^\+][a-zA-Z]+)/
+| parse originationPhoneNumber /(?<shortCode>237762)/
+| stats
+    count(longCode) as TotalLongCode,
+    count(shortCode) as TotalShortCode,
+    count(senderId) as TotalSenderId
+    by Country, EventType, senderId
+| sort Country asc, EventType asc
+
+QUERY
+}
+
 resource "aws_cloudwatch_query_definition" "pinpoint-sms-get-sms-logs-by-dest-phone-number" {
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "SMS (Pinpoint) / Get SMS logs by destination phone number"


### PR DESCRIPTION
# Summary | Résumé

* Track sender IDs that are used for SMS sent at the international, via a CloudWatch query. 

## Related Issues | Cartes liées

* None

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

You can test the query in production as it was saved via clickops in that env. 

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
