### PR TITLE
Base Name String Manipulation for Snapshots

### DIFF
--- a/.github/workflows/refresh_dev_db_snapshot.yml
+++ b/.github/workflows/refresh_dev_db_snapshot.yml
@@ -49,45 +49,47 @@ jobs:
             --query "DBClusterSnapshots | sort_by(@, &SnapshotCreateTime) | [-1].DBClusterSnapshotIdentifier" \
             --output text)
           echo "LATEST_SNAPSHOT=$LATEST_SNAPSHOT" >> $GITHUB_ENV
-          
+          SNAPSHOT_BASE_NAME=$(echo "$SNAPSHOT_NAME" | rev | cut -d':' -f1 | rev)
+          echo "SNAPSHOT_BASE_NAME=$SNAPSHOT_BASE_NAME" >> $GITHUB_ENV
+          echo "Snapshot to be replaced: $SNAPSHOT_BASE_NAME"
           echo "Found latest snapshot: $LATEST_SNAPSHOT for cluster: $CLUSTER_ID"
       
       - name: Delete existing snapshot if exists
         run: |
           SNAPSHOT_EXISTS=$(aws rds describe-db-cluster-snapshots \
-            --db-cluster-snapshot-identifier ${{ env.SNAPSHOT_NAME }} \
+            --db-cluster-snapshot-identifier ${{ env.SNAPSHOT_BASE_NAME }} \
             --query "length(DBClusterSnapshots)" \
             --output text 2>/dev/null || echo "0")
           
           if [ "$SNAPSHOT_EXISTS" != "0" ]; then
-            echo "Deleting existing snapshot '${{ env.SNAPSHOT_NAME }}'..."
+            echo "Deleting existing snapshot '${{ env.SNAPSHOT_BASE_NAME }}'..."
             aws rds delete-db-cluster-snapshot \
-              --db-cluster-snapshot-identifier ${{ env.SNAPSHOT_NAME }}
+              --db-cluster-snapshot-identifier ${{ env.SNAPSHOT_BASE_NAME }}
               
             # Wait for deletion to complete
             echo "Waiting for snapshot deletion to complete..."
             aws rds wait db-cluster-snapshot-deleted \
-              --db-cluster-snapshot-identifier ${{ env.SNAPSHOT_NAME }}
+              --db-cluster-snapshot-identifier ${{ env.SNAPSHOT_BASE_NAME }}
           fi
       
       - name: Copy snapshot with new name
         run: |
-          echo "Creating snapshot copy '${{ env.SNAPSHOT_NAME }}' from '${{ env.LATEST_SNAPSHOT }}'..."
+          echo "Creating snapshot copy '${{ env.SNAPSHOT_BASE_NAME }}' from '${{ env.LATEST_SNAPSHOT }}'..."
           aws rds copy-db-cluster-snapshot \
             --source-db-cluster-snapshot-identifier ${{ env.LATEST_SNAPSHOT }} \
-            --target-db-cluster-snapshot-identifier ${{ env.SNAPSHOT_NAME }} \
+            --target-db-cluster-snapshot-identifier ${{ env.SNAPSHOT_BASE_NAME }} \
             --kms-key-id ${{ secrets.STAGING_AWS_KMS_KEY_ID }} \
             
           # Wait for copy to complete
           echo "Waiting for snapshot copy to complete..."
           aws rds wait db-cluster-snapshot-available \
-            --db-cluster-snapshot-identifier ${{ env.SNAPSHOT_NAME }}
+            --db-cluster-snapshot-identifier ${{ env.SNAPSHOT_BASE_NAME }}
       
       - name: Share snapshot with dev account
         run: |
           echo "Sharing snapshot with dev account..."
           aws rds modify-db-cluster-snapshot-attribute \
-            --db-cluster-snapshot-identifier ${{ env.SNAPSHOT_NAME }} \
+            --db-cluster-snapshot-identifier ${{ env.SNAPSHOT_BASE_NAME }} \
             --attribute-name restore \
             --values-to-add ${{ secrets.DEV_ACCOUNT_ID }}
           


### PR DESCRIPTION
# Summary | Résumé

Keeping the ARN in our secrets file, string manipulation so that our workflow uses the base name as expected.

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/542

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
