### PR TITLE
adding tf user as admin and cleaning up workflow

### DIFF
--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -372,11 +372,6 @@ jobs:
           aws eks update-kubeconfig --name notification-canada-ca-${{env.ENVIRONMENT}}-eks-cluster     
           kubectl config rename-context arn:aws:eks:ca-central-1:${{env.ACCOUNT_ID}}:cluster/notification-canada-ca-${{env.ENVIRONMENT}}-eks-cluster ${{env.ENVIRONMENT}}
 
-      - name: get role name
-        run: |
-          export TF_VAR_role_name=$(aws iam list-roles | jq -r '.Roles[] | select(.RoleName|match("AWSReservedSSO_AWSAdministratorAccess_*")) | .RoleName')
-          echo "TF_VAR_role_name=$TF_VAR_role_name" >> $GITHUB_ENV
-
       - name: terragrunt apply aws-auth
         run: |
           cd env/${{env.ENVIRONMENT}}/aws-auth

--- a/.github/workflows/terragrunt_create_dev_environment.yml
+++ b/.github/workflows/terragrunt_create_dev_environment.yml
@@ -405,11 +405,6 @@ jobs:
           aws eks update-kubeconfig --name notification-canada-ca-${{env.ENVIRONMENT}}-eks-cluster     
           kubectl config rename-context arn:aws:eks:ca-central-1:${{env.ACCOUNT_ID}}:cluster/notification-canada-ca-${{env.ENVIRONMENT}}-eks-cluster ${{env.ENVIRONMENT}}
 
-      - name: get role name
-        run: |
-          export TF_VAR_role_name=$(aws iam list-roles | jq -r '.Roles[] | select(.RoleName|match("AWSReservedSSO_AWSAdministratorAccess_*")) | .RoleName')
-          echo "TF_VAR_role_name=$TF_VAR_role_name" >> $GITHUB_ENV
-
       - name: terragrunt apply aws-auth
         run: |
           cd env/${{env.ENVIRONMENT}}/aws-auth

--- a/.github/workflows/terragrunt_plan_dev.yml
+++ b/.github/workflows/terragrunt_plan_dev.yml
@@ -452,11 +452,6 @@ jobs:
           aws eks update-kubeconfig --name notification-canada-ca-${{env.ENVIRONMENT}}-eks-cluster     
           kubectl config rename-context arn:aws:eks:ca-central-1:${{env.ACCOUNT_ID}}:cluster/notification-canada-ca-${{env.ENVIRONMENT}}-eks-cluster ${{env.ENVIRONMENT}}
 
-      - name: get role name
-        run: |
-          export TF_VAR_role_name=$(aws iam list-roles | jq -r '.Roles[] | select(.RoleName|match("AWSReservedSSO_AWSAdministratorAccess_*")) | .RoleName')
-          echo "TF_VAR_role_name=$TF_VAR_role_name" >> $GITHUB_ENV
-
       - name: Terragrunt plan ${{env.COMPONENT}}
         uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
         with:

--- a/.github/workflows/terragrunt_plan_dev.yml
+++ b/.github/workflows/terragrunt_plan_dev.yml
@@ -447,6 +447,13 @@ jobs:
           config_file: /var/tmp/${{env.ENVIRONMENT}}.ovpn
           echo_config: false       
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-manifests-apply
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"       
+
       - name: Configure kubeconfig
         run: |
           aws eks update-kubeconfig --name notification-canada-ca-${{env.ENVIRONMENT}}-eks-cluster     

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -492,11 +492,6 @@ jobs:
           aws eks update-kubeconfig --name notification-canada-ca-${{env.ENVIRONMENT}}-eks-cluster     
           kubectl config rename-context arn:aws:eks:ca-central-1:${{env.ACCOUNT_ID}}:cluster/notification-canada-ca-${{env.ENVIRONMENT}}-eks-cluster ${{env.ENVIRONMENT}}
 
