### PR TITLE
Remove socket specific warnings

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -129,39 +129,6 @@ resource "aws_cloudwatch_metric_alarm" "logs-10-celery-error-1-minute-critical" 
   ok_actions          = [var.sns_alert_critical_arn]
 }
 
-
-resource "aws_cloudwatch_metric_alarm" "logs-1-socket-error-1-minute-warning" {
-  count               = var.cloudwatch_enabled ? 1 : 0
-  alarm_name          = "logs-1-socket-error-1-minute-warning"
-  alarm_description   = "One socket error in 1 minute"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.socket-error[0].metric_transformation[0].name
-  namespace           = aws_cloudwatch_log_metric_filter.socket-error[0].metric_transformation[0].namespace
-  period              = 60
-  statistic           = "Sum"
-  threshold           = 1
-  treat_missing_data  = "notBreaching"
-  alarm_actions       = [var.sns_alert_warning_arn]
-}
-
-
-resource "aws_cloudwatch_metric_alarm" "logs-10-socket-error-1-minute-warning" {
-  count               = var.cloudwatch_enabled ? 1 : 0
-  alarm_name          = "logs-10-socket-error-1-minute-warning"
-  alarm_description   = "Ten Socket errors in 1 minute"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.socket-error[0].metric_transformation[0].name
-  namespace           = aws_cloudwatch_log_metric_filter.socket-error[0].metric_transformation[0].namespace
-  period              = 60
-  statistic           = "Sum"
-  threshold           = 10
-  treat_missing_data  = "notBreaching"
-  alarm_actions       = [var.sns_alert_warning_arn]
-  ok_actions          = [var.sns_alert_warning_arn]
-}
-
 resource "aws_cloudwatch_metric_alarm" "logs-1-500-error-1-minute-warning" {
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-1-500-error-1-minute-warning"

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -52,24 +52,11 @@ resource "aws_cloudwatch_log_metric_filter" "web-500-errors" {
 resource "aws_cloudwatch_log_metric_filter" "celery-error" {
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "celery-error"
-  pattern        = "\"ERROR/\" ?Worker ?MainProcess -\"Failed to write metrics\" -\"Socket timeout durring send\" -\"Failed to connect to the socket\""
+  pattern        = "%ERROR/.*Worker|ERROR/MainProcess%"
   log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs[0].name
 
   metric_transformation {
     name      = "celery-error"
-    namespace = "LogMetrics"
-    value     = "1"
-  }
-}
-
-resource "aws_cloudwatch_log_metric_filter" "socket-error" {
-  count          = var.cloudwatch_enabled ? 1 : 0
-  name           = "socket-error"
-  pattern        = "%Failed to write metrics to the socket due to socket%"
-  log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs[0].name
-
-  metric_transformation {
-    name      = "socket-error"
     namespace = "LogMetrics"
     value     = "1"
   }


### PR DESCRIPTION
# Summary | Résumé

We put these socket warnings in place when we had several blips of these in the system. We did not have these errors since that day in the past month so I am removing the specific ones we installed as a temporary measure. The risk of not reverting is that we will have legitimate socket errors outside of business hours and we will be unaware of potential networking issues.

Socket errors in the past 5 weeks. The spikes are when we encountered issues first and decided to install these alarms:
![image](https://github.com/user-attachments/assets/6de490a4-1c43-499f-9708-076869f6620d)

## Related Issues | Cartes liées

None, small maintenance item.

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
