### PR TITLE
Fixing newrelic deploy to new environment

### DIFF
--- a/aws/common/import.tf
+++ b/aws/common/import.tf
@@ -1,0 +1,99 @@
+import {
+  to = aws_cloudwatch_metric_stream.newrelic_metric_stream[0]
+  id = "newrelic-metric-stream-${var.env}"
+}
+
+import {
+  to = aws_config_configuration_recorder_status.newrelic_recorder_status[0]
+  id = var.aws_config_recorder_name
+}
+
+import {
+  to = aws_iam_policy.newrelic_aws_permissions[0]
+  id = "arn:aws:iam::${var.account_id}:policy/NewRelicCloudStreamReadPermissions-${var.env}"
+}
+
+import {
+  to = aws_iam_role.firehose_newrelic_role[0]
+  id = "firehose_newrelic_role_${var.env}"
+}
+
+import {
+  to = aws_iam_role.metric_stream_to_firehose[0]
+  id = "newrelic_metric_stream_to_firehose_role_${var.env}"
+}
+
+import {
+  to = aws_iam_role.newrelic_aws_role[0]
+  id = "NewRelicInfrastructure-Integrations-${var.env}"
+}
+
+import {
+  to = aws_iam_role.newrelic_configuration_recorder[0]
+  id = "newrelic_configuration_recorder-${var.env}"
+}
+
+import {
+  to = aws_iam_role_policy.metric_stream_to_firehose[0]
+  id = "newrelic_metric_stream_to_firehose_role_${var.env}:default"
+}
+
+import {
+  to = aws_iam_role_policy.newrelic_configuration_recorder_s3[0]
+  id = "newrelic_configuration_recorder-${var.env}:newrelic-configuration-recorder-s3-${var.env}"
+}
+
+import {
+  to = aws_iam_role_policy_attachment.newrelic_aws_policy_attach[0]
+  id = "NewRelicInfrastructure-Integrations-${var.env}/arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+import {
+  to = aws_iam_role_policy_attachment.newrelic_configuration_recorder[0]
+  id = "newrelic_configuration_recorder-${var.env}/arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
+}
+
+import {
+  to = aws_kinesis_firehose_delivery_stream.newrelic_firehose_stream[0]
+  id = "arn:aws:firehose:ca-central-1:${var.account_id}:deliverystream/newrelic_firehose_stream_${var.env}"
+}
+
+import {
+  to = aws_s3_bucket.newrelic_aws_bucket[0]
+  id = "newrelic-aws-bucket-${random_string.s3-bucket-name[0].id}"
+}
+
+import {
+  to = aws_s3_bucket.newrelic_configuration_recorder_s3[0]
+  id = "newrelic-configuration-recorder-${random_string.s3-bucket-name[0].id}"
+}
+
+import {
+  to = aws_s3_bucket_ownership_controls.newrelic_ownership_controls[0]
+  id = "newrelic-aws-bucket-${random_string.s3-bucket-name[0].id}"
+}
+
+import {
+  to = newrelic_api_access_key.newrelic_aws_access_key[0]
+  id = "5EA911F90B135B0D61DB4012CB0DC376CCC5017C98EB1688932254CDDAFD3443:USER"
+}
+
+import {
+  to = newrelic_cloud_aws_integrations.newrelic_cloud_integration_pull[0]
+  id = var.env == "dev" ? "242485" : "225924"
+}
+
+import {
+  to = newrelic_cloud_aws_link_account.newrelic_cloud_integration_pull[0]
+  id = var.env == "dev" ? "242485" : "225924"
+}
+
+import {
+  to = newrelic_cloud_aws_link_account.newrelic_cloud_integration_push[0]
+  id = var.env == "dev" ? "242484" : "225918"
+}
+
+import {
+  to = random_string.s3-bucket-name[0]
+  id = var.env == "dev" ? "fiskyzxf" : "9p5x8bkb"
+}

--- a/aws/common/variables.tf
+++ b/aws/common/variables.tf
@@ -1,0 +1,9 @@
+variable "newrelic_account_region" {
+  type    = string
+  default = "US"
+
+  validation {
+    condition     = contains(["US", "EU"], var.newrelic_account_region)
+    error_message = "Valid values for region are 'US' or 'EU'."
+  }
+}

