### PR TITLE
change rds cpu critical to warning and increase evaluation period

### DIFF
--- a/aws/rds/cloudwatch_alarms.tf
+++ b/aws/rds/cloudwatch_alarms.tf
@@ -58,9 +58,9 @@ resource "aws_cloudwatch_metric_alarm" "high-db-cpu-warning" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "high-db-cpu-critical" {
+resource "aws_cloudwatch_metric_alarm" "very-high-db-cpu-warning" {
   count               = var.rds_instance_count
-  alarm_name          = "high-db-cpu-critical-instance-${count.index}"
+  alarm_name          = "very-high-db-cpu-warning-instance-${count.index}"
   alarm_description   = "CPU usage of the RDS instance > 95%"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
@@ -69,7 +69,7 @@ resource "aws_cloudwatch_metric_alarm" "high-db-cpu-critical" {
   period              = 60
   statistic           = "Average"
   threshold           = 95
-  alarm_actions       = [var.sns_alert_critical_arn]
+  alarm_actions       = [var.sns_alert_warning_arn]
   treat_missing_data  = "notBreaching"
   dimensions = {
     DBInstanceIdentifier = aws_rds_cluster_instance.notification-canada-ca-instances[count.index].identifier

--- a/aws/rds/cloudwatch_alarms.tf
+++ b/aws/rds/cloudwatch_alarms.tf
@@ -43,9 +43,10 @@ resource "aws_cloudwatch_metric_alarm" "high-dbload-critical" {
 resource "aws_cloudwatch_metric_alarm" "high-db-cpu-warning" {
   count               = var.rds_instance_count
   alarm_name          = "high-db-cpu-warning-instance-${count.index}"
-  alarm_description   = "CPU usage of the RDS instance > 80%"
+  alarm_description   = "CPU usage of the RDS instance > 80% for 5 minutes"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 1
+  evaluation_periods  = 5
+  datapoints_to_alarm = 5
   metric_name         = "CPUUtilization"
   namespace           = "AWS/RDS"
   period              = 60
@@ -61,9 +62,10 @@ resource "aws_cloudwatch_metric_alarm" "high-db-cpu-warning" {
 resource "aws_cloudwatch_metric_alarm" "very-high-db-cpu-warning" {
   count               = var.rds_instance_count
   alarm_name          = "very-high-db-cpu-warning-instance-${count.index}"
-  alarm_description   = "CPU usage of the RDS instance > 95%"
+  alarm_description   = "CPU usage of the RDS instance > 95% for 5 minutes"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 1
+  evaluation_periods  = 5
+  datapoints_to_alarm = 5
   metric_name         = "CPUUtilization"
   namespace           = "AWS/RDS"
   period              = 60


### PR DESCRIPTION
# Summary | Résumé

This alarm went off yesterday evening and the system stayed solid. We can change this to a warning so that if other badness is happening we will still be aware of the RDS cpu load.

We also change this and the other RDS cpu alarm to require the load to be above the threshold for 5 minutes in a row

## Test instructions | Instructions pour tester la modification

View in staging / prod

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
