### PR TITLE
Create new SQS buffer queue for ses receipt callbacks for batch saving V2

### DIFF
--- a/aws/common/iam.tf
+++ b/aws/common/iam.tf
@@ -129,7 +129,7 @@ resource "aws_iam_role_policy_attachment" "lambda_sqs" {
 
 ##
 # IAM role for a Kinesis Firehose to write AWS WAF ACL logs to the
-# Cloud Based Sensor S3 satellite bucket 
+# Cloud Based Sensor S3 satellite bucket
 ##
 resource "aws_iam_role" "firehose_waf_logs" {
   name               = "FirehoseWafLogs"
@@ -182,6 +182,32 @@ data "aws_iam_policy_document" "firehose_waf_logs" {
     resources = [
       "arn:aws:iam::*:role/aws-service-role/wafv2.amazonaws.com/AWSServiceRoleForWAFV2Logging"
     ]
+  }
+}
+
+resource "aws_sqs_queue_policy" "allow_sns_publish" {
+  queue_url = aws_sqs_queue.ses_receipt_callback_buffer.id
+  policy    = data.aws_iam_policy_document.sns_to_sqs.json
+}
+
+data "aws_iam_policy_document" "sns_to_sqs" {
+  statement {
+    sid    = "AllowSNSPublish"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions   = ["sqs:SendMessage"]
+    resources = [aws_sqs_queue.ses_receipt_callback_buffer.arn]
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = [aws_sns_topic.notification-canada-ca-ses-callback.arn]
+    }
   }
 }
 

--- a/aws/common/outputs.tf
+++ b/aws/common/outputs.tf
@@ -175,6 +175,10 @@ output "sqs_eks_notification_canada_cadelivery_receipts_arn" {
   value = aws_sqs_queue.eks_notification_canada_cadelivery_receipts.arn
 }
 
+output "ses_receipt_callback_buffer_arn" {
+  value = aws_sqs_queue.ses_receipt_callback_buffer.arn
+}
+
 output "notification_base_url_regex_arn" {
   value       = aws_wafv2_regex_pattern_set.notification_base_url.arn
   description = "The ARN of the regex pattern set for the allowed base domains"

--- a/aws/common/sns.tf
+++ b/aws/common/sns.tf
@@ -149,6 +149,13 @@ resource "aws_sns_sms_preferences" "update-sms-prefs-us-west-2" {
   default_sms_type                      = "Transactional"
 }
 
+resource "aws_sns_topic_subscription" "sqs_callback_subscription" {
+  topic_arn            = aws_sns_topic.notification-canada-ca-ses-callback.arn
+  protocol             = "sqs"
+  endpoint             = aws_sqs_queue.ses_receipt_callback_buffer.arn
+  raw_message_delivery = true
+}
+
 resource "aws_sns_topic_subscription" "sns_alert_ok_us_west_2_to_lambda" {
   provider = aws.us-west-2
 

--- a/aws/common/sqs.tf
+++ b/aws/common/sqs.tf
@@ -63,3 +63,17 @@ resource "aws_sqs_queue" "eks_notification_canada_cadelivery_receipts" {
     Environment = var.env
   }
 }
+
+resource "aws_sqs_queue" "ses_receipt_callback_buffer" {
+  name                       = "ses-receipt-callback-buffer"
+  delay_seconds              = 0
+  max_message_size           = 262144
+  message_retention_seconds  = 345600
+  receive_wait_time_seconds  = 0
+  visibility_timeout_seconds = var.sqs_visibility_timeout_default
+  sqs_managed_sse_enabled    = true
+
+  tags = {
+    Environment = var.env
+  }
+}

--- a/aws/ses_to_sqs_email_callbacks/lambda.tf
+++ b/aws/ses_to_sqs_email_callbacks/lambda.tf
@@ -24,17 +24,23 @@ data "aws_iam_policy_document" "ses_to_sqs_email_callbacks" {
     effect    = "Allow"
     resources = [var.sqs_eks_notification_canada_cadelivery_receipts_arn]
   }
+
+  # Gives the lambda function permission to receive messages from the receipt buffer SQS queue
+  statement {
+    actions = [
+      "sqs:GetQueueAttributes",
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage"
+    ]
+    effect    = "Allow"
+    resources = [var.ses_receipt_callback_buffer_arn]
+  }
 }
 
