### PR TITLE
Add a budget alert for when we use a lot of cloudwatch data scanning

### DIFF
--- a/aws/common/budget.tf
+++ b/aws/common/budget.tf
@@ -23,6 +23,38 @@ resource "aws_budgets_budget" "notify_global" {
   }
 }
 
+resource "aws_budgets_budget" "cloudwatch_data_scanned" {
+  name         = "coudwatch-data-scanned-budget"
+  budget_type  = "USAGE"
+  limit_amount = "10000"
+  limit_unit   = "GB"
+  time_unit    = "DAILY"
+
+  cost_filter {
+    name = "UsageType"
+    values = [
+      "CAN1-DataScanned-Bytes",
+    ]
+  }
+
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 100
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "ACTUAL"
+    subscriber_sns_topic_arns = [aws_sns_topic.notification-canada-ca-alert-general.arn]
+  }
+
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 80
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "ACTUAL"
+    subscriber_sns_topic_arns = [aws_sns_topic.notification-canada-ca-alert-general.arn]
+  }
+
+}
+
 module "budget_notifier" {
   source                     = "github.com/cds-snc/terraform-modules//spend_notifier?ref=v9.6.4"
   daily_spend_notifier_hook  = var.budget_sre_bot_webhook

--- a/aws/common/budget.tf
+++ b/aws/common/budget.tf
@@ -24,7 +24,7 @@ resource "aws_budgets_budget" "notify_global" {
 }
 
 resource "aws_budgets_budget" "cloudwatch_data_scanned" {
-  name         = "coudwatch-data-scanned-budget"
+  name         = "cloudwatch-data-scanned-budget"
   budget_type  = "USAGE"
   limit_amount = "10000"
   limit_unit   = "GB"


### PR DESCRIPTION
# Summary | Résumé

We had a large charge in AWS Cloudwatch for querying data. This budget will alert us when we're going crazy in the future.

## Related Issues | Cartes liées

Chore

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

TF Apply 
Verify budget shows data in target environment

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
