### PR TITLE
IAM For K8s Secrets API

### DIFF
--- a/aws/eks/secrets-iam.tf
+++ b/aws/eks/secrets-iam.tf
@@ -187,3 +187,53 @@ resource "aws_iam_role_policy_attachment" "parameters_csi_github" {
   policy_arn = aws_iam_policy.parameters_csi.arn
   role       = aws_iam_role.secrets_csi_github.name
 }
+
+#
+# API
+#
+#
+# NOTIFY-API
+#
+
+data "aws_iam_policy_document" "secrets_csi_assume_role_policy_api" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(aws_iam_openid_connect_provider.notification-canada-ca.url, "https://", "")}:sub"
+      values   = ["system:serviceaccount:notification-canada-ca:notify-api"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(aws_iam_openid_connect_provider.notification-canada-ca.url, "https://", "")}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    principals {
+      identifiers = [aws_iam_openid_connect_provider.notification-canada-ca.arn]
+      type        = "Federated"
+    }
+  }
+}
+
+# Role
+resource "aws_iam_role" "secrets_csi_api" {
+  assume_role_policy = data.aws_iam_policy_document.secrets_csi_assume_role_policy_api.json
+  name               = "secrets-csi-role-api"
+}
+
+
+# Policy Attachment
+resource "aws_iam_role_policy_attachment" "secrets_csi_api" {
+  policy_arn = aws_iam_policy.secrets_csi.arn
+  role       = aws_iam_role.secrets_csi_api.name
+}
+
+# Policy Attachment
+resource "aws_iam_role_policy_attachment" "parameters_csi_api" {
+  policy_arn = aws_iam_policy.parameters_csi.arn
+  role       = aws_iam_role.secrets_csi_api.name
+}


### PR DESCRIPTION
# Summary | Résumé

This will add the required permissions for the K8s api to read from secrets manager

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/444

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

TF Apply Works
Verify that api can read secrets

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
