### PR TITLE
manifests smoke secrets

### DIFF
--- a/aws/github/manifest-secrets.tf
+++ b/aws/github/manifest-secrets.tf
@@ -60,9 +60,9 @@ resource "github_actions_secret" "smoke_admin_client_secret" {
   plaintext_value = var.manifest_smoke_admin_client_secret
 }
 
-resource "github_actions_secret" "smoke_admin_api_key" {
+resource "github_actions_secret" "smoke_api_key" {
   count           = var.env == "staging" ? 1 : 0
   repository      = data.github_repository.notification_manifests.name
   secret_name     = "SMOKE_API_KEY"
-  plaintext_value = var.manifest_smoke_admin_api_key
+  plaintext_value = var.manifest_smoke_api_key
 }

--- a/aws/github/manifest-secrets.tf
+++ b/aws/github/manifest-secrets.tf
@@ -52,3 +52,17 @@ resource "github_actions_secret" "manifests_new_relic_api_key" {
   secret_name     = "${upper(var.env)}_NEW_RELIC_API_KEY"
   plaintext_value = var.new_relic_api_key
 }
+
+resource "github_actions_secret" "smoke_admin_client_secret" {
+  count           = var.env == "staging" ? 1 : 0
+  repository      = data.github_repository.notification_manifests.name
+  secret_name     = "SMOKE_ADMIN_CLIENT_SECRET"
+  plaintext_value = var.manifest_smoke_admin_client_secret
+}
+
+resource "github_actions_secret" "smoke_admin_api_key" {
+  count           = var.env == "staging" ? 1 : 0
+  repository      = data.github_repository.notification_manifests.name
+  secret_name     = "SMOKE_API_KEY"
+  plaintext_value = var.manifest_smoke_admin_api_key
+}

--- a/env/variables.tf
+++ b/env/variables.tf
@@ -976,7 +976,7 @@ variable "manifest_cypress_auth_client_secret" {
   sensitive = true
 }
 
-variable "manifest_smoke_admin_api_key" {
+variable "manifest_smoke_api_key" {
   type      = string
   sensitive = true
   default   = "stagingonly"

--- a/env/variables.tf
+++ b/env/variables.tf
@@ -976,7 +976,7 @@ variable "manifest_cypress_auth_client_secret" {
   sensitive = true
 }
 
-variable "manifest_smoke_admin_api_key"  {
+variable "manifest_smoke_admin_api_key" {
   type      = string
   sensitive = true
   default   = "stagingonly"

--- a/env/variables.tf
+++ b/env/variables.tf
@@ -976,6 +976,18 @@ variable "manifest_cypress_auth_client_secret" {
   sensitive = true
 }
 
+variable "manifest_smoke_admin_api_key"  {
+  type      = string
+  sensitive = true
+  default   = "stagingonly"
+}
+
+variable "manifest_smoke_admin_client_secret" {
+  type      = string
+  sensitive = true
+  default   = "stagingonly"
+}
+
 variable "github_app_id" {
   type      = string
   sensitive = true


### PR DESCRIPTION
# Summary | Résumé

Adding smoke test secrets to manifests github repository secrets

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/299

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

TF Apply works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [x] This PR does not break existing functionality.
* [x] This PR does not violate GCNotify's privacy policies.
* [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [x] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