-      - name: get role name
-        run: |
-          export TF_VAR_role_name=$(aws iam list-roles | jq -r '.Roles[] | select(.RoleName|match("AWSReservedSSO_AWSAdministratorAccess_*")) | .RoleName')
-          echo "TF_VAR_role_name=$TF_VAR_role_name" >> $GITHUB_ENV
-
       - name: Terragrunt plan ${{env.COMPONENT}}
         uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
         with:

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -487,6 +487,13 @@ jobs:
           config_file: /var/tmp/${{env.ENVIRONMENT}}.ovpn
           echo_config: false       
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-manifests-apply
+          role-session-name: NotifyTerraformPlan
+          aws-region: "ca-central-1"              
+
       - name: Configure kubeconfig
         run: |
           aws eks update-kubeconfig --name notification-canada-ca-${{env.ENVIRONMENT}}-eks-cluster     

--- a/aws/aws-auth/aws-auth.tf
+++ b/aws/aws-auth/aws-auth.tf
@@ -69,8 +69,3 @@ module "eks" {
     var.account_id
   ]
 }
-
-variable "role_name" {
-  type        = string
-  description = "The name of the role to create"
-}

--- a/aws/aws-auth/aws-auth.tf
+++ b/aws/aws-auth/aws-auth.tf
@@ -5,6 +5,11 @@ provider "kubernetes" {
 
 data "aws_caller_identity" "current" {}
 
+data "external" "aws_role_name" {
+  # Get the role name from aws
+  program = ["./getRoleName.sh"]
+}
+
 module "eks" {
   count   = var.env != "production" ? 1 : 0
   source  = "terraform-aws-modules/eks/aws//modules/aws-auth"
@@ -19,7 +24,7 @@ module "eks" {
       groups   = ["system:nodes", "system:bootstrappers"]
     },
     {
-      rolearn  = "arn:aws:iam::${var.account_id}:role/${var.role_name}"
+      rolearn  = "arn:aws:iam::${var.account_id}:role/${data.external.aws_role_name.result.rolename}"
       username = "AWSAdministratorAccess:{{SessionName}}"
       groups   = ["system:masters"]
     },
@@ -46,6 +51,11 @@ module "eks" {
     {
       rolearn  = "arn:aws:iam::${var.account_id}:role/notification-manifests-apply"
       username = "notification-manifests-apply"
+      groups   = ["system:masters"]
+    },
+    {
+      rolearn  = "arn:aws:iam::${var.account_id}:role/notification-terraform-apply"
+      username = "notification-terraform-apply"
       groups   = ["system:masters"]
     },
     {

--- a/aws/aws-auth/aws-auth.tf
+++ b/aws/aws-auth/aws-auth.tf
@@ -59,6 +59,11 @@ module "eks" {
       groups   = ["system:masters"]
     },
     {
+      rolearn  = "arn:aws:iam::${var.account_id}:role/notification-terraform-plan"
+      username = "notification-terraform-plan"
+      groups   = ["system:masters"]
+    },
+    {
       rolearn  = "arn:aws:iam::${var.account_id}:role/ipv4-geolocate-webservice-apply"
       username = "ipv4-geolocate-webservice-apply"
       groups   = ["system:masters"]

--- a/aws/aws-auth/getRoleName.sh
+++ b/aws/aws-auth/getRoleName.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Used by aws-auth terraform to get the role name for the running user
+ROLE_NAME=$(aws iam list-roles | jq -r '.Roles[] | select(.RoleName|match("AWSReservedSSO_AWSAdministratorAccess_*")) | .RoleName')
+
+jq --null-input \
+  --arg rolename "$ROLE_NAME" \
+  '{"rolename": $rolename}'

--- a/aws/aws-auth/getRoleName.sh
+++ b/aws/aws-auth/getRoleName.sh
@@ -5,3 +5,4 @@ ROLE_NAME=$(aws iam list-roles | jq -r '.Roles[] | select(.RoleName|match("AWSRe
 jq --null-input \
   --arg rolename "$ROLE_NAME" \
   '{"rolename": $rolename}'
+  

--- a/env/dev/aws-auth/.terraform.lock.hcl
+++ b/env/dev/aws-auth/.terraform.lock.hcl
@@ -1,0 +1,133 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.88.0"
+  constraints = "~> 5.66"
+  hashes = [
+    "h1:8So0IR8jwKx8WhVuD1LDsbeMTe78/SF5g4d7z5C6+C4=",
+    "zh:24f852b1cca276d91f950cb7fb575cacc385f55edccf4beec1f611cdd7626cf5",
+    "zh:2a3b3f5ac513f8d6448a31d9619f8a96e0597dd354459de3a4698e684c909f96",
+    "zh:3700499885a8e0e532eccba3cb068340e411cf9e616bf8a59e815d3b62ca3e46",
+    "zh:4aab3605468244a74cbde66784ea1d30dc0fc6caf26d1b099427ecd5790f7c4d",
+    "zh:74eca9314d6dd80b215d7bc1c4be37d81e1045d625d5b512995f3a352d7a43bc",
+    "zh:77d9a06c63a4ad615bc97f67f948250397267f15698ebb2547fbdd20f734983c",
+    "zh:82d6aaef1eb0caf9ca451887fdbdcff10ab09318b1d60faa883a013283ab2b15",
+    "zh:8dbcfb121b887ce8572f5ab8174d592a729390ca32dc5fdacac4c7c1c508411a",
+    "zh:95d51e80b55ff9064f5c1bc61d78f992e2f89c986ba2b10546ea4461d35c24f9",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9ead5de0e123020926a0edaf88d9eed5cb86afe438a875528f6d11d0d27eed73",
+    "zh:ab7c940cbb2081314f4af3cdd61ed2c1d59fd7a60fa3db27770887d63072fbdd",
+    "zh:d52cd68006fd6fa8d028cdf569a6620fbc31726019beb7c75affa8764622d398",
+    "zh:f179ca86ad5d5fb88dfd8e8e7c448f2c0ad550d22152f939b8465baeaf9289e9",
+    "zh:f54dda271fa6dfee06537066278669a3f92c872e7dfa5a0184cd9117f7e47b8c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/external" {
+  version = "2.3.4"
+  hashes = [
+    "h1:cCabxnWQ5fX1lS7ZqgUzsvWmKZw9FA7NRxAZ94vcTcc=",
+    "zh:037fd82cd86227359bc010672cd174235e2d337601d4686f526d0f53c87447cb",
+    "zh:0ea1db63d6173d01f2fa8eb8989f0809a55135a0d8d424b08ba5dabad73095fa",
+    "zh:17a4d0a306566f2e45778fbac48744b6fd9c958aaa359e79f144c6358cb93af0",
+    "zh:298e5408ab17fd2e90d2cd6d406c6d02344fe610de5b7dae943a58b958e76691",
+    "zh:38ecfd29ee0785fd93164812dcbe0664ebbe5417473f3b2658087ca5a0286ecb",
+    "zh:59f6a6f31acf66f4ea3667a555a70eba5d406c6e6d93c2c641b81d63261eeace",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:ad0279dfd09d713db0c18469f585e58d04748ca72d9ada83883492e0dd13bd58",
+    "zh:c69f66fd21f5e2c8ecf7ca68d9091c40f19ad913aef21e3ce23836e91b8cbb5f",
+    "zh:d4a56f8c48aa86fc8e0c233d56850f5783f322d6336f3bf1916e293246b6b5d4",
+    "zh:f2b394ebd4af33f343835517e80fc876f79361f4688220833bc3c77655dd2202",
+    "zh:f31982f29f12834e5d21e010856eddd19d59cd8f449adf470655bfd19354377e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.35.1"
+  constraints = ">= 2.20.0"
+  hashes = [
+    "h1:zgXeWvp4//Ry+4glwNrLMpPFOU8QBQlARNmR9WCNe9o=",
+    "zh:12212ca5ae47823ce14bfafb909eeb6861faf1e2435fb2fc4a8b334b3544b5f5",
+    "zh:3f49b3d77182df06b225ab266667de69681c2e75d296867eb2cf06a8f8db768c",
+    "zh:40832494d19f8a2b3cd0c18b80294d0b23ef6b82f6f6897b5fe00248a9997460",
+    "zh:739a5ddea61a77925ee7006a29c8717377a2e9d0a79a0bbd98738d92eec12c0d",
+    "zh:a02b472021753627c5c39447a56d125a32214c29ff9108fc499f2dcdf4f1cc4f",
+    "zh:b78865b3867065aa266d6758c9601a2756741478f5735a838c20d633d65e085b",
+    "zh:d362e87464683f5632790e66920ea803adb54c2bc0cb24b6fd9a314d2b1efffd",
+    "zh:d98206fe88c2c9a52b8d2d0cb2c877c812a4a51d19f9d8428e63cbd5fd8a304d",
+    "zh:dfa320946b1ce3f3615c42b3447a28dc9f604c06d8b9a6fe289855ab2ade4d11",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fc1debd2e695b5222d2ccc8b24dab65baba4ee2418ecce944e64d42e79474cb5",
+    "zh:fdaf960443720a238c09e519aeb30faf74f027ac5d1e0a309c3b326888e031d7",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.0.6"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:n3M50qfWfRSpQV9Pwcvuse03pEizqrmYEryxKky4so4=",
+    "zh:10de0d8af02f2e578101688fd334da3849f56ea91b0d9bd5b1f7a243417fdda8",
+    "zh:37fc01f8b2bc9d5b055dc3e78bfd1beb7c42cfb776a4c81106e19c8911366297",
+    "zh:4578ca03d1dd0b7f572d96bd03f744be24c726bfd282173d54b100fd221608bb",
+    "zh:6c475491d1250050765a91a493ef330adc24689e8837a0f07da5a0e1269e11c1",
+    "zh:81bde94d53cdababa5b376bbc6947668be4c45ab655de7aa2e8e4736dfd52509",
+    "zh:abdce260840b7b050c4e401d4f75c7a199fafe58a8b213947a258f75ac18b3e8",
+    "zh:b754cebfc5184873840f16a642a7c9ef78c34dc246a8ae29e056c79939963c7a",
+    "zh:c928b66086078f9917aef0eec15982f2e337914c5c4dbc31dd4741403db7eb18",
+    "zh:cded27bee5f24de6f2ee0cfd1df46a7f88e84aaffc2ecbf3ff7094160f193d50",
+    "zh:d65eb3867e8f69aaf1b8bb53bd637c99c6b649ba3db16ded50fa9a01076d1a27",
+    "zh:ecb0c8b528c7a619fa71852bb3fb5c151d47576c5aab2bf3af4db52588722eeb",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "6.5.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:rMuaCjyJo4zR9CKZoB1kCpZ9pZke4rlfd+ea0vCpaVg=",
+    "zh:3088bfd30c51ebfcb7c8d829465ec7b3c19af684cf1aff1ea1111ad3c6421c11",
+    "zh:34f9054b0123f9fa7ab8ebc73591d2cf502f1cc75e7594bde42ce799fcac32b6",
+    "zh:406dc2e63d43a24ac4f1b004e5c60ada3347207ea750bbd51e6199eb7f044f9f",
+    "zh:43e7b6cb7e5062d9b7b7cf4d23f6ea99fb9605fb014fede62cda307051063c05",
+    "zh:6a0923ebcc09cb98c488c11582375d2145ba965d1e6f2f69c077be8e1224020b",
+    "zh:a2331f06b7ed57e83eadb784211067d675826f67cf0ed051c8ab20335d83de9a",
+    "zh:a3f82213c98319f20438bdb92145ce1b0407cd8b8eec9745c036db10deb3d3a2",
+    "zh:b4b8db8537d8e6fb3f05ed875726823e1dc6925c479db8749016e71568ebafc4",
+    "zh:cdcf76f6f6f5c638db540490ab35bb1aacfc27204f1197004da5e950024afc06",
+    "zh:de36cea60efe2b74cec958f88ec5c39d467ad9443c9c9e311424c3db229c4e78",
+    "zh:dfb8949edc6722da66c78a19ccb1b81ac855439a28ca3badfdac5c10bbf2190d",
+    "zh:e1a81734cc81f4f51dd11ca8a62b420f68e72d00835ed54f84d71bd56d19f37f",
+    "zh:ec0d51640c3e3cf933c73d0ed79ba8b395d1b94fed8117a6438dba872aa5561f",
+    "zh:ec59b7c420a2358e9750e9c6a8a5ef26ccbb8a2cae417e115e86d63520759ea5",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}
+
+provider "registry.terraform.io/newrelic/newrelic" {
+  version     = "3.57.0"
+  constraints = "~> 3.3"
+  hashes = [
+    "h1:tkGat2AhylI5euYORLYAju7SZG/1SVqGZcR/0RCJEsA=",
+    "zh:0b5180e0b0ed2b0d7a7b2340ae465121a1fa10313a7783bdbc904b3596f7c725",
+    "zh:1ee6458b5e9ec51b24789ce28c68e006f0e365c558073e634a3e545357501fa7",
+    "zh:20ea548ea31ee761c9a936c6648c62c506d76bcf1ebf937ff5cdca8034fd8cdb",
+    "zh:2c78d070f3c5eea171c1ad1520ce3de08cf6405dcda1b3ebd74603039a3406cb",
+    "zh:2f5ce3ac9708ffa1077d4b3de527d598be16aaeb562108c9cbeadbc5af025fc2",
+    "zh:54d8f25402bd95e0efd6e10fab4fea17c6e3915e5b9ca0b6139b93a3aec21def",
+    "zh:6ca0f572602415bda07749c205160c1ac0bd9d764e76b44cbc1323b80932a08c",
+    "zh:8cbe877f0a7378b162dea8ca0512ecd7860e7d9b97837011ca9685e4dea1d27e",
+    "zh:a37430b41e8d72cfdcec6255046e2a1b7359b541a7e2f4ddac24969002cdc653",
+    "zh:c8501d4ef9e7fd6cc02576e4a141fef4ac3ef7ec7876008ccf0c17160104657f",
+    "zh:db15cb9efd59f0f7e984f1c067a0c38f6324c528f33817ddb0b30aa7467673a6",
+    "zh:f30c2d2606cb57ee615cc725b1b18791c8faf73be3beaca1472dba9602ef226c",
+    "zh:f57ef3f4840557c996e0493ad0d373e87c457d434b0801b98b1cb462e56eb502",
+    "zh:f68f4f94e4a634af3d505171fb4ca63a657e97ac1e4dd1097e4683c7e5d5e40d",
+    "zh:f74440e5c479b4f8b3e0c9cfed5ee4c9a71b8d5a075724fadc82f05d8c86880e",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+    "zh:fc9aa2d568d606d0d2f95001e2a9d66febe391991cb654970a2cf8bf7fac72c4",
+    "zh:fefd31ef8ec63d722b5af6f629ac45ea6e23ad3e58f620b328022082e5b40ffd",
+  ]
+}


### PR DESCRIPTION
# Summary | Résumé

Adding the notification-terraform user as an admin in EKS now that we control aws-auth with it. This should let us get rid of the role assumption of notification-manifests in the workflows (to be tested) in staging)

Also removing the role name fetching from an external command in github pipelines and adding it as a data source in Terraform.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/504

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

TF Apply in staging works, verify that the configmap looks good

```
kubectl get cm aws-auth -o yaml -n kube-system
```

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
