### PR TITLE
use new celery pod names in alarms and dashboards

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -202,9 +202,9 @@ resource "aws_cloudwatch_metric_alarm" "api-pods-high-cpu-warning" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "celery-primary-pods-high-cpu-warning" {
+resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-static-pods-high-cpu-warning" {
   count                     = var.cloudwatch_enabled ? 1 : 0
-  alarm_name                = "celery-primary-pods-high-cpu-warning"
+  alarm_name                = "celery-core-tasks-static-pods-high-cpu-warning"
   alarm_description         = "Average CPU of Primary Celery pods >=50% during 10 minutes"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "2"
@@ -218,14 +218,14 @@ resource "aws_cloudwatch_metric_alarm" "celery-primary-pods-high-cpu-warning" {
   treat_missing_data        = "missing"
   dimensions = {
     Namespace   = "notification-canada-ca"
-    Service     = "notify-celery-primary"
+    Service     = "notify-celery-core-tasks-static"
     ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "celery-scalable-pods-high-cpu-warning" {
+resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-scalable-pods-high-cpu-warning" {
   count                     = var.cloudwatch_enabled ? 1 : 0
-  alarm_name                = "celery-scalable-pods-high-cpu-warning"
+  alarm_name                = "celery-core-tasks-scalable-pods-high-cpu-warning"
   alarm_description         = "Average CPU of Scalable Celery pods >=50% during 10 minutes"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "2"
@@ -239,15 +239,15 @@ resource "aws_cloudwatch_metric_alarm" "celery-scalable-pods-high-cpu-warning" {
   treat_missing_data        = "missing"
   dimensions = {
     Namespace   = "notification-canada-ca"
-    Service     = "notify-celery-scalable"
+    Service     = "notify-celery-core-tasks-scalable"
     ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "celery-sms-pods-high-cpu-warning" {
+resource "aws_cloudwatch_metric_alarm" "celery-sms-dedicated-static-pods-high-cpu-warning" {
   count                     = var.cloudwatch_enabled ? 1 : 0
-  alarm_name                = "celery-sms-pods-high-cpu-warning"
-  alarm_description         = "Average CPU of celery-sms pods >=50% during 10 minutes"
+  alarm_name                = "celery-sms-dedicated-static-pods-high-cpu-warning"
+  alarm_description         = "Average CPU of celery-sms-dedicated-static pods >=50% during 10 minutes"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "2"
   metric_name               = "pod_cpu_utilization"
@@ -260,7 +260,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-sms-pods-high-cpu-warning" {
   treat_missing_data        = "missing"
   dimensions = {
     Namespace   = "notification-canada-ca"
-    Service     = "notify-celery-sms"
+    Service     = "notify-celery-sms-dedicated-static"
     ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
   }
 }
@@ -308,9 +308,9 @@ resource "aws_cloudwatch_metric_alarm" "api-pods-high-memory-warning" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "celery-primary-pods-high-memory-warning" {
+resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-static-pods-high-memory-warning" {
   count                     = var.cloudwatch_enabled ? 1 : 0
-  alarm_name                = "celery-primary-pods-high-memory-warning"
+  alarm_name                = "celery-core-tasks-static-pods-high-memory-warning"
   alarm_description         = "Average memory of Primary Celery pods >=50% during 10 minutes"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "2"
@@ -324,15 +324,15 @@ resource "aws_cloudwatch_metric_alarm" "celery-primary-pods-high-memory-warning"
   treat_missing_data        = "missing"
   dimensions = {
     Namespace   = "notification-canada-ca"
-    Service     = "notify-celery-primary"
+    Service     = "notify-celery-core-tasks-static"
     ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "celery-sms-pods-high-memory-warning" {
+resource "aws_cloudwatch_metric_alarm" "celery-sms-dedicated-static-pods-high-memory-warning" {
   count                     = var.cloudwatch_enabled ? 1 : 0
-  alarm_name                = "celery-sms-pods-high-memory-warning"
-  alarm_description         = "Average memory of celery-sms >=50% during 10 minutes"
+  alarm_name                = "celery-sms-dedicated-static-pods-high-memory-warning"
+  alarm_description         = "Average memory of celery-sms-dedicated-static >=50% during 10 minutes"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "2"
   metric_name               = "pod_memory_utilization"
@@ -345,7 +345,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-sms-pods-high-memory-warning" {
   treat_missing_data        = "missing"
   dimensions = {
     Namespace   = "notification-canada-ca"
-    Service     = "notify-celery-sms"
+    Service     = "notify-celery-sms-dedicated-static"
     ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
   }
 }
@@ -456,9 +456,9 @@ resource "aws_cloudwatch_metric_alarm" "kubernetes-failed-nodes" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "celery-primary-replicas-unavailable" {
+resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-static-replicas-unavailable" {
   count               = var.cloudwatch_enabled ? 1 : 0
-  alarm_name          = "celery-primary-replicas-unavailable"
+  alarm_name          = "celery-core-tasks-static-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
   alarm_description   = "Celery Primary Replicas Unavailable"
@@ -478,16 +478,16 @@ resource "aws_cloudwatch_metric_alarm" "celery-primary-replicas-unavailable" {
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace
-        deployment  = "notify-celery-primary"
+        deployment  = "notify-celery-core-tasks-static"
       }
     }
   }
 }
 
 
-resource "aws_cloudwatch_metric_alarm" "celery-scalable-replicas-unavailable" {
+resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-scalable-replicas-unavailable" {
   count               = var.cloudwatch_enabled ? 1 : 0
-  alarm_name          = "celery-scalable-replicas-unavailable"
+  alarm_name          = "celery-core-tasks-scalable-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 3
   alarm_description   = "Celery Scalable Replicas Unavailable"
@@ -507,7 +507,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-scalable-replicas-unavailable" {
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace
-        deployment  = "notify-celery-scalable"
+        deployment  = "notify-celery-core-tasks-scalable"
       }
     }
   }
@@ -541,9 +541,9 @@ resource "aws_cloudwatch_metric_alarm" "celery-beat-replicas-unavailable" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "celery-sms-replicas-unavailable" {
+resource "aws_cloudwatch_metric_alarm" "celery-sms-dedicated-static-replicas-unavailable" {
   count               = var.cloudwatch_enabled ? 1 : 0
-  alarm_name          = "celery-sms-replicas-unavailable"
+  alarm_name          = "celery-sms-dedicated-static-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
   alarm_description   = "Celery SMS Replicas Unavailable"
@@ -563,15 +563,15 @@ resource "aws_cloudwatch_metric_alarm" "celery-sms-replicas-unavailable" {
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace
-        deployment  = "notify-celery-sms"
+        deployment  = "notify-celery-sms-dedicated-static"
       }
     }
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "celery-email-send-primary-replicas-unavailable" {
+resource "aws_cloudwatch_metric_alarm" "celery-email-send-static-replicas-unavailable" {
   count               = var.cloudwatch_enabled ? 1 : 0
-  alarm_name          = "celery-email-send-primary-replicas-unavailable"
+  alarm_name          = "celery-email-send-static-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
   alarm_description   = "Celery Email Send Primary Replicas Unavailable"
@@ -591,7 +591,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-email-send-primary-replicas-unava
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace
-        deployment  = "notify-celery-email-send-primary"
+        deployment  = "notify-celery-email-send-static"
       }
     }
   }
@@ -626,9 +626,9 @@ resource "aws_cloudwatch_metric_alarm" "celery-email-send-scalable-replicas-unav
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "celery-sms-send-primary-replicas-unavailable" {
+resource "aws_cloudwatch_metric_alarm" "celery-sms-send-static-replicas-unavailable" {
   count               = var.cloudwatch_enabled ? 1 : 0
-  alarm_name          = "celery-sms-send-primary-replicas-unavailable"
+  alarm_name          = "celery-sms-send-static-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
   alarm_description   = "Celery SMS Send Primary Replicas Unavailable"
@@ -648,7 +648,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-sms-send-primary-replicas-unavail
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace
-        deployment  = "notify-celery-sms-send-primary"
+        deployment  = "notify-celery-sms-send-static"
       }
     }
   }

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -205,7 +205,7 @@ resource "aws_cloudwatch_metric_alarm" "api-pods-high-cpu-warning" {
 resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-static-pods-high-cpu-warning" {
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "celery-core-tasks-static-pods-high-cpu-warning"
-  alarm_description         = "Average CPU of Primary Celery pods >=50% during 10 minutes"
+  alarm_description         = "Average CPU of celery-core-tasks-static pods >=50% during 10 minutes"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "2"
   metric_name               = "pod_cpu_utilization"
@@ -226,7 +226,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-static-pods-high-cpu-w
 resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-scalable-pods-high-cpu-warning" {
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "celery-core-tasks-scalable-pods-high-cpu-warning"
-  alarm_description         = "Average CPU of Scalable Celery pods >=50% during 10 minutes"
+  alarm_description         = "Average CPU of celery-core-tasks-scalable pods >=50% during 10 minutes"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "2"
   metric_name               = "pod_cpu_utilization"
@@ -311,7 +311,7 @@ resource "aws_cloudwatch_metric_alarm" "api-pods-high-memory-warning" {
 resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-static-pods-high-memory-warning" {
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "celery-core-tasks-static-pods-high-memory-warning"
-  alarm_description         = "Average memory of Primary Celery pods >=50% during 10 minutes"
+  alarm_description         = "Average memory of celery-core-tasks-static pods >=50% during 10 minutes"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "2"
   metric_name               = "pod_memory_utilization"
@@ -461,7 +461,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-static-replicas-unavai
   alarm_name          = "celery-core-tasks-static-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
-  alarm_description   = "Celery Primary Replicas Unavailable"
+  alarm_description   = "Celery Core Tasks Static Replicas Unavailable"
   #Setting to warn until we verify that it is working as expected
   alarm_actions      = [var.sns_alert_warning_arn]
   treat_missing_data = "breaching"
@@ -490,7 +490,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-scalable-replicas-unav
   alarm_name          = "celery-core-tasks-scalable-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 3
-  alarm_description   = "Celery Scalable Replicas Unavailable"
+  alarm_description   = "Celery Core Tasks Scalable Replicas Unavailable"
   #Setting to warn until we verify that it is working as expected
   alarm_actions      = [var.sns_alert_warning_arn]
   treat_missing_data = "breaching"
@@ -546,7 +546,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-sms-dedicated-static-replicas-una
   alarm_name          = "celery-sms-dedicated-static-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
-  alarm_description   = "Celery SMS Replicas Unavailable"
+  alarm_description   = "Celery SMS Dedicated Static Replicas Unavailable"
   #Setting to warn until we verify that it is working as expected
   alarm_actions      = [var.sns_alert_warning_arn]
   treat_missing_data = "breaching"
@@ -574,7 +574,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-email-send-static-replicas-unavai
   alarm_name          = "celery-email-send-static-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
-  alarm_description   = "Celery Email Send Primary Replicas Unavailable"
+  alarm_description   = "Celery Email Send Static Replicas Unavailable"
   #Setting to warn until we verify that it is working as expected
   alarm_actions      = [var.sns_alert_warning_arn]
   treat_missing_data = "breaching"
@@ -631,7 +631,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-sms-send-static-replicas-unavaila
   alarm_name          = "celery-sms-send-static-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 2
-  alarm_description   = "Celery SMS Send Primary Replicas Unavailable"
+  alarm_description   = "Celery SMS Send Static Replicas Unavailable"
   #Setting to warn until we verify that it is working as expected
   alarm_actions      = [var.sns_alert_warning_arn]
   treat_missing_data = "breaching"

--- a/aws/eks/dashboards.tf
+++ b/aws/eks/dashboards.tf
@@ -12,7 +12,7 @@ resource "aws_cloudwatch_dashboard" "notify_system" {
             "type": "metric",
             "properties": {
                 "metrics": [
-                    [ "ContainerInsights/Prometheus", "kube_deployment_status_replicas_available", "namespace", "notification-canada-ca", "ClusterName", "${aws_eks_cluster.notification-canada-ca-eks-cluster.name}", "deployment", "${local.celery_name}-email-send-primary", { "region": "${var.region}", "label": "${local.celery_name}-email-send-primary" } ],
+                    [ "ContainerInsights/Prometheus", "kube_deployment_status_replicas_available", "namespace", "notification-canada-ca", "ClusterName", "${aws_eks_cluster.notification-canada-ca-eks-cluster.name}", "deployment", "${local.celery_name}-email-send-static", { "region": "${var.region}", "label": "${local.celery_name}-email-send-static" } ],
                     [ "ContainerInsights/Prometheus", "kube_deployment_status_replicas_available", "namespace", "notification-canada-ca", "ClusterName", "${aws_eks_cluster.notification-canada-ca-eks-cluster.name}", "deployment", "${local.celery_name}-email-send-scalable", { "region": "${var.region}", "label": "${local.celery_name}-email-send-scalable" } ]
                 ],
                 "sparkline": true,
@@ -363,7 +363,7 @@ resource "aws_cloudwatch_dashboard" "notify_system" {
             "type": "metric",
             "properties": {
                 "metrics": [
-                    [ "ContainerInsights/Prometheus", "kube_deployment_status_replicas_available", "namespace", "notification-canada-ca", "ClusterName", "${aws_eks_cluster.notification-canada-ca-eks-cluster.name}", "deployment", "${local.celery_name}-sms-send-primary", { "region": "${var.region}", "label": "${local.celery_name}-sms-send-primary" } ],
+                    [ "ContainerInsights/Prometheus", "kube_deployment_status_replicas_available", "namespace", "notification-canada-ca", "ClusterName", "${aws_eks_cluster.notification-canada-ca-eks-cluster.name}", "deployment", "${local.celery_name}-sms-send-static", { "region": "${var.region}", "label": "${local.celery_name}-sms-send-static" } ],
                     [ "...", "${local.celery_name}-sms-send-scalable", { "region": "${var.region}", "label": "${local.celery_name}-sms-send-scalable" } ]
                 ],
                 "sparkline": true,

--- a/aws/pinpoint_to_sqs_sms_callbacks/dashboards.tf
+++ b/aws/pinpoint_to_sqs_sms_callbacks/dashboards.tf
@@ -595,7 +595,7 @@ resource "aws_cloudwatch_dashboard" "sms-send-rate" {
             "type": "metric",
             "properties": {
                 "metrics": [
-                    [ "ContainerInsights/Prometheus", "kube_deployment_status_replicas_available", "namespace", "notification-canada-ca", "ClusterName", "notification-canada-ca-${var.env}-eks-cluster", "deployment", "${local.celery_name}-sms-send-primary", { "region": "${var.region}", "label": "${local.celery_name}-sms-send-primary" } ],
+                    [ "ContainerInsights/Prometheus", "kube_deployment_status_replicas_available", "namespace", "notification-canada-ca", "ClusterName", "notification-canada-ca-${var.env}-eks-cluster", "deployment", "${local.celery_name}-sms-send-static", { "region": "${var.region}", "label": "${local.celery_name}-sms-send-static" } ],
                     [ "ContainerInsights/Prometheus", "kube_deployment_status_replicas_available", "namespace", "notification-canada-ca", "ClusterName", "notification-canada-ca-${var.env}-eks-cluster", "deployment", "${local.celery_name}-sms-send-scalable", { "region": "${var.region}", "label": "${local.celery_name}-sms-send-scalable" } ]
                 ],
                 "sparkline": true,


### PR DESCRIPTION
# Summary | Résumé

Use the new celery pod names (in alarms and dashboards) that were changed in https://github.com/cds-snc/notification-manifests/pull/3564

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/543

## Test instructions | Instructions pour tester la modification

view alarms and dashboards in staging

## Release Instructions | Instructions pour le déploiement

none.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
