### PR TITLE
renaming account ids to aws account ids

### DIFF
--- a/.github/workflows/check_rds_cluster_update.yml
+++ b/.github/workflows/check_rds_cluster_update.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Configure AWS credentials using OIDC
       uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
       with:
-        role-to-assume: arn:aws:iam::${{ secrets.STAGING_ACCOUNT_ID }}:role/notification-terraform-apply
+        role-to-assume: arn:aws:iam::${{ secrets.STAGING_AWS_ACCOUNT_ID }}:role/notification-terraform-apply
         role-session-name: RDSClusterUpdateCheck
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
 

--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -14,7 +14,7 @@ defaults:
     shell: bash
 
 env:
-  ACCOUNT_ID: ${{ secrets.PRODUCTION_ACCOUNT_ID }}
+  ACCOUNT_ID: ${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}
   AWS_REGION: ca-central-1
   ENVIRONMENT: production
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PRODUCTION }}

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -18,7 +18,7 @@ defaults:
     shell: bash
 
 env:
-  ACCOUNT_ID: ${{ secrets.STAGING_ACCOUNT_ID }}
+  ACCOUNT_ID: ${{ secrets.STAGING_AWS_ACCOUNT_ID }}
   AWS_REGION: ca-central-1
   ENVIRONMENT: staging
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING }}
@@ -40,7 +40,7 @@ jobs:
 
       - uses: ./.github/actions/setup-terraform
         with:
-          role_to_assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-terraform-apply
+          role_to_assume: arn:aws:iam::${{env.STAGING_AWS_ACCOUNT_ID}}:role/notification-terraform-apply
           role_session_name: NotifyTerraformDevApply
 
       - name: Install 1Pass CLI

--- a/.github/workflows/terragrunt_plan_production.yml
+++ b/.github/workflows/terragrunt_plan_production.yml
@@ -13,7 +13,7 @@ permissions:
 
 env:
   ENVIRONMENT: production
-  ACCOUNT_ID: ${{ secrets.PRODUCTION_ACCOUNT_ID }}
+  ACCOUNT_ID: ${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}
   AWS_REGION: ca-central-1
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PRODUCTION }}
   WORKFLOW: true

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -2,7 +2,7 @@ name: "Terragrunt plan STAGING"
 
 env:
   ENVIRONMENT: staging
-  ACCOUNT_ID: ${{ secrets.STAGING_ACCOUNT_ID }}
+  ACCOUNT_ID: ${{ secrets.STAGING_AWS_ACCOUNT_ID }}
   AWS_REGION: ca-central-1
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING }}
   WORKFLOW: true

--- a/.github/workflows/terragrunt_quicksight_production.yml
+++ b/.github/workflows/terragrunt_quicksight_production.yml
@@ -12,7 +12,7 @@ defaults:
     shell: bash
 
 env:
-  ACCOUNT_ID: ${{ secrets.PRODUCTION_ACCOUNT_ID }}
+  ACCOUNT_ID: ${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}
   AWS_REGION: ca-central-1
   ENVIRONMENT: production
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PRODUCTION }}

--- a/aws/github/api-secrets.tf
+++ b/aws/github/api-secrets.tf
@@ -1,6 +1,6 @@
 resource "github_actions_secret" "api_account_id" {
   repository      = data.github_repository.notification_api.name
-  secret_name     = "${upper(var.env)}_ACCOUNT_ID"
+  secret_name     = "${upper(var.env)}_AWS_ACCOUNT_ID"
   plaintext_value = var.account_id
 }
 

--- a/aws/github/manifest-secrets.tf
+++ b/aws/github/manifest-secrets.tf
@@ -1,6 +1,6 @@
 resource "github_actions_secret" "manifests_account_id" {
   repository      = data.github_repository.notification_manifests.name
-  secret_name     = "${upper(var.env)}_ACCOUNT_ID"
+  secret_name     = "${upper(var.env)}_AWS_ACCOUNT_ID"
   plaintext_value = var.account_id
 }
 

--- a/aws/github/terraform-secrets.tf
+++ b/aws/github/terraform-secrets.tf
@@ -1,6 +1,6 @@
 resource "github_actions_secret" "account_id" {
   repository      = data.github_repository.notification_terraform.name
-  secret_name     = "${upper(var.env)}_ACCOUNT_ID"
+  secret_name     = "${upper(var.env)}_AWS_ACCOUNT_ID"
   plaintext_value = var.account_id
 }
 


### PR DESCRIPTION
# Summary | Résumé

Rename ENVIRONMENT_ACCOUNT_IDs to ENVIRONMENT_AWS_ACCOUNT_ID

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/299

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

TF Apply works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
