### PR TITLE
Dev setup for blue/green valkey

### DIFF
--- a/aws/elasticache/elasticache.tf
+++ b/aws/elasticache/elasticache.tf
@@ -21,9 +21,54 @@ resource "aws_elasticache_replication_group" "notification-cluster-cache-multiaz
   description                 = "Redis/Valkey multiaz cluster with replication group"
   node_type                   = var.elasticache_node_type
   num_cache_clusters          = var.elasticache_node_number_cache_clusters
-  engine                      = var.env != "production" ? "valkey" : "redis"
-  engine_version              = var.env != "production" ? "7.2" : "6.x"
-  parameter_group_name        = var.env != "production" ? "default.valkey7" : "default.redis6.x"
+  engine                      = "redis"
+  engine_version              = "6.x"
+  parameter_group_name        = "default.redis6.x"
+  port                        = 6379
+  maintenance_window          = "thu:04:00-thu:05:00"
+  multi_az_enabled            = true
+
+  security_group_ids = local.cluster_security_group_ids
+  subnet_group_name  = aws_elasticache_subnet_group.notification-canada-ca-cache-subnet.name
+
+  log_delivery_configuration {
+    destination      = aws_cloudwatch_log_group.notification-canada-ca-elasticache-slow-logs.name
+    destination_type = "cloudwatch-logs"
+    log_format       = "json"
+    log_type         = "slow-log"
+  }
+
+  log_delivery_configuration {
+    destination      = aws_cloudwatch_log_group.notification-canada-ca-elasticache-engine-logs.name
+    destination_type = "cloudwatch-logs"
+    log_format       = "json"
+    log_type         = "engine-log"
+  }
+
+  tags = {
+    CostCenter = "notification-canada-ca-${var.env}"
+  }
+
+  lifecycle {
+    ignore_changes = [num_cache_clusters]
+  }
+}
+
+
+resource "aws_elasticache_replication_group" "notification_valkey_cluster" {
+
+  count = var.elasticache_use_valkey == true ? 1 : 0
+
+  apply_immediately           = true
+  automatic_failover_enabled  = true
+  preferred_cache_cluster_azs = ["ca-central-1b", "ca-central-1d", "ca-central-1a"]
+  replication_group_id        = "notify-${var.env}-cluster-cache-valkey"
+  description                 = "Valkey multiaz cluster with replication group"
+  node_type                   = var.elasticache_node_type
+  num_cache_clusters          = var.elasticache_node_number_cache_clusters
+  engine                      = "valkey"
+  engine_version              = "7.2"
+  parameter_group_name        = "default.valkey7"
   port                        = 6379
   maintenance_window          = "thu:04:00-thu:05:00"
   multi_az_enabled            = true

--- a/aws/elasticache/outputs.tf
+++ b/aws/elasticache/outputs.tf
@@ -5,6 +5,6 @@ output "redis_cluster_security_group_id" {
 
 output "redis_primary_endpoint_address" {
   description = "The address of the primary node for the cluster"
-  value       = aws_elasticache_replication_group.notification-cluster-cache-multiaz-group.primary_endpoint_address
+  value       = var.elasticache_use_valkey == true ? aws_elasticache_replication_group.notification_valkey_cluster[0].primary_endpoint_address : aws_elasticache_replication_group.notification-cluster-cache-multiaz-group.primary_endpoint_address
   sensitive   = true
 }

--- a/env/dev/lambda-api/.terraform.lock.hcl
+++ b/env/dev/lambda-api/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.67.0"
   constraints = "~> 5.66"
   hashes = [
+    "h1:8wkuQvQiqjjm2+gQepy6xFBfimGoesKz1BPcVKWvED8=",
     "h1:gljTHIfOelTepL5K1zblNXb3yaUDxcZTEyXeMvO+H1E=",
     "zh:1259c8106c0a3fc0ed3b3eb814ab88d6a672e678b533f47d1bbbe3107949f43e",
     "zh:226414049afd6d334cc16ff5d6cef23683620a9b56da67a21422a113d9cce4ab",
@@ -29,6 +30,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   constraints = "~> 4.0"
   hashes = [
     "h1:/sSdjHoiykrPdyBP1JE03V/KDgLXnHZhHcSOYIdDH/A=",
+    "h1:n3M50qfWfRSpQV9Pwcvuse03pEizqrmYEryxKky4so4=",
     "zh:10de0d8af02f2e578101688fd334da3849f56ea91b0d9bd5b1f7a243417fdda8",
     "zh:37fc01f8b2bc9d5b055dc3e78bfd1beb7c42cfb776a4c81106e19c8911366297",
     "zh:4578ca03d1dd0b7f572d96bd03f744be24c726bfd282173d54b100fd221608bb",
@@ -49,6 +51,7 @@ provider "registry.terraform.io/integrations/github" {
   constraints = "~> 6.0"
   hashes = [
     "h1:B1q5+Ub1G3zJa9y474Fg40eo/N04/vOSeaf3dWaCG0I=",
+    "h1:YiGCvjr7R77HGTzw81legWicEHApVTli8O+ooDpLexE=",
     "zh:00f431c2a2510efcb1115442dda5e90815bcb16e1a3301679ade0139fa963d3b",
     "zh:12a862f4317b3cb65682c1b687650cd91eeee99e63774bdcfa8bcfc64bad097b",
     "zh:226d5e09ff27f94cb9336089181d26f85cb30219b863a579597f2e107f37de49",
@@ -71,6 +74,7 @@ provider "registry.terraform.io/newrelic/newrelic" {
   version     = "3.46.0"
   constraints = "~> 3.3"
   hashes = [
+    "h1:8oD/Ei8WzPbtaaIGByqW3ovfAFep1HC6e6DxBCnbcoI=",
     "h1:T5CAzHHihaRCfOLgAApW3UXVSBk+KrqFoOS/qsSbejM=",
     "zh:0a12eba6813faf3697ef02f2a88f13d16dd448671e8bfabc27a545153e69b47e",
     "zh:10d1c79f3ce247883de2809e1aa39668594fc8b162c7b564a9fff5c610677a46",

--- a/env/dev_config.tfvars
+++ b/env/dev_config.tfvars
@@ -70,6 +70,7 @@ vpc_cidr_block = "10.0.0.0/16"
 elasticache_node_count                 = 1
 elasticache_node_number_cache_clusters = 3
 elasticache_node_type                  = "cache.t3.micro"
+elasticache_use_valkey                 = true
 
 ## SLACK INTEGRATION
 slack_channel_warning_topic  = "notification-dev-ops"

--- a/env/variables.tf
+++ b/env/variables.tf
@@ -1074,3 +1074,8 @@ variable "manifest_docker_hub_pat" {
   type      = string
   sensitive = true
 }
+
+variable "elasticache_use_valkey" {
+  type    = bool
+  default = false
+}

--- a/scripts/switchToValkey.sh
+++ b/scripts/switchToValkey.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# This script will perform the necessasry steps to switch Notify from Redis to Valkey
+# Usage ./switchToValkey.sh <environment>
+# Example ./switchToValkey.sh dev
+
+ENVIRONMENT=$1
+
+if [ -z "$ENVIRONMENT" ]; then
+  echo "Please provide an environment (e.g., dev, production)."
+  exit 1
+fi
+
+pushd ../$ENVIRONMENT/elasticache
+echo "Creating Valkey cluster in $ENVIRONMENT environment..."
+
+terragrunt apply
+if [ $? -ne 0 ]; then
+  echo "Failed to apply changes in $ENVIRONMENT environment."
+  exit 1
+fi
+echo "Successfully switched Notify from Redis to Valkey in $ENVIRONMENT environment."
+popd
+
+pushd ../$ENVIRONMENT/lambda-api
+echo "Updating Lambda function in $ENVIRONMENT environment..."
+terragrunt apply
+if [ $? -ne 0 ]; then
+  echo "Failed to apply changes in $ENVIRONMENT environment."
+  exit 1
+fi
+popd
+echo "Successfully updated Lambda function in $ENVIRONMENT environment."
+pushd ../$ENVIRONMENT/manifest_secrets
+echo "Updating manifest secrets in $ENVIRONMENT environment..."
+terragrunt apply
+if [ $? -ne 0 ]; then
+  echo "Failed to apply changes in $ENVIRONMENT environment."
+  exit 1
+fi
+popd
+echo "Successfully updated manifest secrets in $ENVIRONMENT environment."
+
+echo "Ensure you are connected to the VPN"
+read -p "Press [Enter] to continue or [Ctrl+C] to cancel..."
+
+echo "Updating Notify API and Notify Admin deployments in notification-canada-ca namespace..."
+
+kubectl rollout restart deployment/notify-admin -n notification-canada-ca
+kubectl rollout status deployment notify-admin -n notification-canada-ca
+
+kubectl rollout restart deployment/notify-api -n notification-canada-ca
+kubectl rollout status deployment notify-api -n notification-canada-ca
+
+echo "Successfully updated Notify API and Notify Admin deployments in notification-canada-ca namespace."
+echo "Switch to Valkey completed successfully."


### PR DESCRIPTION
[review]

# Summary | Résumé

This will create a valkey instance if the flag "elasticache_use_valkey" is set to true. 

I've added a script to automate the blue/green creation and migration process.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/437

## Before merging this PR

Read code suggestions left by the
[cds-ai-codereviewer](https://github.com/cds-snc/cds-ai-codereviewer/) bot. Address
valid suggestions and shortly write down reasons to not address others. To help
with the classification of the comments, please use these reactions on each of the
comments made by the AI review:

| Classification      | Reaction | Emoticon |
|---------------------|----------|----------|
| Useful              | +1       | 👍        |
| Noisy               | eyes     | 👀        |
| Hallucination       | confused | 😕        |
| Wrong but teachable | rocket   | 🚀        |
| Wrong and incorrect | -1       | 👎        |

The classifications will be extracted and summarized into an analysis of how helpful
or not the AI code review really is.

## Test instructions | Instructions pour tester la modification

Run the valkey migration script in staging

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
