### PR TITLE
fix: allow admin to list the sending domains

### DIFF
--- a/aws/eks/iam.tf
+++ b/aws/eks/iam.tf
@@ -114,6 +114,8 @@ resource "aws_iam_policy" "notification-worker-policy" {
         "mobiletargeting:*",
         "ses:SendEmail",
         "ses:SendRawEmail",
+        "ses:ListIdentities",
+        "ses:GetIdentityVerificationAttributes",
         "sqs:*",
         "sns:Publish",
         "sms-voice:SendTextMessage",


### PR DESCRIPTION
# Summary | Résumé

This PR updates a policy used by admin so that it can get the list of SES sending domains.

## Related Issues | Cartes liées
* https://github.com/cds-snc/notification-planning/issues/1363

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

- [ ] Sending domains can be listed in the admin settings in staging

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
