### PR TITLE
chore: fix metric filters for system status alarms

### DIFF
--- a/aws/system_status/cloudwatch_logs.tf
+++ b/aws/system_status/cloudwatch_logs.tf
@@ -29,7 +29,7 @@ resource "aws_cloudwatch_log_metric_filter" "system_status-500-errors-api" {
 resource "aws_cloudwatch_log_metric_filter" "system_status_email_down" {
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "system_status_email_down"
-  pattern        = "'email': 'down'"
+  pattern        = "\\'email\\': \\'down\\'"
   log_group_name = "/aws/lambda/${module.system_status.function_name}"
 
   metric_transformation {
@@ -42,7 +42,7 @@ resource "aws_cloudwatch_log_metric_filter" "system_status_email_down" {
 resource "aws_cloudwatch_log_metric_filter" "system_status_email_degraded" {
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "system_status_email_degraded"
-  pattern        = "'email': 'degraded'"
+  pattern        = "\\'email\\': \\'degraded\\'"
   log_group_name = "/aws/lambda/${module.system_status.function_name}"
 
   metric_transformation {
@@ -55,7 +55,7 @@ resource "aws_cloudwatch_log_metric_filter" "system_status_email_degraded" {
 resource "aws_cloudwatch_log_metric_filter" "system_status_sms_down" {
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "system_status_sms_down"
-  pattern        = "'sms': 'down'"
+  pattern        = "\\'sms\\': \\'down\\'"
   log_group_name = "/aws/lambda/${module.system_status.function_name}"
 
   metric_transformation {
@@ -68,7 +68,7 @@ resource "aws_cloudwatch_log_metric_filter" "system_status_sms_down" {
 resource "aws_cloudwatch_log_metric_filter" "system_status_sms_degraded" {
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "system_status_sms_degraded"
-  pattern        = "'sms': 'degraded'"
+  pattern        = "\\'sms\\': \\'degraded\\'"
   log_group_name = "/aws/lambda/${module.system_status.function_name}"
 
   metric_transformation {


### PR DESCRIPTION
# Summary | Résumé

_TODO: 1-3 sentence description of the changed you're proposing._

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1
* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/1

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
