### PR TITLE
Fixing the workflow for github secrets in prod

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -721,5 +721,5 @@ jobs:
 
       - name: terragrunt apply github
         run: |
-          cd env/${{env.ENVIRONMENT}}/manifest_secrets
+          cd env/${{env.ENVIRONMENT}}/github
           terragrunt apply --terragrunt-non-interactive -auto-approve      


### PR DESCRIPTION
# Summary | Résumé

Had the wrong folder in the apply for github secrets.

## Related Issues | Cartes liées

Hotfix

## Test instructions | Instructions pour tester la modification

Re-release prod, github secrets should apply in prod.

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [x] This PR does not break existing functionality.
* [x] This PR does not violate GCNotify's privacy policies.
* [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [x] This PR does not significantly alter performance.
* [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
