### PR TITLE
docker hub secrets

### DIFF
--- a/aws/manifest_secrets/secrets.tf
+++ b/aws/manifest_secrets/secrets.tf
@@ -429,3 +429,24 @@ resource "aws_secretsmanager_secret_version" "manifest_cypress_auth_client_secre
   secret_id     = aws_secretsmanager_secret.manifest_cypress_auth_client_secret.id
   secret_string = var.manifest_cypress_auth_client_secret
 }
+
+resource "aws_secretsmanager_secret" "manifest_docker_hub_username" {
+  name                    = "MANIFEST_DOCKER_HUB_USERNAME"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_docker_hub_username" {
+  secret_id     = aws_secretsmanager_secret.manifest_docker_hub_username.id
+  secret_string = var.manifest_docker_hub_username
+}
+
+resource "aws_secretsmanager_secret" "manifest_docker_hub_pat" {
+  name                    = "MANIFEST_DOCKER_HUB_PAT"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_docker_hub_pat" {
+  secret_id     = aws_secretsmanager_secret.manifest_docker_hub_pat.id
+  secret_string = var.manifest_docker_hub_pat
+}
+

--- a/env/dev/manifest_secrets/.terraform.lock.hcl
+++ b/env/dev/manifest_secrets/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 5.66"
   hashes = [
     "h1:fr252BPFVqsCcVoLMN4PTVacXmrW3pbMlK1ibi/wHiU=",
+    "h1:uz55I4t3Pqy3p+82NZ35mkUA9mZ5yu4pS6beZMI8wpA=",
     "zh:1075825e7311a8d2d233fd453a173910e891b0320e8a7698af44d1f90b02621d",
     "zh:203c5d09a03fcaa946defb8459f01227f2fcda07df768f74777beb328d6751ae",
     "zh:21bc79ccb09bfdeb711a3a5226c6c4a457ac7c4bb781dbda6ade7be38461739f",
@@ -29,6 +30,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   constraints = "~> 4.0"
   hashes = [
     "h1:/sSdjHoiykrPdyBP1JE03V/KDgLXnHZhHcSOYIdDH/A=",
+    "h1:n3M50qfWfRSpQV9Pwcvuse03pEizqrmYEryxKky4so4=",
     "zh:10de0d8af02f2e578101688fd334da3849f56ea91b0d9bd5b1f7a243417fdda8",
     "zh:37fc01f8b2bc9d5b055dc3e78bfd1beb7c42cfb776a4c81106e19c8911366297",
     "zh:4578ca03d1dd0b7f572d96bd03f744be24c726bfd282173d54b100fd221608bb",
@@ -49,6 +51,7 @@ provider "registry.terraform.io/integrations/github" {
   constraints = "~> 6.0"
   hashes = [
     "h1:B1q5+Ub1G3zJa9y474Fg40eo/N04/vOSeaf3dWaCG0I=",
+    "h1:YiGCvjr7R77HGTzw81legWicEHApVTli8O+ooDpLexE=",
     "zh:00f431c2a2510efcb1115442dda5e90815bcb16e1a3301679ade0139fa963d3b",
     "zh:12a862f4317b3cb65682c1b687650cd91eeee99e63774bdcfa8bcfc64bad097b",
     "zh:226d5e09ff27f94cb9336089181d26f85cb30219b863a579597f2e107f37de49",
@@ -71,6 +74,7 @@ provider "registry.terraform.io/newrelic/newrelic" {
   version     = "3.52.1"
   constraints = "~> 3.3"
   hashes = [
+    "h1:Y3+FVaasXEVQDkH9oOLFowhgenFyWEgtqC6gT+o6tqg=",
     "h1:Y6bcpmTzjIhfNsm2quEjHN+BcR/8cABqYNkav7PltVs=",
     "zh:07c0beb3979ed390db5e90a48b0b5971910c59282e6e2a66ea5815a54404bc66",
     "zh:1f9083fed84147da5c911380c1c2ebd5cb5f2f894b5e5cda8a3abd1777752cd6",

--- a/env/variables.tf
+++ b/env/variables.tf
@@ -1056,3 +1056,13 @@ variable "github_manifests_workflow_token" {
   sensitive = true
   default   = "prodonly"
 }
+
+variable "manifest_docker_hub_username" {
+  type      = string
+  sensitive = true
+}
+
+variable "manifest_docker_hub_pat" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
[review]

# Summary | Résumé

This adds the secrets required by manifests to have authentication on docker hub. This fixes an issue where we were running into rate limits.

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

Apply this, then apply the manifests update.

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
