### PR TITLE
Update admin WAF rules to allow bypass with secret

### DIFF
--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -536,23 +536,46 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
         limit              = var.non_api_waf_rate_limit
         aggregate_key_type = "IP"
         scope_down_statement {
-          not_statement {
+          and_statement {
             statement {
-              byte_match_statement {
-                positional_constraint = "STARTS_WITH"
-                field_to_match {
-                  single_header {
-                    name = "host"
+              not_statement {
+                statement {
+                  byte_match_statement {
+                    positional_constraint = "EXACTLY"
+                    search_string         = var.waf_secret
+                    field_to_match {
+                      single_header {
+                        name = "waf-secret"
+                      }
+                    }
+                    text_transformation {
+                      priority = 1
+                      type     = "NONE"
+                    }
                   }
                 }
-                search_string = "api"
-                text_transformation {
-                  priority = 1
-                  type     = "COMPRESS_WHITE_SPACE"
-                }
-                text_transformation {
-                  priority = 2
-                  type     = "LOWERCASE"
+              }
+            }
+            statement {
+              not_statement {
+                statement {
+                  byte_match_statement {
+                    positional_constraint = "STARTS_WITH"
+                    field_to_match {
+                      single_header {
+                        name = "host"
+                      }
+                    }
+                    search_string = "api"
+                    text_transformation {
+                      priority = 1
+                      type     = "COMPRESS_WHITE_SPACE"
+                    }
+                    text_transformation {
+                      priority = 2
+                      type     = "LOWERCASE"
+                    }
+                  }
                 }
               }
             }
@@ -561,7 +584,6 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
       }
     }
   }
-
   rule {
     name     = "ApiRateLimit"
     priority = 210


### PR DESCRIPTION
# Summary | Résumé

This PR adds a condition to the `rate_limit_all_except_api` rule to not rate limit if a `waf-secret` header with a specific value is sent.

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
