### PR TITLE
add internal sms test graph to system dashboard

### DIFF
--- a/aws/eks/dashboards.tf
+++ b/aws/eks/dashboards.tf
@@ -551,11 +551,11 @@ resource "aws_cloudwatch_dashboard" "notify_system" {
             "x": 0,
             "type": "log",
             "properties": {
-                "query": "SOURCE '/aws/containerinsights/${aws_eks_cluster.notification-canada-ca-eks-cluster.name}/application' | filter kubernetes.container_name like /^${local.celery_name}/\n| filter @message like /send_delivery_status_to_service request failed for notification_id/\n| parse log \"to url: https://* service: * exc: * \" as endpoint, service_id, error\n| stats count() as fails by service_id, endpoint, error\n| display fails, service_id, error, endpoint\n| order by fails desc\n",
+                "query": "SOURCE '/aws/containerinsights/${aws_eks_cluster.notification-canada-ca-eks-cluster.name}/application' | fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as pod_name, @logStream\n| filter kubernetes.container_name like /celery-sms-send/\n| fields strcontains(@message, 'sending to INTERNAL_TEST_NUMBER') as is_test\n| stats sum(is_test) as tests by bin(1m)\n",
                 "region": "${var.region}",
                 "stacked": false,
-                "title": "Failed Service Callbacks",
-                "view": "table"
+                "title": "Internal Test SMS per Minute",
+                "view": "timeSeries"
             }
         },
         {
@@ -570,6 +570,20 @@ resource "aws_cloudwatch_dashboard" "notify_system" {
                 "stacked": false,
                 "view": "table",
                 "title": "Abnormal Kubernetes Events"
+            }
+        },
+        {
+            "height": 5,
+            "width": 12,
+            "y": 22,
+            "x": 12,
+            "type": "log",
+            "properties": {
+                "query": "SOURCE '/aws/containerinsights/${aws_eks_cluster.notification-canada-ca-eks-cluster.name}/application' | filter kubernetes.container_name like /^${local.celery_name}/\n| filter @message like /send_delivery_status_to_service request failed for notification_id/\n| parse log \"to url: https://* service: * exc: * \" as endpoint, service_id, error\n| stats count() as fails by service_id, endpoint, error\n| display fails, service_id, error, endpoint\n| order by fails desc\n",
+                "region": "${var.region}",
+                "stacked": false,
+                "title": "Failed Service Callbacks",
+                "view": "table"
             }
         }
     ]


### PR DESCRIPTION
# Summary | Résumé

Add internal sms test graph to system dashboard. This is useful when looking at the performance tests.
Should look like [this staging dashboard](https://ca-central-1.console.aws.amazon.com/cloudwatch/home?region=ca-central-1#dashboards/dashboard/Notify-System-Overview-SJA-pr-temp).

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

View in staging / prod

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
