### PR TITLE
Raise dbload warning threshold

### DIFF
--- a/aws/rds/cloudwatch_alarms.tf
+++ b/aws/rds/cloudwatch_alarms.tf
@@ -7,14 +7,14 @@
 resource "aws_cloudwatch_metric_alarm" "high-dbload-warning" {
   count               = var.rds_instance_count
   alarm_name          = "high-dbload-warning-instance-${count.index}"
-  alarm_description   = "DBLoad > 1. Check if there's a query that is causing this."
+  alarm_description   = "DBLoad > 10. Check if there's a query that is causing this."
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
   metric_name         = "DBLoad"
   namespace           = "AWS/RDS"
   period              = 60
   statistic           = "Average"
-  threshold           = 1
+  threshold           = 10
   alarm_actions       = [var.sns_alert_warning_arn]
   treat_missing_data  = "notBreaching"
   dimensions = {


### PR DESCRIPTION
# Summary | Résumé

Raise threshold for dbload warning, as it is going off under normal high usage.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/349

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

None

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
