### PR TITLE
Delete event targets

### DIFF
--- a/scripts/deleteEnvironment.sh
+++ b/scripts/deleteEnvironment.sh
@@ -126,6 +126,31 @@ aws events delete-rule --name google_cidr_testing
 
 aws sesv2 delete-email-identity --email-identity dev.notification.cdssandbox.xyz
 
+SYSTEM_STATUS_TARGET=$(aws events list-targets-by-rule --rule system_status_testing --query 'Targets[].Id' --output text)
+
+for target in $SYSTEM_STATUS_TARGET; do
+  echo "Deleting event target $target"
+  aws events remove-targets --rule "system_status_testing" --ids "$target"
+  echo "Done."
+done
+
+HEARTBEAT_TESTING_TARGET=$(aws events list-targets-by-rule --rule heartbeat_testing --query 'Targets[].Id' --output text)
+
+for target in $HEARTBEAT_TESTING_TARGET; do
+  echo "Deleting event target $target"
+  aws events remove-targets --rule "heartbeat_testing" --ids "$target"
+  echo "Done."
+done
+
+PERFTEST_TARGET=$(aws events list-targets-by-rule --rule perf_test_event_rule --query 'Targets[].Id' --output text)
+
+for target in $PERFTEST_TARGET; do
+  echo "Deleting event target $target"
+  aws events remove-targets --rule "perf_test_event_rule" --ids "$target"
+  echo "Done."
+done
+
+
 AWS_REGION=us-east-1  aws ses set-active-receipt-rule-set
 AWS_REGION=us-east-1 aws ses delete-receipt-rule-set --rule-set-name main
 


### PR DESCRIPTION
# Summary | Résumé

Event bridge targets are failing create after multiple creates in dev. Deleting them manually since aws nuke ain't doing it.

## Related Issues | Cartes liées

Chore

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

Delete env/create env works next week.

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
