### PR TITLE
Adding retries to TF apply stuff

### DIFF
--- a/.github/workflows/terragrunt_create_dev_environment.yml
+++ b/.github/workflows/terragrunt_create_dev_environment.yml
@@ -43,7 +43,7 @@ jobs:
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
 
       - name: terragrunt apply COMMON
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@7152eba # V3.0
         with:
           timeout_seconds: 600
           max_attempts: 3
@@ -89,9 +89,14 @@ jobs:
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
 
       - name: terragrunt apply ECR
-        run: |
-          cd env/${{env.ENVIRONMENT}}/ecr
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        uses: nick-fields/retry@7152eba # V3.0
+        with:
+          timeout_seconds: 1200
+          max_attempts: 3
+          retry_on: error
+          command: |
+            cd env/${{env.ENVIRONMENT}}/ecr
+            terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-ecr-us-east:
     if: |
@@ -130,9 +135,14 @@ jobs:
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
 
       - name: terragrunt apply ECR US East
-        run: |
-          cd env/${{env.ENVIRONMENT}}/ecr-us-east
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        uses: nick-fields/retry@7152eba # V3.0
+        with:
+          timeout_seconds: 1200
+          max_attempts: 3
+          retry_on: error
+          command: |
+            cd env/${{env.ENVIRONMENT}}/ecr-us-east
+            terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-ses_receiving_emails:
     if: |
@@ -161,9 +171,14 @@ jobs:
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
   
       - name: terragrunt apply ses_receiving_emails
-        run: |
-          cd env/${{env.ENVIRONMENT}}/ses_receiving_emails
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        uses: nick-fields/retry@7152eba # V3.0
+        with:
+          timeout_seconds: 1200
+          max_attempts: 3
+          retry_on: error
+          command: |
+            cd env/${{env.ENVIRONMENT}}/ses_receiving_emails
+            terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-dns:
     if: |
@@ -192,9 +207,14 @@ jobs:
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
 
       - name: terragrunt apply dns
-        run: |
-          cd env/${{env.ENVIRONMENT}}/dns
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        uses: nick-fields/retry@7152eba # V3.0
+        with:
+          timeout_seconds: 1200
+          max_attempts: 3
+          retry_on: error
+          command: |
+            cd env/${{env.ENVIRONMENT}}/dns
+            terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-ses_validation_dns_entries:
     if: |
@@ -223,9 +243,14 @@ jobs:
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
 
       - name: terragrunt apply ses_validation_dns_entries
-        run: |
-          cd env/${{env.ENVIRONMENT}}/ses_validation_dns_entries
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        uses: nick-fields/retry@7152eba # V3.0
+        with:
+          timeout_seconds: 1200
+          max_attempts: 3
+          retry_on: error
+          command: |
+            cd env/${{env.ENVIRONMENT}}/ses_validation_dns_entries
+            terragrunt apply --terragrunt-non-interactive -auto-approve
 
 
   terragrunt-apply-cloudfront:
@@ -255,9 +280,14 @@ jobs:
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars
 
       - name: terragrunt apply cloudfront
-        run: |
-          cd env/${{env.ENVIRONMENT}}/cloudfront
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        uses: nick-fields/retry@7152eba # V3.0
+        with:
+          timeout_seconds: 1200
+          max_attempts: 3
+          retry_on: error
+          command: |
+            cd env/${{env.ENVIRONMENT}}/cloudfront
+            terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-eks:
     if: |
@@ -286,9 +316,14 @@ jobs:
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
           
       - name: terragrunt apply eks
-        run: |
-          cd env/${{env.ENVIRONMENT}}/eks
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        uses: nick-fields/retry@7152eba # V3.0
+        with:
+          timeout_seconds: 6000
+          max_attempts: 3
+          retry_on: error
+          command: |
+            cd env/${{env.ENVIRONMENT}}/eks
+            terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-elasticache:
     if: |
@@ -317,9 +352,14 @@ jobs:
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
 
       - name: terragrunt apply elasticache
-        run: |
-          cd env/${{env.ENVIRONMENT}}/elasticache
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        uses: nick-fields/retry@7152eba # V3.0
+        with:
+          timeout_seconds: 3000
+          max_attempts: 3
+          retry_on: error
+          command: |
+            cd env/${{env.ENVIRONMENT}}/elasticache
+            terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-rds:
     if: |
@@ -348,9 +388,14 @@ jobs:
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
 
       - name: terragrunt apply rds
-        run: |
-          cd env/${{env.ENVIRONMENT}}/rds
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        uses: nick-fields/retry@7152eba # V3.0
+        with:
+          timeout_seconds: 6000
+          max_attempts: 3
+          retry_on: error
+          command: |
+            cd env/${{env.ENVIRONMENT}}/rds
+            terragrunt apply --terragrunt-non-interactive -auto-approve
 
   # terragrunt-apply-lambda-api:
   #   if: |
@@ -410,9 +455,14 @@ jobs:
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
 
       - name: terragrunt apply lambda-admin-pr
-        run: |
-          cd env/${{env.ENVIRONMENT}}/lambda-admin-pr
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        uses: nick-fields/retry@7152eba # V3.0
+        with:
+          timeout_seconds: 1200
+          max_attempts: 3
+          retry_on: error
+          command: |
+            cd env/${{env.ENVIRONMENT}}/lambda-admin-pr
+            terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-performance-test:
     if: |
@@ -441,9 +491,14 @@ jobs:
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
 
       - name: terragrunt apply performance-test