--- a/aws/newrelic/removed.tf
+++ b/aws/newrelic/removed.tf
@@ -1,0 +1,151 @@
+removed {
+  from = aws_cloudwatch_metric_stream.newrelic_metric_stream
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = aws_config_configuration_recorder_status.newrelic_recorder_status
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = aws_iam_policy.newrelic_aws_permissions
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = aws_iam_role.firehose_newrelic_role
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = aws_iam_role.metric_stream_to_firehose
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = aws_iam_role.newrelic_aws_role
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = aws_iam_role.newrelic_configuration_recorder
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = aws_iam_role_policy.metric_stream_to_firehose
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = aws_iam_role_policy.newrelic_configuration_recorder_s3
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = aws_iam_role_policy_attachment.newrelic_aws_policy_attach
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = aws_iam_role_policy_attachment.newrelic_configuration_recorder
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = aws_kinesis_firehose_delivery_stream.newrelic_firehose_stream
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = aws_s3_bucket.newrelic_aws_bucket
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = aws_s3_bucket.newrelic_configuration_recorder_s3
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = aws_s3_bucket_ownership_controls.newrelic_ownership_controls
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = newrelic_api_access_key.newrelic_aws_access_key
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = newrelic_cloud_aws_integrations.newrelic_cloud_integration_pull
+
+  lifecycle {
+    destroy = false
+  }
+}
+removed {
+
+  from = newrelic_cloud_aws_link_account.newrelic_cloud_integration_pull
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = newrelic_cloud_aws_link_account.newrelic_cloud_integration_push
+
+  lifecycle {
+    destroy = false
+  }
+}

