### PR TITLE
feat: Platform Data Lake export role in all envs

### DIFF
--- a/aws/rds/iam.tf
+++ b/aws/rds/iam.tf
@@ -111,13 +111,3 @@ moved {
   from = aws_iam_role_policy_attachment.platform_data_lake_export[0]
   to   = aws_iam_role_policy_attachment.platform_data_lake_export
 }
-
-moved {
-  from = data.aws_iam_policy_document.platform_data_lake_export_assume[0]
-  to   = data.aws_iam_policy_document.platform_data_lake_export_assume
-}
-
-moved {
-  from = data.aws_iam_policy_document.platform_data_lake_export[0]
-  to   = data.aws_iam_policy_document.platform_data_lake_export
-}


### PR DESCRIPTION
# Summary
Remove the environment check on the IAM role used to trigger RDS snapshot exports to the data lake.  This will cause the role to be created in all environments.  

Since this is removing the `count` attribute from the resources, `moved` blocks have been added to refactor the Staging TF state.  After this PR merges, these can be removed.

⚠️  Note that this does not have a TF plan because of [a bug with the `cds-snc/terraform-plan` action](https://github.com/cds-snc/terraform-plan/issues/455) that happens if there are only `moved` block changes.


## Related Issues | Cartes liées

* https://github.com/cds-snc/platform-core-services/issues/668

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

1. Confirm that the Staging IAM role is unchanged.
2. Once deployed to Prod, confirm the IAM role has been created and can trigger RDS snapshot exports to S3.

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [x] This PR does not break existing functionality.
* [x] This PR does not violate GCNotify's privacy policies.
* [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [x] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
