### PR TITLE
Adding filter back for staging plan

### DIFF
--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -126,6 +126,9 @@ jobs:
               - 'env/${{env.ENVIRONMENT}}/manifest_secrets/**'
 
   terragrunt-plan-common:
+    if: |
+      needs.terragrunt-filter.outputs.common == 'true'
+    needs: terragrunt-filter
     runs-on: ubuntu-latest  
     env:
       COMPONENT: "common"
@@ -156,8 +159,10 @@ jobs:
   terragrunt-plan-ecr:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
+    needs: terragrunt-filter
     runs-on: ubuntu-latest 
     env:
       COMPONENT: "ecr" 
@@ -189,8 +194,10 @@ jobs:
   terragrunt-plan-ecr-us-east:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
+    needs: terragrunt-filter
     runs-on: ubuntu-latest 
     env:
       COMPONENT: "ecr-us-east" 
@@ -223,12 +230,13 @@ jobs:
   terragrunt-plan-ses_receiving_emails:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest  
     env:
       COMPONENT: "ses_receiving_emails"
-    needs: [terragrunt-plan-common,terragrunt-plan-ecr,terragrunt-plan-ecr-us-east]
+    needs: [terragrunt-filter,terragrunt-plan-common,terragrunt-plan-ecr,terragrunt-plan-ecr-us-east]
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -256,12 +264,13 @@ jobs:
   terragrunt-plan-dns:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest  
     env:
       COMPONENT: "dns"
-    needs: [terragrunt-plan-common,terragrunt-plan-ses_receiving_emails]
+    needs: [terragrunt-filter,terragrunt-plan-common,terragrunt-plan-ses_receiving_emails]
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -289,12 +298,13 @@ jobs:
   terragrunt-plan-ses_validation_dns_entries:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest  
     env:
       COMPONENT: "ses_validation_dns_entries"
-    needs: [terragrunt-plan-common,terragrunt-plan-dns]
+    needs: [terragrunt-filter,terragrunt-plan-common,terragrunt-plan-dns]
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -322,10 +332,11 @@ jobs:
   terragrunt-plan-cloudfront:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest  
-    needs: [terragrunt-plan-common]
+    needs: [terragrunt-filter,terragrunt-plan-common]
     env:
       COMPONENT: "cloudfront"
     steps:
@@ -355,10 +366,11 @@ jobs:
   terragrunt-plan-eks:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest  
-    needs: [terragrunt-plan-common,terragrunt-plan-dns,terragrunt-plan-cloudfront]
+    needs: [terragrunt-filter,terragrunt-plan-common,terragrunt-plan-dns,terragrunt-plan-cloudfront]
     env:
       COMPONENT: "eks"
     steps:
@@ -388,10 +400,11 @@ jobs:
   terragrunt-plan-elasticache:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest  
-    needs: [terragrunt-plan-common,terragrunt-plan-eks]
+    needs: [terragrunt-filter,terragrunt-plan-common,terragrunt-plan-eks]
     env:
       COMPONENT: "elasticache"
     steps:
@@ -421,10 +434,11 @@ jobs:
   terragrunt-plan-rds:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest  
-    needs: [terragrunt-plan-common,terragrunt-plan-eks]
+    needs: [terragrunt-filter,terragrunt-plan-common,terragrunt-plan-eks]
     env:
       COMPONENT: "rds"
     steps:
@@ -454,10 +468,11 @@ jobs:
   terragrunt-plan-lambda-api:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest  
-    needs: [terragrunt-plan-common,terragrunt-plan-eks,terragrunt-plan-ecr,terragrunt-plan-rds]
+    needs: [terragrunt-filter,terragrunt-plan-common,terragrunt-plan-eks,terragrunt-plan-ecr,terragrunt-plan-rds]
     env:
       COMPONENT: "lambda-api"
     steps:
@@ -487,10 +502,11 @@ jobs:
   terragrunt-plan-lambda-admin-pr:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest  
-    needs: [terragrunt-plan-common,terragrunt-plan-elasticache,terragrunt-plan-ecr]
+    needs: [terragrunt-filter,terragrunt-plan-common,terragrunt-plan-elasticache,terragrunt-plan-ecr]
     env:
       COMPONENT: "lambda-admin-pr"
     steps:
@@ -520,10 +536,11 @@ jobs:
   terragrunt-plan-performance-test:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest  
-    needs: [terragrunt-plan-common,terragrunt-plan-eks,terragrunt-plan-ecr]
+    needs: [terragrunt-filter,terragrunt-plan-common,terragrunt-plan-eks,terragrunt-plan-ecr]
     env:
       COMPONENT: "performance-test"
     steps:
@@ -554,10 +571,11 @@ jobs:
   terragrunt-plan-heartbeat:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest  
-    needs: [terragrunt-plan-common,terragrunt-plan-ecr]
+    needs: [terragrunt-filter,terragrunt-plan-common,terragrunt-plan-ecr]
     env:
       COMPONENT: "heartbeat"
     steps:
@@ -587,10 +605,11 @@ jobs:
   terragrunt-plan-database-tools:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest  
-    needs: [terragrunt-plan-common,terragrunt-plan-eks,terragrunt-plan-rds]
+    needs: [terragrunt-filter,terragrunt-plan-common,terragrunt-plan-eks,terragrunt-plan-rds]
     env:
       COMPONENT: "database-tools"
     steps:
@@ -620,10 +639,11 @@ jobs:
   terragrunt-plan-quicksight:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest  
-    needs: [terragrunt-plan-common,terragrunt-plan-eks,terragrunt-plan-rds]
+    needs: [terragrunt-filter,terragrunt-plan-common,terragrunt-plan-eks,terragrunt-plan-rds]
     env:
       COMPONENT: "quicksight"
     steps:
@@ -653,10 +673,11 @@ jobs:
   terragrunt-plan-lambda-google-cidr:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest  
-    needs: [terragrunt-plan-common,terragrunt-plan-eks,terragrunt-plan-ecr]
+    needs: [terragrunt-filter,terragrunt-plan-common,terragrunt-plan-eks,terragrunt-plan-ecr]
     env:
       COMPONENT: "lambda-google-cidr"
     steps:
@@ -686,10 +707,11 @@ jobs:
   terragrunt-plan-ses_to_sqs_email_callbacks:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest  
-    needs: [terragrunt-plan-common,terragrunt-plan-ecr]
+    needs: [terragrunt-filter,terragrunt-plan-common,terragrunt-plan-ecr]
     env:
       COMPONENT: "ses_to_sqs_email_callbacks"
     steps:
@@ -719,10 +741,11 @@ jobs:
   terragrunt-plan-sns_to_sqs_sms_callbacks:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest  
-    needs: [terragrunt-plan-common,terragrunt-plan-ecr]
+    needs: [terragrunt-filter,terragrunt-plan-common,terragrunt-plan-ecr]
     env:
       COMPONENT: "sns_to_sqs_sms_callbacks"
     steps:
@@ -752,10 +775,11 @@ jobs:
   terragrunt-plan-pinpoint_to_sqs_sms_callbacks:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest  
-    needs: [terragrunt-plan-common,terragrunt-plan-ecr]
+    needs: [terragrunt-filter,terragrunt-plan-common,terragrunt-plan-ecr]
     env:
       COMPONENT: "pinpoint_to_sqs_sms_callbacks"
     steps:
@@ -785,10 +809,11 @@ jobs:
   terragrunt-plan-system_status:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest  
-    needs: [terragrunt-plan-common,terragrunt-plan-ecr,terragrunt-plan-rds,terragrunt-plan-eks]
+    needs: [terragrunt-filter,terragrunt-plan-common,terragrunt-plan-ecr,terragrunt-plan-rds,terragrunt-plan-eks]
     env:
       COMPONENT: "system_status"
     steps:
@@ -818,9 +843,10 @@ jobs:
   terragrunt-plan-system_status_static_site:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    needs: [terragrunt-plan-common,terragrunt-plan-system_status]
+    needs: [terragrunt-filter,terragrunt-plan-common,terragrunt-plan-system_status]
     runs-on: ubuntu-latest  
     env:
       COMPONENT: "system_status_static_site"
@@ -851,9 +877,10 @@ jobs:
   terragrunt-plan-newrelic:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    needs: [terragrunt-plan-common]
+    needs: [terragrunt-filter,terragrunt-plan-common]
     runs-on: ubuntu-latest  
     env:
       COMPONENT: "newrelic"
@@ -884,9 +911,10 @@ jobs:
   terragrunt-plan-manifest_secrets:
     if: |
       always() &&
+      needs.terragrunt-filter.outputs.common == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    needs: [terragrunt-plan-rds, terragrunt-plan-elasticache, terragrunt-plan-eks, terragrunt-plan-lambda-api, terragrunt-plan-lambda-admin-pr, terragrunt-plan-performance-test, terragrunt-plan-heartbeat, terragrunt-plan-database-tools, terragrunt-plan-quicksight, terragrunt-plan-lambda-google-cidr, terragrunt-plan-ses_to_sqs_email_callbacks, terragrunt-plan-sns_to_sqs_sms_callbacks, terragrunt-plan-pinpoint_to_sqs_sms_callbacks, terragrunt-plan-system_status, terragrunt-plan-system_status_static_site, terragrunt-plan-newrelic]
+    needs: [terragrunt-filter,terragrunt-plan-rds, terragrunt-plan-elasticache, terragrunt-plan-eks, terragrunt-plan-lambda-api, terragrunt-plan-lambda-admin-pr, terragrunt-plan-performance-test, terragrunt-plan-heartbeat, terragrunt-plan-database-tools, terragrunt-plan-quicksight, terragrunt-plan-lambda-google-cidr, terragrunt-plan-ses_to_sqs_email_callbacks, terragrunt-plan-sns_to_sqs_sms_callbacks, terragrunt-plan-pinpoint_to_sqs_sms_callbacks, terragrunt-plan-system_status, terragrunt-plan-system_status_static_site, terragrunt-plan-newrelic]
     runs-on: ubuntu-latest  
     env:
       COMPONENT: "manifest_secrets"


### PR DESCRIPTION
# Summary | Résumé

The staging plan lost the filter step from some of our latest changes. Adding it back.

## Related Issues | Cartes liées

Chore

## Test instructions | Instructions pour tester la modification

TF Plan filters appropriately 

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