--- a/env/dev/newrelic/.terraform.lock.hcl
+++ b/env/dev/newrelic/.terraform.lock.hcl
@@ -1,28 +1,9 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/archive" {
-  version = "2.7.0"
-  hashes = [
-    "h1:uZO0XsK1RW1mBRn8SsVPXT76pSSbyb4SmA0eLJsOe38=",
-    "zh:04e23bebca7f665a19a032343aeecd230028a3822e546e6f618f24c47ff87f67",
-    "zh:5bb38114238e25c45bf85f5c9f627a2d0c4b98fe44a0837e37d48574385f8dad",
-    "zh:64584bc1db4c390abd81c76de438d93acf967c8a33e9b923d68da6ed749d55bd",
-    "zh:697695ab9cce351adf91a1823bdd72ce6f0d219138f5124ef7645cedf8f59a1f",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:7edefb1d1e2fead8fd155f7b50a2cb49f2f3fed154ac3ef5f991ccaff93d6120",
-    "zh:807fb15b75910bf14795f2ad1a2d41b069f9ef52c242131b2964c8527312e235",
-    "zh:821d9148d261df1d1a8e5a4812df2a6a3ffaf0d2070dad3c785382e489069239",
-    "zh:a7d92251118fb723048c482154a6ac6368aad583d28d15fffc6f5dafd9507463",
-    "zh:b627d4cef192b3c12ddaf9cb2c4f98c10d0129883c8c2a9c0049983f9de7030d",
-    "zh:dfb70306fcc0ad1d512ab7c24765703783cc286062d4849de4fbe23526f5dc8e",
-    "zh:f21de276f857b7e51fa2593d8fef05a7faafb0a7b62db14ac58a03ce1be7d881",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.80.0"
-  constraints = ">= 4.8.0, >= 4.9.0, ~> 5.66"
+  constraints = "~> 5.66"
   hashes = [
     "h1:1O1XLPOrMg30ATXLC9itDvvyQUoIPIre7NiNscCOz28=",
     "zh:0b1655e39639d60f2de2860a5df8642f9556ba0ca04529c1b861fde4935cb0df",
@@ -40,66 +21,6 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:c7681134a123486e72eaedc3f8d2d75e267dbbfd45fa7de5aea8f757af57f89b",
     "zh:ea717ebad3561fd02591f9eecf30f3df5635405556fba2bdbf29fd42691bebac",
     "zh:f4e1e8f23c58c3e8f4371f9c3379a723ab4155246e6b6daad8eb99e16666b2cb",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/external" {
-  version     = "2.3.4"
-  constraints = ">= 1.0.0"
-  hashes = [
-    "h1:U6W8rgrdmR2pZ2cicFoGOSQ4GXuIf/4EK7s0vTJN7is=",
-    "zh:037fd82cd86227359bc010672cd174235e2d337601d4686f526d0f53c87447cb",
-    "zh:0ea1db63d6173d01f2fa8eb8989f0809a55135a0d8d424b08ba5dabad73095fa",
-    "zh:17a4d0a306566f2e45778fbac48744b6fd9c958aaa359e79f144c6358cb93af0",
-    "zh:298e5408ab17fd2e90d2cd6d406c6d02344fe610de5b7dae943a58b958e76691",
-    "zh:38ecfd29ee0785fd93164812dcbe0664ebbe5417473f3b2658087ca5a0286ecb",
-    "zh:59f6a6f31acf66f4ea3667a555a70eba5d406c6e6d93c2c641b81d63261eeace",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:ad0279dfd09d713db0c18469f585e58d04748ca72d9ada83883492e0dd13bd58",
-    "zh:c69f66fd21f5e2c8ecf7ca68d9091c40f19ad913aef21e3ce23836e91b8cbb5f",
-    "zh:d4a56f8c48aa86fc8e0c233d56850f5783f322d6336f3bf1916e293246b6b5d4",
-    "zh:f2b394ebd4af33f343835517e80fc876f79361f4688220833bc3c77655dd2202",
-    "zh:f31982f29f12834e5d21e010856eddd19d59cd8f449adf470655bfd19354377e",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/local" {
-  version     = "2.5.2"
-  constraints = ">= 1.0.0"
-  hashes = [
-    "h1:p99F1AoV9z51aJ4EdItxz/vLwWIyhx/0Iw7L7sWSH1o=",
-    "zh:136299545178ce281c56f36965bf91c35407c11897f7082b3b983d86cb79b511",
-    "zh:3b4486858aa9cb8163378722b642c57c529b6c64bfbfc9461d940a84cd66ebea",
-    "zh:4855ee628ead847741aa4f4fc9bed50cfdbf197f2912775dd9fe7bc43fa077c0",
-    "zh:4b8cd2583d1edcac4011caafe8afb7a95e8110a607a1d5fb87d921178074a69b",
-    "zh:52084ddaff8c8cd3f9e7bcb7ce4dc1eab00602912c96da43c29b4762dc376038",
-    "zh:71562d330d3f92d79b2952ffdda0dad167e952e46200c767dd30c6af8d7c0ed3",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:805f81ade06ff68fa8b908d31892eaed5c180ae031c77ad35f82cb7a74b97cf4",
-    "zh:8b6b3ebeaaa8e38dd04e56996abe80db9be6f4c1df75ac3cccc77642899bd464",
-    "zh:ad07750576b99248037b897de71113cc19b1a8d0bc235eb99173cc83d0de3b1b",
-    "zh:b9f1c3bfadb74068f5c205292badb0661e17ac05eb23bfe8bd809691e4583d0e",
-    "zh:cc4cbcd67414fefb111c1bf7ab0bc4beb8c0b553d01719ad17de9a047adff4d1",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/null" {
-  version     = "3.2.3"
-  constraints = ">= 2.0.0"
-  hashes = [
-    "h1:nKUqWEza6Lcv3xRlzeiRQrHtqvzX1BhIzjaOVXRYQXQ=",
-    "zh:22d062e5278d872fe7aed834f5577ba0a5afe34a3bdac2b81f828d8d3e6706d2",
-    "zh:23dead00493ad863729495dc212fd6c29b8293e707b055ce5ba21ee453ce552d",
-    "zh:28299accf21763ca1ca144d8f660688d7c2ad0b105b7202554ca60b02a3856d3",
-    "zh:55c9e8a9ac25a7652df8c51a8a9a422bd67d784061b1de2dc9fe6c3cb4e77f2f",
-    "zh:756586535d11698a216291c06b9ed8a5cc6a4ec43eee1ee09ecd5c6a9e297ac1",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:9d5eea62fdb587eeb96a8c4d782459f4e6b73baeece4d04b4a40e44faaee9301",
-    "zh:a6355f596a3fb8fc85c2fb054ab14e722991533f87f928e7169a486462c74670",
-    "zh:b5a65a789cff4ada58a5baffc76cb9767dc26ec6b45c00d2ec8b1b027f6db4ed",
-    "zh:db5ab669cf11d0e9f81dc380a6fdfcac437aea3d69109c7aef1a5426639d2d65",
-    "zh:de655d251c470197bcbb5ac45d289595295acb8f829f6c781d4a75c8c8b7c7dd",
-    "zh:f5c68199f2e6076bce92a12230434782bf768103a427e9bb9abee99b116af7b5",
   ]
 }
 

--- a/env/staging/newrelic/.terraform.lock.hcl
+++ b/env/staging/newrelic/.terraform.lock.hcl
@@ -1,28 +1,9 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/archive" {
-  version = "2.7.0"
-  hashes = [
-    "h1:uZO0XsK1RW1mBRn8SsVPXT76pSSbyb4SmA0eLJsOe38=",
-    "zh:04e23bebca7f665a19a032343aeecd230028a3822e546e6f618f24c47ff87f67",
-    "zh:5bb38114238e25c45bf85f5c9f627a2d0c4b98fe44a0837e37d48574385f8dad",
-    "zh:64584bc1db4c390abd81c76de438d93acf967c8a33e9b923d68da6ed749d55bd",
-    "zh:697695ab9cce351adf91a1823bdd72ce6f0d219138f5124ef7645cedf8f59a1f",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:7edefb1d1e2fead8fd155f7b50a2cb49f2f3fed154ac3ef5f991ccaff93d6120",
-    "zh:807fb15b75910bf14795f2ad1a2d41b069f9ef52c242131b2964c8527312e235",
-    "zh:821d9148d261df1d1a8e5a4812df2a6a3ffaf0d2070dad3c785382e489069239",
-    "zh:a7d92251118fb723048c482154a6ac6368aad583d28d15fffc6f5dafd9507463",
-    "zh:b627d4cef192b3c12ddaf9cb2c4f98c10d0129883c8c2a9c0049983f9de7030d",
-    "zh:dfb70306fcc0ad1d512ab7c24765703783cc286062d4849de4fbe23526f5dc8e",
-    "zh:f21de276f857b7e51fa2593d8fef05a7faafb0a7b62db14ac58a03ce1be7d881",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.80.0"
-  constraints = ">= 4.8.0, >= 4.9.0, ~> 5.66"
+  constraints = "~> 5.66"
   hashes = [
     "h1:1O1XLPOrMg30ATXLC9itDvvyQUoIPIre7NiNscCOz28=",
     "zh:0b1655e39639d60f2de2860a5df8642f9556ba0ca04529c1b861fde4935cb0df",
@@ -40,66 +21,6 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:c7681134a123486e72eaedc3f8d2d75e267dbbfd45fa7de5aea8f757af57f89b",
     "zh:ea717ebad3561fd02591f9eecf30f3df5635405556fba2bdbf29fd42691bebac",
     "zh:f4e1e8f23c58c3e8f4371f9c3379a723ab4155246e6b6daad8eb99e16666b2cb",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/external" {
-  version     = "2.3.4"
-  constraints = ">= 1.0.0"
-  hashes = [
-    "h1:U6W8rgrdmR2pZ2cicFoGOSQ4GXuIf/4EK7s0vTJN7is=",
-    "zh:037fd82cd86227359bc010672cd174235e2d337601d4686f526d0f53c87447cb",
-    "zh:0ea1db63d6173d01f2fa8eb8989f0809a55135a0d8d424b08ba5dabad73095fa",
-    "zh:17a4d0a306566f2e45778fbac48744b6fd9c958aaa359e79f144c6358cb93af0",
-    "zh:298e5408ab17fd2e90d2cd6d406c6d02344fe610de5b7dae943a58b958e76691",
-    "zh:38ecfd29ee0785fd93164812dcbe0664ebbe5417473f3b2658087ca5a0286ecb",
-    "zh:59f6a6f31acf66f4ea3667a555a70eba5d406c6e6d93c2c641b81d63261eeace",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:ad0279dfd09d713db0c18469f585e58d04748ca72d9ada83883492e0dd13bd58",
-    "zh:c69f66fd21f5e2c8ecf7ca68d9091c40f19ad913aef21e3ce23836e91b8cbb5f",
-    "zh:d4a56f8c48aa86fc8e0c233d56850f5783f322d6336f3bf1916e293246b6b5d4",
-    "zh:f2b394ebd4af33f343835517e80fc876f79361f4688220833bc3c77655dd2202",
-    "zh:f31982f29f12834e5d21e010856eddd19d59cd8f449adf470655bfd19354377e",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/local" {
-  version     = "2.5.2"
-  constraints = ">= 1.0.0"
-  hashes = [
-    "h1:p99F1AoV9z51aJ4EdItxz/vLwWIyhx/0Iw7L7sWSH1o=",
-    "zh:136299545178ce281c56f36965bf91c35407c11897f7082b3b983d86cb79b511",
-    "zh:3b4486858aa9cb8163378722b642c57c529b6c64bfbfc9461d940a84cd66ebea",
-    "zh:4855ee628ead847741aa4f4fc9bed50cfdbf197f2912775dd9fe7bc43fa077c0",
-    "zh:4b8cd2583d1edcac4011caafe8afb7a95e8110a607a1d5fb87d921178074a69b",
-    "zh:52084ddaff8c8cd3f9e7bcb7ce4dc1eab00602912c96da43c29b4762dc376038",
-    "zh:71562d330d3f92d79b2952ffdda0dad167e952e46200c767dd30c6af8d7c0ed3",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:805f81ade06ff68fa8b908d31892eaed5c180ae031c77ad35f82cb7a74b97cf4",
-    "zh:8b6b3ebeaaa8e38dd04e56996abe80db9be6f4c1df75ac3cccc77642899bd464",
-    "zh:ad07750576b99248037b897de71113cc19b1a8d0bc235eb99173cc83d0de3b1b",
-    "zh:b9f1c3bfadb74068f5c205292badb0661e17ac05eb23bfe8bd809691e4583d0e",
-    "zh:cc4cbcd67414fefb111c1bf7ab0bc4beb8c0b553d01719ad17de9a047adff4d1",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/null" {
-  version     = "3.2.3"
-  constraints = ">= 2.0.0"
-  hashes = [
-    "h1:nKUqWEza6Lcv3xRlzeiRQrHtqvzX1BhIzjaOVXRYQXQ=",
-    "zh:22d062e5278d872fe7aed834f5577ba0a5afe34a3bdac2b81f828d8d3e6706d2",
-    "zh:23dead00493ad863729495dc212fd6c29b8293e707b055ce5ba21ee453ce552d",
-    "zh:28299accf21763ca1ca144d8f660688d7c2ad0b105b7202554ca60b02a3856d3",
-    "zh:55c9e8a9ac25a7652df8c51a8a9a422bd67d784061b1de2dc9fe6c3cb4e77f2f",
-    "zh:756586535d11698a216291c06b9ed8a5cc6a4ec43eee1ee09ecd5c6a9e297ac1",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:9d5eea62fdb587eeb96a8c4d782459f4e6b73baeece4d04b4a40e44faaee9301",
-    "zh:a6355f596a3fb8fc85c2fb054ab14e722991533f87f928e7169a486462c74670",
-    "zh:b5a65a789cff4ada58a5baffc76cb9767dc26ec6b45c00d2ec8b1b027f6db4ed",
-    "zh:db5ab669cf11d0e9f81dc380a6fdfcac437aea3d69109c7aef1a5426639d2d65",
-    "zh:de655d251c470197bcbb5ac45d289595295acb8f829f6c781d4a75c8c8b7c7dd",
-    "zh:f5c68199f2e6076bce92a12230434782bf768103a427e9bb9abee99b116af7b5",
   ]
 }
 


### PR DESCRIPTION
# Summary | Résumé

Had to move the AWS new relic integration point into common so that it's already there when it's time to apply newrelic alarms etc.

## Related Issues | Cartes liées

My own free will

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

Tested in dev
Staging plan should show no destroys (may be small changes on import)

## Release Instructions | Instructions pour le déploiement

Once this is released to staging, a new PR should be created to remove the removed.tf and import.tf

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
