### PR TITLE
renaming document download for prod

### DIFF
--- a/aws/eks/cloudwatch_queries.tf
+++ b/aws/eks/cloudwatch_queries.tf
@@ -2,7 +2,7 @@ locals {
   celery_name            = var.env == "production" ? "celery" : "notify-celery"
   admin_name             = var.env == "production" ? "admin" : "notify-admin"
   api_name               = var.env == "production" ? "api" : "notify-api"
-  document_download_name = var.env == "production" ? "document-download" : "notify-document-download"
+  document_download_name = var.env == "production" ? "document-download-api" : "notify-document-download"
   documentation_name     = var.env == "production" ? "documentation" : "notify-documentation"
 
 }


### PR DESCRIPTION
# Summary | Résumé

Document download was named incorrectly for prod dashboards. Fixing.

## Related Issues | Cartes liées

Chore

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

TF Apply works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
