### PR TITLE
Cleaning up Rulesets and SES Identities

### DIFF
--- a/aws/lambda-admin-pr/outputs.tf
+++ b/aws/lambda-admin-pr/outputs.tf
@@ -1,3 +1,3 @@
 output "admin_pr_security_group_id" {
-  value = aws_security_group.lambda_admin_pr_review[0].id
+  value = var.env == "staging" ? aws_security_group.lambda_admin_pr_review[0].id : ""
 }

--- a/scripts/deleteEnvironment.sh
+++ b/scripts/deleteEnvironment.sh
@@ -117,6 +117,9 @@ aws events delete-rule --name weeklyBudgetSpend
 aws events remove-targets --rule google_cidr_testing --ids $(aws events list-targets-by-rule --rule google_cidr_testing --query 'Targets[].Id' --output text)
 aws events delete-rule --name google_cidr_testing
 
+AWS_REGION=us-east-1  aws ses set-active-receipt-rule-set
+
+AWS_REGION=us-east-1 aws ses delete-receipt-rule-set --rule-set-name main
 
 echo "Done."
 echo "Account $ACCOUNT_ID has been cleaned up."

--- a/scripts/deleteEnvironment.sh
+++ b/scripts/deleteEnvironment.sh
@@ -118,8 +118,26 @@ aws events remove-targets --rule google_cidr_testing --ids $(aws events list-tar
 aws events delete-rule --name google_cidr_testing
 
 AWS_REGION=us-east-1  aws ses set-active-receipt-rule-set
-
 AWS_REGION=us-east-1 aws ses delete-receipt-rule-set --rule-set-name main
+
+IDENTITIES=$(aws sesv2 list-email-identities --query 'EmailIdentities[].IdentityName' --output text)
+
+for identity in $IDENTITIES; do
+  echo "Deleting ses email identity $identity"
+  aws sesv2 delete-email-identity --email-identity $identity
+  echo "Done."
+done
+
+# We have to switch to US-EAST-1 to delete the email identities
+export AWS_REGION=us-east-1
+US_IDENTITIES=$(aws sesv2 list-email-identities --query 'EmailIdentities[].IdentityName' --output text)
+
+for identity in $US_IDENTITIES; do
+  echo "Deleting ses email identity $identity"
+  aws sesv2 delete-email-identity --email-identity $identity
+  echo "Done."
+done
+
 
 echo "Done."
 echo "Account $ACCOUNT_ID has been cleaned up."

--- a/scripts/deleteEnvironment.sh
+++ b/scripts/deleteEnvironment.sh
@@ -138,6 +138,5 @@ for identity in $US_IDENTITIES; do
   echo "Done."
 done
 
-
 echo "Done."
 echo "Account $ACCOUNT_ID has been cleaned up."


### PR DESCRIPTION
# Summary | Résumé

Rulesets and SES Identities don't seem to be getting deleted properly with AWS anymore. This will manually delete them.

Also adding conditional on lambda admin pr security group output

## Related Issues | Cartes liées

Chore

## Test instructions | Instructions pour tester la modification

Run delete/recreate workflows - I've continued the recreate workflow from yesterday after manually running the script for now.

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
