### PR TITLE
removing manifests credential assumption on aws auth

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -347,14 +347,7 @@ jobs:
         with:
           install-kubectl: yes
           install-helm: yes       
-          helmfile-version: "v0.151.0"
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@master
-        with:
-          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-manifests-apply
-          role-session-name: NotifyTerraformApply
-          aws-region: "ca-central-1"      
+          helmfile-version: "v0.151.0"  
           
       - name: Connect to VPN
         uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5" # v3.1.0

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -353,13 +353,6 @@ jobs:
           install-kubectl: yes
           install-helm: yes       
           helmfile-version: "v0.151.0"
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@master
-        with:
-          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-manifests-apply
-          role-session-name: NotifyTerraformApply
-          aws-region: "ca-central-1"      
           
       - name: Connect to VPN
         uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5" # v3.1.0

--- a/.github/workflows/terragrunt_create_dev_environment.yml
+++ b/.github/workflows/terragrunt_create_dev_environment.yml
@@ -385,14 +385,7 @@ jobs:
         with:
           install-kubectl: yes
           install-helm: yes       
-          helmfile-version: "v0.151.0"
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@master
-        with:
-          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-terraform-apply
-          role-session-name: NotifyTerraformApply
-          aws-region: "ca-central-1"      
+          helmfile-version: "v0.151.0"   
 
       - name: Connect to VPN
         uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5" # v3.1.0

--- a/.github/workflows/terragrunt_plan_production.yml
+++ b/.github/workflows/terragrunt_plan_production.yml
@@ -341,14 +341,7 @@ jobs:
         uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5" # v3.1.0
         with:
           config_file: /var/tmp/${{env.ENVIRONMENT}}.ovpn
-          echo_config: false       
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@master
-        with:
-          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-manifests-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"              
+          echo_config: false            
 
       - name: Configure kubeconfig
         run: |

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -485,14 +485,7 @@ jobs:
         uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5" # v3.1.0
         with:
           config_file: /var/tmp/${{env.ENVIRONMENT}}.ovpn
-          echo_config: false       
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@master
-        with:
-          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-manifests-apply
-          role-session-name: NotifyTerraformPlan
-          aws-region: "ca-central-1"              
+          echo_config: false             
 
       - name: Configure kubeconfig
         run: |


### PR DESCRIPTION
# Summary | Résumé

Now that terraform is managing aws-auth, we don't need to assume the terraform-manifests-apply role in order to administer the cluster. We can remove the credential assumptions.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/504

## Test instructions | Instructions pour tester la modification

Verify TF plan and apply works in workflows

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
