### PR TITLE
adding the new relic secrets we needed for manifests

### DIFF
--- a/aws/manifest_secrets/secrets.tf
+++ b/aws/manifest_secrets/secrets.tf
@@ -138,6 +138,26 @@ resource "aws_secretsmanager_secret_version" "manifest_new_relic_license_key_ver
   secret_string = var.manifest_new_relic_license_key
 }
 
+resource "aws_secretsmanager_secret" "manifest_new_relic_account_id" {
+  name                    = "MANIFEST_NEW_RELIC_ACCOUNT_ID"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_new_relic_account_id_version" {
+  secret_id     = aws_secretsmanager_secret.manifest_new_relic_account_id.id
+  secret_string = var.manifest_new_relic_account_id
+}
+
+resource "aws_secretsmanager_secret" "manifest_new_relic_api_key" {
+  name                    = "MANIFEST_NEW_RELIC_API_KEY"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_new_relic_api_key_version" {
+  secret_id     = aws_secretsmanager_secret.manifest_new_relic_api_key.id
+  secret_string = var.manifest_new_relic_api_key
+}
+
 resource "aws_secretsmanager_secret" "manifest_crm_github_personal_access_token" {
   name                    = "MANIFEST_CRM_GITHUB_PERSONAL_ACCESS_TOKEN"
   recovery_window_in_days = 0

--- a/env/variables.tf
+++ b/env/variables.tf
@@ -861,6 +861,16 @@ variable "manifest_new_relic_license_key" {
   sensitive = true
 }
 
+variable "manifest_new_relic_account_id" {
+  type      = string
+  sensitive = true
+}
+
+variable "manifest_new_relic_api_key" {
+  type      = string
+  sensitive = true
+}
+
 variable "manifest_crm_github_personal_access_token" {
   type      = string
   sensitive = true


### PR DESCRIPTION
# Summary | Résumé

Some new relic secrets were defined outside the scope of manifests so they weren't being read by new relic.  This adds them.

## Related Issues | Cartes liées

This is a quick fix for a bug discovered today.

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

- check the secrets store here: [https://ca-central-1.console.aws.amazon.com/secretsmanager/listsecrets?region=ca-central-1](url)
- verify that MANIFEST_NEW_RELIC_API_KEY, MANIFEST_NEW_RELIC_ACCOUNT_ID are added properly.

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
