### PR TITLE
PCA Script fix for Prod

### DIFF
--- a/aws/eks/vpn.tf
+++ b/aws/eks/vpn.tf
@@ -95,7 +95,8 @@ resource "aws_acmpca_certificate" "client_vpn" {
 data "external" "get_pca_arn" {
   # Get the PCA ARN
   # Yes this is horrific. I'm sorry.
-  program = ["../../../../../../../scripts/getPCAARN.sh"]
+  program = [var.env == "production" ? "../../../../../../../../scripts/getPCAARN.sh" : "../../../../../../../scripts/getPCAARN.sh"]
+
 }
 
 import {


### PR DESCRIPTION
# Summary | Résumé

When running TF plan/apply against production, the getPCA script is one level deeper than in lower state environments. Adding a conditional to add the extra layer.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/439

## Test instructions | Instructions pour tester la modification

TF Plan/Apply Staging Works
TF Plan/Apply Prod works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
