### PR TITLE
Fixing the PCA Import

### DIFF
--- a/.github/workflows/terragrunt_create_dev_environment.yml
+++ b/.github/workflows/terragrunt_create_dev_environment.yml
@@ -284,12 +284,6 @@ jobs:
           sudo mkdir -p aws
           cd aws
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
-
-      - name: Import Private Cert
-        run: |
-          cd env/${{env.ENVIRONMENT}}/eks
-          PCA_ARN=$(aws acm-pca list-certificate-authorities --query 'CertificateAuthorities[?Status == `ACTIVE`].Arn' --output text)
-          terragrunt import aws_acmpca_certificate_authority.client_vpn $PCA_ARN
           
       - name: terragrunt apply eks
         run: |

--- a/aws/eks/vpn.tf
+++ b/aws/eks/vpn.tf
@@ -93,8 +93,9 @@ resource "aws_acmpca_certificate" "client_vpn" {
 }
 
 data "external" "get_pca_arn" {
-  # return the commit hash as a map: {"commit" = "05eda5d"}
-  program = ["/Users/benlarabie/projects/notification-terraform/scripts/getPCAARN.sh"]
+  # Get the PCA ARN
+  # Yes this is horrific. I'm sorry.
+  program = ["../../../../../../../scripts/getPCAARN.sh"]
 }
 
 import {

--- a/aws/eks/vpn.tf
+++ b/aws/eks/vpn.tf
@@ -92,6 +92,16 @@ resource "aws_acmpca_certificate" "client_vpn" {
   }
 }
 
+data "external" "get_pca_arn" {
+  # return the commit hash as a map: {"commit" = "05eda5d"}
+  program = ["/Users/benlarabie/projects/notification-terraform/scripts/getPCAARN.sh"]
+}
+
+import {
+  to = aws_acmpca_certificate_authority.client_vpn
+  id = data.external.get_pca_arn.result.arn
+}
+
 resource "aws_acmpca_certificate_authority" "client_vpn" {
   type = "ROOT"
 

--- a/scripts/getPCAARN.sh
+++ b/scripts/getPCAARN.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# This is a dirty hack to get the ARN of the PCA so that we can import it when creating a new environment.
+# Terraform external datasources require a very basic JSON output, so we're using jq to format the output.
+PCA=$(aws acm-pca list-certificate-authorities --query 'CertificateAuthorities[?Status == `ACTIVE`].Arn' --output text)
+
+jq --null-input \
+  --arg arn "$PCA" \
+  '{"arn": $arn}'

--- a/scripts/getPCAARN.sh
+++ b/scripts/getPCAARN.sh
@@ -6,3 +6,4 @@ PCA=$(aws acm-pca list-certificate-authorities --query 'CertificateAuthorities[?
 jq --null-input \
   --arg arn "$PCA" \
   '{"arn": $arn}'
+  


### PR DESCRIPTION
# Summary | Résumé

The terraform(grunt) import command requires that some bits of the infrastructure have been deployed before importing. Switching to using an import block and an external datasource/script that will fetch the ARN.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/439

## Test instructions | Instructions pour tester la modification

TF Apply on create new environment works
TF Apply on staging/production still works (it will likely show an import but it will import what it's already controlling)

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [x] This PR does not break existing functionality.
* [x] This PR does not violate GCNotify's privacy policies.
* [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [x] This PR does not significantly alter performance.
* [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
