### PR TITLE
Index key on lambda admin output

### DIFF
--- a/aws/lambda-admin-pr/outputs.tf
+++ b/aws/lambda-admin-pr/outputs.tf
@@ -1,3 +1,3 @@
 output "admin_pr_security_group_id" {
-  value = aws_security_group.lambda_admin_pr_review.id
+  value = aws_security_group.lambda_admin_pr_review[0].id
 }


### PR DESCRIPTION
# Summary | Résumé

Mixed the index key on lambda admin security group output

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/299

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
