### PR TITLE
Need to put version in quotes or else the trailing zeroes get removed

### DIFF
--- a/env/dev_config.tfvars
+++ b/env/dev_config.tfvars
@@ -167,4 +167,4 @@ pinpoint_to_sqs_sms_callbacks_docker_tag = "bootstrap"
 
 ## BLAZER
 blazer_image_tag = "latest"
-blazer_rds_version = 15.10
+blazer_rds_version = "15.10"

--- a/env/production_config.tfvars
+++ b/env/production_config.tfvars
@@ -171,4 +171,4 @@ pinpoint_to_sqs_sms_callbacks_docker_tag = "bootstrap"
 
 ## BLAZER
 blazer_image_tag = "latest"
-blazer_rds_version = 15.5
+blazer_rds_version = "15.5"

--- a/env/staging_config.tfvars
+++ b/env/staging_config.tfvars
@@ -166,4 +166,4 @@ pinpoint_to_sqs_sms_callbacks_docker_tag = "bootstrap"
 
 ## BLAZER
 blazer_image_tag = "latest"
-blazer_rds_version = 15.5
+blazer_rds_version = "15.5"


### PR DESCRIPTION
# Summary | Résumé

Dev database-tools apply failed because the "0" in 15.10 was being truncated.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/480

## Test instructions | Instructions pour tester la modification

Create Dev works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
