### PR TITLE
removing unused dependency

### DIFF
--- a/env/dev/ses_validation_dns_entries/terragrunt.hcl
+++ b/env/dev/ses_validation_dns_entries/terragrunt.hcl
@@ -28,7 +28,6 @@ dependency "dns" {
     lambda_ses_receiving_emails_image_arn = ""
     notification_canada_ca_receiving_dkim = []
     notification_canada_ca_dkim = []
-    cic_trvapply_vrtdemande_dkim = []
     custom_sending_domains_dkim = []
     route53_zone_id = "Z04028033PLSHVOO9ZJ1Z"
   }
@@ -41,7 +40,6 @@ include {
 
 inputs = {
   custom_sending_domains_dkim   = dependency.dns.outputs.custom_sending_domains_dkim
-  cic_trvapply_vrtdemande_dkim  = dependency.dns.outputs.cic_trvapply_vrtdemande_dkim
   notification_canada_ca_dkim   = dependency.dns.outputs.notification_canada_ca_dkim
   notification_canada_ca_receiving_dkim   = dependency.dns.outputs.notification_canada_ca_receiving_dkim
   route53_zone_id                        = dependency.dns.outputs.route53_zone_id

--- a/env/production/ses_validation_dns_entries/terragrunt.hcl
+++ b/env/production/ses_validation_dns_entries/terragrunt.hcl
@@ -28,7 +28,6 @@ dependency "dns" {
     lambda_ses_receiving_emails_image_arn = ""
     notification_canada_ca_receiving_dkim = []
     notification_canada_ca_dkim = []
-    cic_trvapply_vrtdemande_dkim = []
     custom_sending_domains_dkim = []
     route53_zone_id = "Z04028033PLSHVOO9ZJ1Z"
   }
@@ -41,7 +40,6 @@ include {
 
 inputs = {
   custom_sending_domains_dkim   = dependency.dns.outputs.custom_sending_domains_dkim
-  cic_trvapply_vrtdemande_dkim  = dependency.dns.outputs.cic_trvapply_vrtdemande_dkim
   notification_canada_ca_dkim   = dependency.dns.outputs.notification_canada_ca_dkim
   notification_canada_ca_receiving_dkim   = dependency.dns.outputs.notification_canada_ca_receiving_dkim
   route53_zone_id                        = dependency.dns.outputs.route53_zone_id

--- a/env/sandbox/ses_validation_dns_entries/terragrunt.hcl
+++ b/env/sandbox/ses_validation_dns_entries/terragrunt.hcl
@@ -28,7 +28,6 @@ dependency "dns" {
     lambda_ses_receiving_emails_image_arn = ""
     notification_canada_ca_receiving_dkim = []
     notification_canada_ca_dkim = []
-    cic_trvapply_vrtdemande_dkim = []
     custom_sending_domains_dkim = []
     route53_zone_id = "Z04028033PLSHVOO9ZJ1Z"
   }
@@ -41,7 +40,6 @@ include {
 
 inputs = {
   custom_sending_domains_dkim   = dependency.dns.outputs.custom_sending_domains_dkim
-  cic_trvapply_vrtdemande_dkim  = dependency.dns.outputs.cic_trvapply_vrtdemande_dkim
   notification_canada_ca_dkim   = dependency.dns.outputs.notification_canada_ca_dkim
   notification_canada_ca_receiving_dkim   = dependency.dns.outputs.notification_canada_ca_receiving_dkim
   route53_zone_id                        = dependency.dns.outputs.route53_zone_id

--- a/env/staging/ses_validation_dns_entries/terragrunt.hcl
+++ b/env/staging/ses_validation_dns_entries/terragrunt.hcl
@@ -28,7 +28,6 @@ dependency "dns" {
     lambda_ses_receiving_emails_image_arn = ""
     notification_canada_ca_receiving_dkim = []
     notification_canada_ca_dkim = []
-    cic_trvapply_vrtdemande_dkim = []
     custom_sending_domains_dkim = []
     route53_zone_id = "Z04028033PLSHVOO9ZJ1Z"
   }
@@ -41,7 +40,6 @@ include {
 
 inputs = {
   custom_sending_domains_dkim   = dependency.dns.outputs.custom_sending_domains_dkim
-  cic_trvapply_vrtdemande_dkim  = dependency.dns.outputs.cic_trvapply_vrtdemande_dkim
   notification_canada_ca_dkim   = dependency.dns.outputs.notification_canada_ca_dkim
   notification_canada_ca_receiving_dkim   = dependency.dns.outputs.notification_canada_ca_receiving_dkim
   route53_zone_id                        = dependency.dns.outputs.route53_zone_id


### PR DESCRIPTION
# Summary | Résumé

Removing references to trv apply DKIM records since they no longer exist

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/448

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

TF Apply works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
