### PR TITLE
default pool for aws pinpoint

### DIFF
--- a/aws/pinpoint_to_sqs_sms_callbacks/helper_scripts/getDefaultPoolId.sh
+++ b/aws/pinpoint_to_sqs_sms_callbacks/helper_scripts/getDefaultPoolId.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This is a dirty hack to get the ARN of the PCA so that we can import it when creating a new environment.
+# This is a dirty hack to get the pool id so that we can import it when creating a new environment.
 # Terraform external datasources require a very basic JSON output, so we're using jq to format the output.
 poolArns=$(aws pinpoint-sms-voice-v2 describe-pools --output json | jq -r '.Pools[].PoolArn')
 defaultPoolExists=false

--- a/aws/pinpoint_to_sqs_sms_callbacks/helper_scripts/getDefaultPoolId.sh
+++ b/aws/pinpoint_to_sqs_sms_callbacks/helper_scripts/getDefaultPoolId.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# This is a dirty hack to get the ARN of the PCA so that we can import it when creating a new environment.
+# Terraform external datasources require a very basic JSON output, so we're using jq to format the output.
+poolArns=$(aws pinpoint-sms-voice-v2 describe-pools --output json | jq -r '.Pools[].PoolArn')
+defaultPoolExists=false
+for poolArn in $poolArns; do
+    isDefault=$(aws pinpoint-sms-voice-v2 list-tags-for-resource --resource-arn $poolArn | jq -r '.Tags[].Value' | grep 'default-pool' | wc -l)
+    if [ $isDefault == 1 ]; then
+        poolId=$(aws pinpoint-sms-voice-v2 describe-pools --query "Pools[?PoolArn=='"$poolArn"'].PoolId" --output text)
+    fi
+done
+
+jq --null-input \
+  --arg poolId "$poolId" \
+  '{"poolId": $poolId}'
+  

--- a/aws/pinpoint_to_sqs_sms_callbacks/helper_scripts/getShortCodePoolId.sh
+++ b/aws/pinpoint_to_sqs_sms_callbacks/helper_scripts/getShortCodePoolId.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# This is a dirty hack to get the pool id so that we can import it when creating a new environment.
+# Terraform external datasources require a very basic JSON output, so we're using jq to format the output.
+poolArns=$(aws pinpoint-sms-voice-v2 describe-pools --output json | jq -r '.Pools[].PoolArn')
+defaultPoolExists=false
+for poolArn in $poolArns; do
+    isShort=$(aws pinpoint-sms-voice-v2 list-tags-for-resource --resource-arn $poolArn | jq -r '.Tags[].Value' | grep "shortcode-pool" | wc -l)
+    if [ $isShort == 1 ]; then
+        poolId=$(aws pinpoint-sms-voice-v2 describe-pools --query "Pools[?PoolArn=='"$poolArn"'].PoolId" --output text)
+    fi
+done
+
+jq --null-input \
+  --arg poolId "$poolId" \
+  '{"poolId": $poolId}'
+  

--- a/aws/pinpoint_to_sqs_sms_callbacks/pools.tf
+++ b/aws/pinpoint_to_sqs_sms_callbacks/pools.tf
@@ -7,7 +7,7 @@ resource "null_resource" "create_pools" {
 }
 
 data "external" "get_default_pool_id" {
-  # Get the Latest Sentinel Layer version
+  # Get the Default Pool Id
   program = ["helper_scripts/getDefaultPoolId.sh"]
 
 }
@@ -20,4 +20,20 @@ resource "aws_secretsmanager_secret" "pinpoint_default_pool_id" {
 resource "aws_secretsmanager_secret_version" "pinpoint_default_pool_id" {
   secret_id     = aws_secretsmanager_secret.pinpoint_default_pool_id.id
   secret_string = data.external.get_default_pool_id.result.poolId
+}
+
+data "external" "get_short_code_pool_id" {
+  # Get the short code pool id
+  program = ["helper_scripts/getShortCodePoolId.sh"]
+
+}
+
+resource "aws_secretsmanager_secret" "pinpoint_shortcode_pool_id" {
+  name                    = "PINPOINT_SHORT_CODE_POOL_ID"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "pinpoint_shortcode_pool_id" {
+  secret_id     = aws_secretsmanager_secret.pinpoint_shortcode_pool_id.id
+  secret_string = data.external.get_short_code_pool_id.result.poolId
 }

--- a/aws/pinpoint_to_sqs_sms_callbacks/pools.tf
+++ b/aws/pinpoint_to_sqs_sms_callbacks/pools.tf
@@ -5,3 +5,19 @@ resource "null_resource" "create_pools" {
     command = "./create_pinpoint_pools.sh ${aws_iam_role.pinpoint_logs.arn} ${aws_cloudwatch_log_group.pinpoint_deliveries.arn} ${aws_cloudwatch_log_group.pinpoint_deliveries_failures.arn}"
   }
 }
+
+data "external" "get_default_pool_id" {
+  # Get the Latest Sentinel Layer version
+  program = ["helper_scripts/getDefaultPoolId.sh"]
+
+}
+
+resource "aws_secretsmanager_secret" "pinpoint_default_pool_id" {
+  name                    = "PINPOINT_DEFAULT_POOL_ID"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "pinpoint_default_pool_id" {
+  secret_id     = aws_secretsmanager_secret.pinpoint_default_pool_id.id
+  secret_string = data.external.get_default_pool_id.result.poolId
+}


### PR DESCRIPTION
# Summary | Résumé

Sending the default pinpoint pool id to aws secrets manager to be read by manifests

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/484

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
