### PR TITLE
Changing degraded threshold to 5

### DIFF
--- a/aws/system_status/cloudwatch_alarms.tf
+++ b/aws/system_status/cloudwatch_alarms.tf
@@ -64,7 +64,7 @@ resource "aws_cloudwatch_metric_alarm" "system_status_email_degraded_warning" {
   namespace           = aws_cloudwatch_log_metric_filter.system_status_email_degraded[0].metric_transformation[0].namespace
   period              = 600 # 10 minutes
   statistic           = "Sum"
-  threshold           = 2
+  threshold           = 5
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_warning_arn]
   ok_actions          = [var.sns_alert_warning_arn]
@@ -98,7 +98,7 @@ resource "aws_cloudwatch_metric_alarm" "system_status_sms_degraded_warning" {
   namespace           = aws_cloudwatch_log_metric_filter.system_status_sms_degraded[0].metric_transformation[0].namespace
   period              = 600 # 10 minutes
   statistic           = "Sum"
-  threshold           = 2
+  threshold           = 5
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_warning_arn]
   ok_actions          = [var.sns_alert_warning_arn]

--- a/aws/system_status/cloudwatch_alarms.tf
+++ b/aws/system_status/cloudwatch_alarms.tf
@@ -62,9 +62,9 @@ resource "aws_cloudwatch_metric_alarm" "system_status_email_degraded_warning" {
   evaluation_periods  = 1
   metric_name         = aws_cloudwatch_log_metric_filter.system_status_email_degraded[0].metric_transformation[0].name
   namespace           = aws_cloudwatch_log_metric_filter.system_status_email_degraded[0].metric_transformation[0].namespace
-  period              = 600 # 10 minutes
+  period              = 1800 # 30 minutes
   statistic           = "Sum"
-  threshold           = 5
+  threshold           = 3 # 3 out of 5 metric updates in 30 minutes
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_warning_arn]
   ok_actions          = [var.sns_alert_warning_arn]
@@ -96,9 +96,9 @@ resource "aws_cloudwatch_metric_alarm" "system_status_sms_degraded_warning" {
   evaluation_periods  = 1
   metric_name         = aws_cloudwatch_log_metric_filter.system_status_sms_degraded[0].metric_transformation[0].name
   namespace           = aws_cloudwatch_log_metric_filter.system_status_sms_degraded[0].metric_transformation[0].namespace
-  period              = 600 # 10 minutes
+  period              = 1800 # 30 minutes
   statistic           = "Sum"
-  threshold           = 5
+  threshold           = 3 # 3 out of 5 metric updates in 30 minutes
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_warning_arn]
   ok_actions          = [var.sns_alert_warning_arn]

--- a/aws/system_status/cloudwatch_alarms.tf
+++ b/aws/system_status/cloudwatch_alarms.tf
@@ -64,7 +64,7 @@ resource "aws_cloudwatch_metric_alarm" "system_status_email_degraded_warning" {
   namespace           = aws_cloudwatch_log_metric_filter.system_status_email_degraded[0].metric_transformation[0].namespace
   period              = 1800 # 30 minutes
   statistic           = "Sum"
-  threshold           = 3 # 3 out of 5 metric updates in 30 minutes
+  threshold           = 3 # 3 out of 6 metric updates in 30 minutes
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_warning_arn]
   ok_actions          = [var.sns_alert_warning_arn]
@@ -98,7 +98,7 @@ resource "aws_cloudwatch_metric_alarm" "system_status_sms_degraded_warning" {
   namespace           = aws_cloudwatch_log_metric_filter.system_status_sms_degraded[0].metric_transformation[0].namespace
   period              = 1800 # 30 minutes
   statistic           = "Sum"
-  threshold           = 3 # 3 out of 5 metric updates in 30 minutes
+  threshold           = 3 # 3 out of 6 metric updates in 30 minutes
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_warning_arn]
   ok_actions          = [var.sns_alert_warning_arn]


### PR DESCRIPTION
# Summary | Résumé

Set the threshold for sms/email degradation alarms to 3 over a time period of 30 minutes (so > 50%)

## Related Issues | Cartes liées

BE QUIET ALARMS

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
