### PR TITLE
adding manifests workflow token

### DIFF
--- a/aws/github/admin-secrets.tf
+++ b/aws/github/admin-secrets.tf
@@ -61,3 +61,9 @@ resource "github_actions_secret" "admin_slack_webhook" {
   plaintext_value = var.notify_dev_slack_webhook
 }
 
+resource "github_actions_secret" "admin_github_manifests_workflow_token" {
+  count           = var.env == "staging" ? 1 : 0
+  repository      = data.github_repository.notification_admin.name
+  secret_name     = "MANIFESTS_WORKFLOW_TOKEN"
+  plaintext_value = var.github_manifests_workflow_token
+}

--- a/aws/github/api-secrets.tf
+++ b/aws/github/api-secrets.tf
@@ -45,3 +45,10 @@ resource "github_actions_secret" "api_slack_webhook" {
   secret_name     = "SLACK_WEBHOOK"
   plaintext_value = var.notify_dev_slack_webhook
 }
+
+resource "github_actions_secret" "api_github_manifests_workflow_token" {
+  count           = var.env == "staging" ? 1 : 0
+  repository      = data.github_repository.notification_api.name
+  secret_name     = "MANIFESTS_WORKFLOW_TOKEN"
+  plaintext_value = var.github_manifests_workflow_token
+}

--- a/aws/github/document-download-secrets.tf
+++ b/aws/github/document-download-secrets.tf
@@ -11,3 +11,10 @@ resource "github_actions_secret" "dd_slack_webhook" {
   secret_name     = "SLACK_WEBHOOK"
   plaintext_value = var.notify_dev_slack_webhook
 }
+
+resource "github_actions_secret" "dd_github_manifests_workflow_token" {
+  count           = var.env == "staging" ? 1 : 0
+  repository      = data.github_repository.notification_document_download.name
+  secret_name     = "MANIFESTS_WORKFLOW_TOKEN"
+  plaintext_value = var.github_manifests_workflow_token
+}

--- a/aws/github/documentation-secrets.tf
+++ b/aws/github/documentation-secrets.tf
@@ -5,7 +5,7 @@ resource "github_actions_secret" "documentation_op_service_account_token" {
   plaintext_value = var.op_service_account_token
 }
 
-resource "github_actions_secret" "documentation_api_github_manifests_workflow_token" {
+resource "github_actions_secret" "documentation_github_manifests_workflow_token" {
   count           = var.env == "staging" ? 1 : 0
   repository      = data.github_repository.notification_documentation.name
   secret_name     = "MANIFESTS_WORKFLOW_TOKEN"

--- a/aws/github/documentation-secrets.tf
+++ b/aws/github/documentation-secrets.tf
@@ -4,3 +4,10 @@ resource "github_actions_secret" "documentation_op_service_account_token" {
   secret_name     = "OP_SERVICE_ACCOUNT_TOKEN_${upper(var.env)}"
   plaintext_value = var.op_service_account_token
 }
+
+resource "github_actions_secret" "documentation_api_github_manifests_workflow_token" {
+  count           = var.env == "staging" ? 1 : 0
+  repository      = data.github_repository.notification_documentation.name
+  secret_name     = "MANIFESTS_WORKFLOW_TOKEN"
+  plaintext_value = var.github_manifests_workflow_token
+}

--- a/env/variables.tf
+++ b/env/variables.tf
@@ -1051,3 +1051,8 @@ variable "ipv4_maxmind_license_key" {
   sensitive = true
   default   = "prodonly"
 }
+
+variable "github_manifests_workflow_token" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
[review]

# Summary | Résumé

adding a github secret to each component repo f or manifests workflow triggers

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/491

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

verify that admin, api, dd and documentation workflows are still running and not having any issues triggering the workflow in manifests repo.

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
