### PR TITLE
fixing the if statement for delete env timeout

### DIFF
--- a/scripts/deleteEnvironment.sh
+++ b/scripts/deleteEnvironment.sh
@@ -190,9 +190,9 @@ done
 
 END_TIME=$(date +%s.%N)
 
-RUN_TIME=$( echo "$END_TIME - $START_TIME" | bc )
+RUN_TIME=$(printf "%.0f" $(echo "$END_TIME - $START_TIME" | bc))
 
-if [ $RUN_TIME > 3540.0 ]; then
+if [ $RUN_TIME ig 3540 ]; then
     echo "Timing out the job since it's taking longer than an hour to run"
     exit 1
 fi

--- a/scripts/deleteEnvironment.sh
+++ b/scripts/deleteEnvironment.sh
@@ -192,7 +192,7 @@ END_TIME=$(date +%s.%N)
 
 RUN_TIME=$(printf "%.0f" $(echo "$END_TIME - $START_TIME" | bc))
 
-if [ $RUN_TIME ig 3540 ]; then
+if [ $RUN_TIME -gt 3540 ]; then
     echo "Timing out the job since it's taking longer than an hour to run"
     exit 1
 fi


### PR DESCRIPTION
# Summary | Résumé

The syntax on the if statement checking the run time was wrong, causing it to always fail.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/480

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
