### PR TITLE
Switch off notification-terraform-api 

### DIFF
--- a/.github/workflows/terragrunt_create_dev_environment.yml
+++ b/.github/workflows/terragrunt_create_dev_environment.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Configure credentials to Notify Private ECR using OIDC
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-api-apply
+          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-terraform-apply
           role-session-name: NotifyApiGitHubActions
           aws-region: "ca-central-1"        
 
@@ -115,7 +115,7 @@ jobs:
       - name: Configure credentials to Notify Private ECR using OIDC
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-api-apply
+          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-terraform-apply
           role-session-name: NotifyApiGitHubActions
           aws-region: "us-east-1"  
 
@@ -568,7 +568,7 @@ jobs:
       - name: Configure credentials to Notify Private ECR using OIDC
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-api-apply
+          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-terraform-apply
           role-session-name: NotifyApiGitHubActions
           aws-region: "ca-central-1"        
 


### PR DESCRIPTION
# Summary | Résumé

Create dev is failing when trying to use the notification-api-terraform role for AWS. Not sure why but also not sure why we're not just using the regular terraform role. Lets try this.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/480

## Test instructions | Instructions pour tester la modification

Merge to main, run create-dev

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
