### PR TITLE
Adding the pr bot github app token to github secrets

### DIFF
--- a/aws/github/manifest-secrets.tf
+++ b/aws/github/manifest-secrets.tf
@@ -71,5 +71,5 @@ resource "github_actions_secret" "pr_bot_github_token" {
   count           = var.env == "staging" ? 1 : 0
   repository      = data.github_repository.notification_manifests.name
   secret_name     = "PR_BOT_GITHUB_TOKEN"
-  plaintext_value = var.manifests_pr_bot_github_token
+  plaintext_value = var.manifest_pr_bot_github_token
 }

--- a/aws/github/manifest-secrets.tf
+++ b/aws/github/manifest-secrets.tf
@@ -66,3 +66,10 @@ resource "github_actions_secret" "smoke_api_key" {
   secret_name     = "SMOKE_API_KEY"
   plaintext_value = var.manifest_smoke_api_key
 }
+
+resource "github_actions_secret" "pr_bot_github_token" {
+  count           = var.env == "staging" ? 1 : 0
+  repository      = data.github_repository.notification_manifests.name
+  secret_name     = "PR_BOT_GITHUB_TOKEN"
+  plaintext_value = var.manifests_pr_bot_github_token
+}

--- a/env/variables.tf
+++ b/env/variables.tf
@@ -988,6 +988,12 @@ variable "manifest_smoke_admin_client_secret" {
   default   = "stagingonly"
 }
 
+variable "manifest_pr_bot_github_token" {
+  type      = string
+  sensitive = true
+  default   = "stagingonly"
+}
+
 variable "github_app_id" {
   type      = string
   sensitive = true


### PR DESCRIPTION
# Summary | Résumé

This is a new github app token for manifests pr bot. We have lost the original value to the ether so I've generated a new one, and this secret is named different now... that way if it doesn't work we can revert back to the old secret for the time being. A second PR to the manifests repo will be created to switch over to this new secret for testing.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/299

## Test instructions | Instructions pour tester la modification

TF Apply works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