-        run: |
-          cd env/${{env.ENVIRONMENT}}/performance-test
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        uses: nick-fields/retry@7152eba # V3.0
+        with:
+          timeout_seconds: 1200
+          max_attempts: 3
+          retry_on: error
+          command: |
+            cd env/${{env.ENVIRONMENT}}/performance-test
+            terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-heartbeat:
     if: |
@@ -472,9 +527,14 @@ jobs:
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
 
       - name: terragrunt apply heartbeat
-        run: |
-          cd env/${{env.ENVIRONMENT}}/heartbeat
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        uses: nick-fields/retry@7152eba # V3.0
+        with:
+          timeout_seconds: 1200
+          max_attempts: 3
+          retry_on: error
+          command: |
+            cd env/${{env.ENVIRONMENT}}/heartbeat
+            terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-database-tools:
     if: |
@@ -514,9 +574,14 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2   
 
       - name: terragrunt apply database-tools
-        run: |
-          cd env/${{env.ENVIRONMENT}}/database-tools
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        uses: nick-fields/retry@7152eba # V3.0
+        with:
+          timeout_seconds: 1200
+          max_attempts: 3
+          retry_on: error
+          command: |
+            cd env/${{env.ENVIRONMENT}}/database-tools
+            terragrunt apply --terragrunt-non-interactive -auto-approve
 
   # terragrunt-apply-quicksight:
   #   if: |
@@ -576,9 +641,14 @@ jobs:
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
   
       - name: terragrunt apply lambda-google-cidr
-        run: |
-          cd env/${{env.ENVIRONMENT}}/lambda-google-cidr
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        uses: nick-fields/retry@7152eba # V3.0
+        with:
+          timeout_seconds: 1200
+          max_attempts: 3
+          retry_on: error
+          command: |
+            cd env/${{env.ENVIRONMENT}}/lambda-google-cidr
+            terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-ses_to_sqs_email_callbacks:
     if: |
@@ -607,9 +677,14 @@ jobs:
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
 
       - name: terragrunt apply ses_to_sqs_email_callbacks
-        run: |
-          cd env/${{env.ENVIRONMENT}}/ses_to_sqs_email_callbacks
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        uses: nick-fields/retry@7152eba # V3.0
+        with:
+          timeout_seconds: 1200
+          max_attempts: 3
+          retry_on: error
+          command: |
+            cd env/${{env.ENVIRONMENT}}/ses_to_sqs_email_callbacks
+            terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-sns_to_sqs_sms_callbacks:
     if: |
@@ -638,9 +713,14 @@ jobs:
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
 
       - name: terragrunt apply sns_to_sqs_sms_callbacks
-        run: |
-          cd env/${{env.ENVIRONMENT}}/sns_to_sqs_sms_callbacks
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        uses: nick-fields/retry@7152eba # V3.0
+        with:
+          timeout_seconds: 1200
+          max_attempts: 3
+          retry_on: error
+          command: |
+            cd env/${{env.ENVIRONMENT}}/sns_to_sqs_sms_callbacks
+            terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-pinpoint_to_sqs_sms_callbacks:
     if: |
@@ -669,9 +749,14 @@ jobs:
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
 
       - name: terragrunt apply pinpoint_to_sqs_sms_callbacks
-        run: |
-          cd env/${{env.ENVIRONMENT}}/pinpoint_to_sqs_sms_callbacks
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        uses: nick-fields/retry@7152eba # V3.0
+        with:
+          timeout_seconds: 1200
+          max_attempts: 3
+          retry_on: error
+          command: |
+            cd env/${{env.ENVIRONMENT}}/pinpoint_to_sqs_sms_callbacks
+            terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-system_status:
     if: |
@@ -700,9 +785,14 @@ jobs:
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
 
       - name: terragrunt apply system_status
-        run: |
-          cd env/${{env.ENVIRONMENT}}/system_status
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        uses: nick-fields/retry@7152eba # V3.0
+        with:
+          timeout_seconds: 1200
+          max_attempts: 3
+          retry_on: error
+          command: |
+            cd env/${{env.ENVIRONMENT}}/system_status
+            terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-system_status_static_site:
     if: |
@@ -731,9 +821,14 @@ jobs:
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
 
       - name: terragrunt apply system_status_static_site
-        run: |
-          cd env/${{env.ENVIRONMENT}}/system_status_static_site
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        uses: nick-fields/retry@7152eba # V3.0
+        with:
+          timeout_seconds: 1200
+          max_attempts: 3
+          retry_on: error
+          command: |
+            cd env/${{env.ENVIRONMENT}}/system_status_static_site
+            terragrunt apply --terragrunt-non-interactive -auto-approve
 
   # terragrunt-apply-newrelic:
   #   if: |
@@ -793,9 +888,14 @@ jobs:
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
 
       - name: terragrunt apply manifest_secrets
-        run: |
-          cd env/${{env.ENVIRONMENT}}/manifest_secrets
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        uses: nick-fields/retry@7152eba # V3.0
+        with:
+          timeout_seconds: 1200
+          max_attempts: 3
+          retry_on: error
+          command: |
+            cd env/${{env.ENVIRONMENT}}/manifest_secrets
+            terragrunt apply --terragrunt-non-interactive -auto-approve
 
   deploy-application:
     if: |


### PR DESCRIPTION
# Summary | Résumé

Configuring the dev recreate workflow to use retries. 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/439

## Test instructions | Instructions pour tester la modification

Verify create dev environment works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