-resource "aws_lambda_permission" "allow_sns_ses_callbacks" {
-  action        = "lambda:InvokeFunction"
-  function_name = module.ses_to_sqs_email_callbacks.function_name
-  principal     = "sns.amazonaws.com"
-  source_arn    = var.notification_canada_ca_ses_callback_arn
-}
-
-resource "aws_sns_topic_subscription" "ses_sns_to_lambda" {
-  topic_arn = var.notification_canada_ca_ses_callback_arn
-  protocol  = "lambda"
-  endpoint  = module.ses_to_sqs_email_callbacks.function_arn
+resource "aws_lambda_event_source_mapping" "sqs_batch_callbacks_trigger" {
+  event_source_arn                   = var.ses_receipt_callback_buffer_arn
+  function_name                      = module.ses_to_sqs_email_callbacks.function_name
+  enabled                            = true
+  batch_size                         = 10
+  maximum_batching_window_in_seconds = 1
 }

--- a/aws/ses_to_sqs_email_callbacks/variables.tf
+++ b/aws/ses_to_sqs_email_callbacks/variables.tf
@@ -14,6 +14,10 @@ variable "notification_canada_ca_ses_callback_arn" {
   type = string
 }
 
+variable "ses_receipt_callback_buffer_arn" {
+  type = string
+}
+
 variable "ses_to_sqs_email_callbacks_ecr_repository_url" {
   type        = string
   description = "Inherited from ecr dependency"

--- a/env/dev/ses_to_sqs_email_callbacks/terragrunt.hcl
+++ b/env/dev/ses_to_sqs_email_callbacks/terragrunt.hcl
@@ -19,6 +19,7 @@ dependency "common" {
   mock_outputs_merge_with_state           = true
   mock_outputs = {
     notification_canada_ca_ses_callback_arn = ""
+    ses_receipt_callback_buffer_arn         = ""
     sns_alert_warning_arn          = ""
     sns_alert_critical_arn         = ""
     sns_alert_ok_arn               = ""
@@ -31,6 +32,7 @@ include {
 
 inputs = {
   notification_canada_ca_ses_callback_arn = dependency.common.outputs.notification_canada_ca_ses_callback_arn
+  ses_receipt_callback_buffer_arn         = dependency.common.outputs.ses_receipt_callback_buffer_arn
   sns_alert_warning_arn                   = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                  = dependency.common.outputs.sns_alert_critical_arn
   sns_alert_ok_arn                        = dependency.common.outputs.sns_alert_ok_arn

--- a/env/production/ses_to_sqs_email_callbacks/terragrunt.hcl
+++ b/env/production/ses_to_sqs_email_callbacks/terragrunt.hcl
@@ -19,6 +19,7 @@ dependency "common" {
   mock_outputs_merge_with_state           = true
   mock_outputs = {
     notification_canada_ca_ses_callback_arn = ""
+    ses_receipt_callback_buffer_arn         = ""
     sns_alert_warning_arn          = ""
     sns_alert_critical_arn         = ""
     sns_alert_ok_arn               = ""
@@ -31,6 +32,7 @@ include {
 
 inputs = {
   notification_canada_ca_ses_callback_arn = dependency.common.outputs.notification_canada_ca_ses_callback_arn
+  ses_receipt_callback_buffer_arn         = dependency.common.outputs.ses_receipt_callback_buffer_arn
   sns_alert_warning_arn                   = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                  = dependency.common.outputs.sns_alert_critical_arn
   sns_alert_ok_arn                        = dependency.common.outputs.sns_alert_ok_arn

--- a/env/sandbox/ses_to_sqs_email_callbacks/terragrunt.hcl
+++ b/env/sandbox/ses_to_sqs_email_callbacks/terragrunt.hcl
@@ -19,6 +19,7 @@ dependency "common" {
   mock_outputs_merge_with_state           = true
   mock_outputs = {
     notification_canada_ca_ses_callback_arn = ""
+    ses_receipt_callback_buffer_arn         = ""
     sns_alert_warning_arn          = ""
     sns_alert_critical_arn         = ""
     sns_alert_ok_arn               = ""
@@ -31,6 +32,7 @@ include {
 
 inputs = {
   notification_canada_ca_ses_callback_arn = dependency.common.outputs.notification_canada_ca_ses_callback_arn
+  ses_receipt_callback_buffer_arn         = dependency.common.outputs.ses_receipt_callback_buffer_arn
   sns_alert_warning_arn                   = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                  = dependency.common.outputs.sns_alert_critical_arn
   sns_alert_ok_arn                        = dependency.common.outputs.sns_alert_ok_arn

--- a/env/staging/ses_to_sqs_email_callbacks/terragrunt.hcl
+++ b/env/staging/ses_to_sqs_email_callbacks/terragrunt.hcl
@@ -19,6 +19,7 @@ dependency "common" {
   mock_outputs_merge_with_state           = true
   mock_outputs = {
     notification_canada_ca_ses_callback_arn = ""
+    ses_receipt_callback_buffer_arn         = ""
     sns_alert_warning_arn          = ""
     sns_alert_critical_arn         = ""
     sns_alert_ok_arn               = ""
@@ -30,6 +31,7 @@ include {
 }
 
 inputs = {
+  ses_receipt_callback_buffer_arn         = dependency.common.outputs.ses_receipt_callback_buffer_arn
   notification_canada_ca_ses_callback_arn = dependency.common.outputs.notification_canada_ca_ses_callback_arn
   sns_alert_warning_arn                   = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                  = dependency.common.outputs.sns_alert_critical_arn


### PR DESCRIPTION
This PR reinstates the SQS buffer queue supporting the batch saving work.

* https://github.com/cds-snc/notification-terraform/pull/1849