### PR TITLE
fix/Move Failed Service Callbacks widget to proper dashboard

### DIFF
--- a/aws/eks/dashboards.tf
+++ b/aws/eks/dashboards.tf
@@ -542,6 +542,20 @@ resource "aws_cloudwatch_dashboard" "notify_system" {
                 "title": "API lambda errors",
                 "view": "timeSeries"
             }
+        },
+        {
+            "height": 4,
+            "width": 8,
+            "y": 17,
+            "x": 0,
+            "type": "log",
+            "properties": {
+                "query": "SOURCE '/aws/containerinsights/${aws_eks_cluster.notification-canada-ca-eks-cluster.name}/application' | filter kubernetes.container_name like /^celery/\n| filter @message like /send_delivery_status_to_service request failed for notification_id/\n| parse log \"to url: https://* service: * exc: * \" as endpoint, service_id, error\n| stats count() as fails by service_id, endpoint, error\n| display fails, service_id, error, endpoint\n| order by fails desc\n",
+                "region": "${var.region}",
+                "stacked": false,
+                "title": "Failed Service Callbacks",
+                "view": "table"
+            }
         }
     ]
 }
@@ -1740,20 +1754,6 @@ resource "aws_cloudwatch_dashboard" "slos" {
                 "start": "-PT72H",
                 "end": "P0D",
                 "title": "Time to process email delivery receipts, per 15 minutes"
-            }
-        },
-        {
-            "height": 4,
-            "width": 8,
-            "y": 17,
-            "x": 0,
-            "type": "log",
-            "properties": {
-                "query": "SOURCE '/aws/containerinsights/${aws_eks_cluster.notification-canada-ca-eks-cluster.name}/application' | filter kubernetes.container_name like /^celery/\n| filter @message like /send_delivery_status_to_service request failed for notification_id/\n| parse log \"to url: https://* service: * exc: * \" as endpoint, service_id, error\n| stats count() as fails by service_id, endpoint, error\n| display fails, service_id, error, endpoint\n| order by fails desc\n",
-                "region": "${var.region}",
-                "stacked": false,
-                "title": "Failed Service Callbacks",
-                "view": "table"
             }
         }
     ]


### PR DESCRIPTION
# Summary | Résumé

Put the widget in the wrong dashboard :/


## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
