### PR TITLE
Route 53 log query config take 2

### DIFF
--- a/scripts/deleteEnvironment.sh
+++ b/scripts/deleteEnvironment.sh
@@ -180,8 +180,10 @@ done
 
 R53_QUERIES=$(aws route53resolver list-resolver-query-log-configs --query 'ResolverQueryLogConfigs[].Id' --output text)
 for query in $R53_QUERIES; do
-  echo "Deleting route53 query log $query"
-  aws route53resolver delete-resolver-query-log-config --resolver-query-log-config-id $query
+    association=$(aws route53resolver list-resolver-query-log-config-associations --query "ResolverQueryLogConfigAssociations[? ResolverQueryLogConfigId=='$query'].Id" --output text)
+    resourceid=$(aws route53resolver get-resolver-query-log-config-association --resolver-query-log-config-association-id $association --query 'ResolverQueryLogConfigAssociation.ResourceId' --output text)
+    aws route53resolver disassociate-resolver-query-log-config --resolver-query-log-config-id $query --resource-id $resourceid
+    aws route53resolver delete-resolver-query-log-config --resolver-query-log-config-id $query
 done
 
 echo "Done."


### PR DESCRIPTION
# Summary | Résumé

Needed to delete a bunch of associations in addition to the queries.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/480

## Test instructions | Instructions pour tester la modification

Delete/recreate dev

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
