### PR TITLE
chore: add cypress secrets

### DIFF
--- a/aws/manifest_secrets/secrets.tf
+++ b/aws/manifest_secrets/secrets.tf
@@ -389,3 +389,23 @@ resource "aws_secretsmanager_secret_version" "manifest_redis_url" {
   secret_id     = aws_secretsmanager_secret.manifest_redis_url.id
   secret_string = "redis://${var.redis_primary_endpoint_address}"
 }
+
+resource "aws_secretsmanager_secret" "manifest_cypress_user_pw_secret" {
+  name                    = "MANIFEST_CYPRESS_USER_PW_SECRET"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_cypress_user_pw_secret" {
+  secret_id     = aws_secretsmanager_secret.manifest_cypress_user_pw_secret.id
+  secret_string = var.manifest_cypress_user_pw_secret
+}
+
+resource "aws_secretsmanager_secret" "manifest_cypress_auth_client_secret" {
+  name                    = "MANIFEST_CYPRESS_AUTH_CLIENT_SECRET"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_cypress_auth_client_secret" {
+  secret_id     = aws_secretsmanager_secret.manifest_cypress_auth_client_secret.id
+  secret_string = var.manifest_cypress_auth_client_secret
+}

--- a/env/variables.tf
+++ b/env/variables.tf
@@ -969,3 +969,13 @@ variable "manifest_aws_pinpoint_default_pool_id" {
   type      = string
   sensitive = true
 }
+
+variable "manifest_cypress_user_pw_secret" {
+  type      = string
+  sensitive = true
+}
+
+variable "manifest_cypress_auth_client_secret" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
# Summary | Résumé

This PR adds two secrets to AWS secret manager:

- `MANIFEST_CYPRESS_USER_PW_SECRET`
- `MANIFEST_CYPRESS_AUTH_CLIENT_SECRET`

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
