### PR TITLE
Move quicksight release outside of main tf apply

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -445,37 +445,6 @@ jobs:
           cd env/${{env.ENVIRONMENT}}/database-tools
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
-  terragrunt-apply-quicksight:
-    if: |
-      always() &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled')
-    runs-on: ubuntu-latest  
-    needs: [terragrunt-apply-common,terragrunt-apply-eks,terragrunt-apply-rds]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-        
-      - name: setup-terraform
-        uses: ./.github/actions/setup-terraform
-        with:
-          role_to_assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-terraform-apply
-          role_session_name: NotifyTerraformApply                  
-
-      - name: Install 1Pass CLI
-        run: |
-          curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
-          sudo dpkg -i 1pass.deb
-          sudo mkdir -p aws
-          cd aws
-          op read op://ppnxsriom3alsxj4ogikyjxlzi/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
-
-      - name: terragrunt apply quicksight
-        run: |
-          cd env/${{env.ENVIRONMENT}}/quicksight
-          terragrunt apply --terragrunt-non-interactive -auto-approve
-
   terragrunt-apply-lambda-google-cidr:
     if: |
       always() &&
@@ -698,7 +667,7 @@ jobs:
       always() &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    needs: [terragrunt-apply-rds, terragrunt-apply-elasticache, terragrunt-apply-eks, terragrunt-apply-ecr, terragrunt-apply-lambda-api, terragrunt-apply-heartbeat, terragrunt-apply-database-tools, terragrunt-apply-quicksight, terragrunt-apply-lambda-google-cidr, terragrunt-apply-ses_to_sqs_email_callbacks, terragrunt-apply-sns_to_sqs_sms_callbacks, terragrunt-apply-pinpoint_to_sqs_sms_callbacks, terragrunt-apply-system_status, terragrunt-apply-system_status_static_site, terragrunt-apply-newrelic]
+    needs: [terragrunt-apply-rds, terragrunt-apply-elasticache, terragrunt-apply-eks, terragrunt-apply-ecr, terragrunt-apply-lambda-api, terragrunt-apply-heartbeat, terragrunt-apply-database-tools, terragrunt-apply-lambda-google-cidr, terragrunt-apply-ses_to_sqs_email_callbacks, terragrunt-apply-sns_to_sqs_sms_callbacks, terragrunt-apply-pinpoint_to_sqs_sms_callbacks, terragrunt-apply-system_status, terragrunt-apply-system_status_static_site, terragrunt-apply-newrelic]
     runs-on: ubuntu-latest  
 
     steps:

--- a/.github/workflows/terragrunt_quicksight_production.yml
+++ b/.github/workflows/terragrunt_quicksight_production.yml
@@ -4,8 +4,8 @@ on:
   # This will be used to dispatch this workflow from the manifest repo when environment variables change
   workflow_dispatch:
   schedule:
-    # 05:00 UTC = 00:00 EST
-    - cron: "0 5 * * 1-4"
+    # 03:00 UTC = 22:00 EST
+    - cron: "0 3 * * 1-4"
 
 defaults:
   run:

--- a/.github/workflows/terragrunt_quicksight_production.yml
+++ b/.github/workflows/terragrunt_quicksight_production.yml
@@ -1,0 +1,56 @@
+name: "Release Quicksight To Production"
+
+on:
+  # This will be used to dispatch this workflow from the manifest repo when environment variables change
+  workflow_dispatch:
+  schedule:
+    # 05:00 UTC = 00:00 EST
+    - cron: "0 5 * * 1-4"
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  ACCOUNT_ID: ${{ secrets.PRODUCTION_ACCOUNT_ID }}
+  AWS_REGION: ca-central-1
+  ENVIRONMENT: production
+  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.PRODUCTION_OP_SERVICE_ACCOUNT_TOKEN }}
+  WORKFLOW: true
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+
+  terragrunt-apply-quicksight:
+    if: |
+      always() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
+    runs-on: ubuntu-latest  
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-terraform-apply
+          role_session_name: NotifyTerraformApply                  
+
+      - name: Install 1Pass CLI
+        run: |
+          curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
+          sudo dpkg -i 1pass.deb
+          sudo mkdir -p aws
+          cd aws
+          op read op://ppnxsriom3alsxj4ogikyjxlzi/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
+
+      - name: terragrunt apply quicksight
+        run: |
+          cd env/${{env.ENVIRONMENT}}/quicksight
+          terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/terragrunt_quicksight_production.yml
+++ b/.github/workflows/terragrunt_quicksight_production.yml
@@ -4,8 +4,8 @@ on:
   # This will be used to dispatch this workflow from the manifest repo when environment variables change
   workflow_dispatch:
   schedule:
-    # 03:00 UTC = 22:00 EST
-    - cron: "0 3 * * 1-4"
+    # 02:00 UTC = 21:00 EST
+    - cron: "0 2 * * 1-4"
 
 defaults:
   run:


### PR DESCRIPTION
# Summary | Résumé

Moving quicksight to a nightly releases schedule so that we don't block our TF apply during the day.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/454

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

Verify that quicksight no longer runs on merge to main production
Verify that quicksight runs every night Mon-Thurs at midnight EST

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
