### PR TITLE
Fixing the lambda api database endpoint

### DIFF
--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -472,7 +472,7 @@ jobs:
   terragrunt-plan-lambda-api:
     if: |
       always() &&
-      needs.terragrunt-filter.outputs.api == 'true' &&
+      needs.terragrunt-filter.outputs.lambda-api == 'true' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest  

--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -29,8 +29,8 @@ resource "aws_lambda_function" "api" {
       ADMIN_BASE_URL                 = "https://${var.base_domain}"
       API_HOST_NAME                  = "https://api.${var.base_domain}"
       DOCUMENT_DOWNLOAD_API_HOST     = "https://api.document.${var.base_domain}"
-      SQLALCHEMY_DATABASE_URI        = "postgresql://app_db_user:${var.app_db_user_password}@${var.database_read_write_proxy_endpoint}/NotificationCanadaCa${var.env}"
-      SQLALCHEMY_DATABASE_READER_URI = "postgresql://app_db_user:${var.app_db_user_password}@${var.database_read_only_proxy_endpoint}/NotificationCanadaCa${var.env}"
+      SQLALCHEMY_DATABASE_URI        = "postgresql://app_db_user:${var.app_db_user_password}@${var.database_read_write_proxy_endpoint}/${var.app_db_database_name}"
+      SQLALCHEMY_DATABASE_READER_URI = "postgresql://app_db_user:${var.app_db_user_password}@${var.database_read_only_proxy_endpoint}/${var.app_db_database_name}"
       NOTIFICATION_QUEUE_PREFIX      = var.notification_queue_prefix
       NOTIFY_EMAIL_DOMAIN            = var.domain
       NOTIFY_ENVIRONMENT             = var.env


### PR DESCRIPTION
# Summary | Résumé

The lambda api database endpoint was using the environment name as part of the database which works everywhere but dev/sandbox because they're using clones of staging. We have already set an app_db_name configuration entry elsewhere, so aligning this to use the same thing.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/315

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

TF Apply should show no changes on staging and prod

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [x] This PR does not break existing functionality.
* [x] This PR does not violate GCNotify's privacy policies.
* [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [x] This PR does not significantly alter performance.
* [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
