### PR TITLE
use INTERNAL_TEST_NUMBER for perf test

### DIFF
--- a/env/dev_config.tfvars
+++ b/env/dev_config.tfvars
@@ -108,7 +108,7 @@ gc_notify_service_email = "gc.notify.notification.gc@staging.notification.cdssan
 
 ## PERF TEST
 aws_pinpoint_region          = "ca-central-1"
-perf_test_phone_number       = "16135550123"
+perf_test_phone_number       = "16135550123" # INTERNAL_TEST_NUMBER - does not send to AWS
 perf_test_email              = "success@simulator.amazonses.com"
 perf_schedule_expression     = "cron(0 0 * * ? *)"
 perf_test_aws_s3_bucket      = "notify-performance-test-results-dev"

--- a/env/dev_config.tfvars
+++ b/env/dev_config.tfvars
@@ -108,7 +108,7 @@ gc_notify_service_email = "gc.notify.notification.gc@staging.notification.cdssan
 
 ## PERF TEST
 aws_pinpoint_region          = "ca-central-1"
-perf_test_phone_number       = "16132532222"
+perf_test_phone_number       = "16135550123"
 perf_test_email              = "success@simulator.amazonses.com"
 perf_schedule_expression     = "cron(0 0 * * ? *)"
 perf_test_aws_s3_bucket      = "notify-performance-test-results-dev"
@@ -166,5 +166,5 @@ ses_receiving_emails_docker_tag          = "bootstrap"
 pinpoint_to_sqs_sms_callbacks_docker_tag = "bootstrap"
 
 ## BLAZER
-blazer_image_tag = "latest"
+blazer_image_tag   = "latest"
 blazer_rds_version = "15.10"

--- a/env/staging_config.tfvars
+++ b/env/staging_config.tfvars
@@ -112,7 +112,7 @@ system_status_admin_url   = "https://staging.notification.cdssandbox.xyz"
 
 ## PERF TEST
 aws_pinpoint_region          = "ca-central-1"
-perf_test_phone_number       = "16132532222"
+perf_test_phone_number       = "16135550123"
 perf_test_email              = "success@simulator.amazonses.com"
 perf_schedule_expression     = "cron(0 0 * * ? *)"
 perf_test_aws_s3_bucket      = "notify-performance-test-results-staging"
@@ -165,5 +165,5 @@ ses_receiving_emails_docker_tag          = "bootstrap"
 pinpoint_to_sqs_sms_callbacks_docker_tag = "bootstrap"
 
 ## BLAZER
-blazer_image_tag = "latest"
+blazer_image_tag   = "latest"
 blazer_rds_version = "15.5"

--- a/env/staging_config.tfvars
+++ b/env/staging_config.tfvars
@@ -112,7 +112,7 @@ system_status_admin_url   = "https://staging.notification.cdssandbox.xyz"
 
 ## PERF TEST
 aws_pinpoint_region          = "ca-central-1"
-perf_test_phone_number       = "16135550123"
+perf_test_phone_number       = "16135550123" # INTERNAL_TEST_NUMBER - does not send to AWS
 perf_test_email              = "success@simulator.amazonses.com"
 perf_schedule_expression     = "cron(0 0 * * ? *)"
 perf_test_aws_s3_bucket      = "notify-performance-test-results-staging"


### PR DESCRIPTION
# Summary | Résumé

Using the INTERNAL_TEST_NUMBER for the SMS parts of the performance test. This will test Notify internals more than the simulated test number currently used.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/485

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

None

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
