### PR TITLE
fixing some bugs we uncovered while db  migration

### DIFF
--- a/aws/rds/outputs.tf
+++ b/aws/rds/outputs.tf
@@ -18,6 +18,6 @@ output "postgres_cluster_endpoint" {
   sensitive = true
 }
 output "shared_staging_kms_key_id" {
-  value     = aws_kms_key.rds_snapshot[0].arn
+  value     = var.env == "staging" ? aws_kms_key.rds_snapshot[0].arn : ""
   sensitive = true
 }

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -91,6 +91,9 @@ provider "aws" {
 provider "aws" {
   alias  = "dns"
   region = "ca-central-1"
+  assume_role { 
+    role_arn = "arn:aws:iam::${local.secret_inputs.account_id}:role/notification-terraform-apply"
+  }
   assume_role {
     role_arn = "arn:aws:iam::${local.secret_inputs.dns_account_id}:role/notify_prod_dns_manager"
   }


### PR DESCRIPTION
# Summary | Résumé

Two fixes that were uncovered from db migration
1) The output for staging kms key needs to be conditional based on environment
2) Assuming Role chain on DNS.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/496

## Test instructions | Instructions pour tester la modification

TF Apply works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
