### PR TITLE
remove the aws-auth moved block

### DIFF
--- a/aws/aws-auth/aws-auth.tf
+++ b/aws/aws-auth/aws-auth.tf
@@ -3,12 +3,6 @@ provider "kubernetes" {
   config_context = var.env
 }
 
-moved {
-  from = module.eks[0]
-  to   = module.eks
-}
-
-
 data "aws_caller_identity" "current" {}
 
 data "external" "aws_role_name" {


### PR DESCRIPTION
# Summary | Résumé

Removing the moved block for aws-auth since it's now been moved in staging. 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/504

## Test instructions | Instructions pour tester la modification

TF Plan should show no changes.

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
