### PR TITLE
Add a new s3 bucket for reports

### DIFF
--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -597,3 +597,27 @@ resource "aws_s3_bucket_public_access_block" "gc_organisations_bucket" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+resource "aws_s3_bucket" "reports_bucket" {
+  bucket        = "notification-canada-ca-${var.env}-reports"
+  force_destroy = var.force_destroy_s3
+
+  logging {
+    target_prefix = var.env
+    target_bucket = module.csv_bucket_logs.s3_bucket_id
+  }
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+
+}
+
+resource "aws_s3_bucket_public_access_block" "reports_bucket" {
+  bucket = aws_s3_bucket.reports_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -602,6 +602,15 @@ resource "aws_s3_bucket" "reports_bucket" {
   bucket        = "notification-canada-ca-${var.env}-reports"
   force_destroy = var.force_destroy_s3
 
+  lifecycle_rule {
+    id      = "expire"
+    enabled = true
+
+    expiration {
+      days = 3
+    }
+  }
+
   logging {
     target_prefix = var.env
     target_bucket = module.csv_bucket_logs.s3_bucket_id
@@ -610,7 +619,7 @@ resource "aws_s3_bucket" "reports_bucket" {
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
   }
-
+  #tfsec:ignore:AWS077 - Versioning is not enabled
 }
 
 resource "aws_s3_bucket_public_access_block" "reports_bucket" {

--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -619,7 +619,8 @@ resource "aws_s3_bucket" "reports_bucket" {
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
   }
-  #tfsec:ignore:AWS077 - Versioning is not enabled
+  #checkov:skip=CKV_AWS_21:Versioning is not enabled for this bucket
+  #checkov:skip=CKV_AWS_291:Event notifications are not required for this bucket
 }
 
 resource "aws_s3_bucket_public_access_block" "reports_bucket" {

--- a/aws/common/s3.tf
+++ b/aws/common/s3.tf
@@ -620,7 +620,7 @@ resource "aws_s3_bucket" "reports_bucket" {
     CostCenter = "notification-canada-ca-${var.env}"
   }
   #checkov:skip=CKV_AWS_21:Versioning is not enabled for this bucket
-  #checkov:skip=CKV_AWS_291:Event notifications are not required for this bucket
+  #checkov:skip=CKV2_AWS_62:Event notifications are not required for this bucket
 }
 
 resource "aws_s3_bucket_public_access_block" "reports_bucket" {

--- a/aws/lambda-api/secrets_manager.tf
+++ b/aws/lambda-api/secrets_manager.tf
@@ -85,6 +85,7 @@ POSTGRES_SQL=postgresql://${var.app_db_user}:${var.app_db_user_password}@${var.d
 
 REDIS_URL=redis://${var.redis_primary_endpoint_address}
 REDIS_PUBLISH_URL=redis://${var.redis_primary_endpoint_address}
+REPORTS_BUCKET_NAME=notification-canada-ca-${var.env}-reports
 
 CRM_GITHUB_PERSONAL_ACCESS_TOKEN=${var.manifest_crm_github_personal_access_token}
 CRM_ORG_LIST_URL=https://raw.githubusercontent.com/cds-snc/gc-organisations-qa/main/data/all.json
@@ -205,6 +206,7 @@ POSTGRES_SQL=postgresql://${var.app_db_user}:${var.app_db_user_password}@${var.d
 
 REDIS_URL=redis://${var.redis_primary_endpoint_address}
 REDIS_PUBLISH_URL=redis://${var.redis_primary_endpoint_address}
+REPORTS_BUCKET_NAME=notification-canada-ca-${var.env}-reports
 
 CRM_GITHUB_PERSONAL_ACCESS_TOKEN=${var.manifest_crm_github_personal_access_token}
 CRM_ORG_LIST_URL=https://raw.githubusercontent.com/cds-snc/gc-organisations-qa/main/data/all.json


### PR DESCRIPTION
# Summary | Résumé

Add a new s3 bucket to hold report csv files that are requested by users. These will be generated by celery and downloaded by notify users.  

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1806

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
