### PR TITLE
enable create lambda in dev

### DIFF
--- a/.github/workflows/terragrunt_create_dev_environment.yml
+++ b/.github/workflows/terragrunt_create_dev_environment.yml
@@ -401,35 +401,35 @@ jobs:
             terragrunt apply --terragrunt-non-interactive -auto-approve
 
   # terragrunt-apply-lambda-api:
-  #   if: |
-  #     always() &&
-  #     !contains(needs.*.result, 'failure') &&
-  #     !contains(needs.*.result, 'cancelled')
-  #   runs-on: ubuntu-latest  
-  #   needs: [terragrunt-apply-common,terragrunt-apply-eks,terragrunt-apply-ecr,terragrunt-apply-rds]
+    if: |
+      always() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
+    runs-on: ubuntu-latest  
+    needs: [terragrunt-apply-common,terragrunt-apply-eks,terragrunt-apply-ecr,terragrunt-apply-rds]
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-        
-  #     - name: setup-terraform
-  #       uses: ./.github/actions/setup-terraform
-  #       with:
-  #         role_to_assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-terraform-apply
-  #         role_session_name: NotifyTerraformApply        
+    steps:
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+       
+      - name: setup-terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          role_to_assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-terraform-apply
+          role_session_name: NotifyTerraformApply        
 
-      #   - name: Install 1Pass CLI
-      #   run: |
-      #     curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
-      #     sudo dpkg -i 1pass.deb
-      #     sudo mkdir -p aws
-      #     cd aws
-      #     op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
+      - name: Install 1Pass CLI
+        run: |
+          curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
+          sudo dpkg -i 1pass.deb
+          sudo mkdir -p aws
+          cd aws
+          op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars   
 
-      # - name: terragrunt apply lambda-api
-      #   run: |
-      #     cd env/${{env.ENVIRONMENT}}/lambda-api
-      #     terragrunt apply --terragrunt-non-interactive -auto-approve
+      - name: terragrunt apply lambda-api
+        run: |
+          cd env/${{env.ENVIRONMENT}}/lambda-api
+          terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-lambda-admin-pr:
     if: |

--- a/.github/workflows/terragrunt_create_dev_environment.yml
+++ b/.github/workflows/terragrunt_create_dev_environment.yml
@@ -400,7 +400,7 @@ jobs:
             cd env/${{env.ENVIRONMENT}}/rds
             terragrunt apply --terragrunt-non-interactive -auto-approve
 
-  # terragrunt-apply-lambda-api:
+  terragrunt-apply-lambda-api:
     if: |
       always() &&
       !contains(needs.*.result, 'failure') &&


### PR DESCRIPTION
# Summary | Résumé

Now that the lambda is working we can add it back to the dev env create.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/315

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

Verify create dev script works on Monday.

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
