### PR TITLE
Karpenter requires new IAM

### DIFF
--- a/aws/eks/iam.tf
+++ b/aws/eks/iam.tf
@@ -287,6 +287,7 @@ resource "aws_iam_role_policy" "karpenter_controller" {
           "iam:GetInstanceProfile",
           "iam:CreateInstanceProfile",
           "iam:TagInstanceProfile",
+          "iam:RemoveRoleFromInstanceProfile",
           "iam:AddRoleToInstanceProfile",
           "ec2:DescribeImages",
           "ec2:RunInstances",


### PR DESCRIPTION
# Summary | Résumé

Upgrading Karpenter to latest, needs a new IAM permission

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/442

## Test instructions | Instructions pour tester la modification

TF Apply, verify karpenter works in staging

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
