### PR TITLE
Beginning upgrade of staging nodes

### DIFF
--- a/env/staging_config.tfvars
+++ b/env/staging_config.tfvars
@@ -8,8 +8,8 @@ billing_tag_key      = "CostCenter"
 ## EKS     
 primary_worker_desired_size     = 5
 primary_worker_instance_types   = ["r5.large"]
-secondary_worker_instance_types = ["r5.large"]
-node_upgrade                    = false
+secondary_worker_instance_types = ["c7i.xlarge"]
+node_upgrade                    = true
 force_upgrade                   = true
 primary_worker_max_size         = 7
 primary_worker_min_size         = 4


### PR DESCRIPTION
# Summary | Résumé

Looking to change the staging node size to something more CPU oriented.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/580

## Test instructions | Instructions pour tester la modification

TF Apply Works

## Release Instructions | Instructions pour le déploiement

Staging node migration (cordon/drain)

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
