### PR TITLE
adding node upgrade back

### DIFF
--- a/env/production_config.tfvars
+++ b/env/production_config.tfvars
@@ -1,19 +1,19 @@
 ## GENERAL
-env                  = "production"
-account_budget_limit = 15000
+env                  = "staging"
+account_budget_limit = 5000
 region               = "ca-central-1"
-billing_tag_value    = "notification-canada-ca-production"
+billing_tag_value    = "notification-canada-ca-staging"
 billing_tag_key      = "CostCenter"
 
-## EKS
-primary_worker_desired_size     = 8
-primary_worker_instance_types   = ["r5.large"]
+## EKS     
+primary_worker_desired_size     = 5
+primary_worker_instance_types   = ["c7i.xlarge"]
 secondary_worker_instance_types = ["c7i.xlarge"]
-node_upgrade                    = true
-force_upgrade                   = false
-primary_worker_max_size         = 8
-primary_worker_min_size         = 3
-eks_cluster_name                = "notification-canada-ca-production-eks-cluster"
+node_upgrade                    = false
+force_upgrade                   = true
+primary_worker_max_size         = 7
+primary_worker_min_size         = 4
+eks_cluster_name                = "notification-canada-ca-staging-eks-cluster"
 eks_cluster_version             = "1.32"
 eks_addon_coredns_version       = "v1.11.4-eksbuild.2"
 eks_addon_kube_proxy_version    = "v1.32.0-eksbuild.2"
@@ -28,13 +28,13 @@ celery_queue_prefix             = "eks-notification-canada-ca"
 notify_k8s_namespace            = "notification-canada-ca"
 
 # lambda-api
-api_image_tag                          = "release"
+api_image_tag                          = "latest"
 redis_enabled                          = "1"
 low_demand_min_concurrency             = 1
 low_demand_max_concurrency             = 5
-high_demand_min_concurrency            = 3
+high_demand_min_concurrency            = 1
 high_demand_max_concurrency            = 10
-new_relic_app_name                     = "notification-lambda-api-production"
+new_relic_app_name                     = "notification-lambda-api-staging"
 new_relic_distribution_tracing_enabled = "true"
 notification_queue_prefix              = "eks-notification-canada-ca"
 
@@ -53,15 +53,11 @@ recovery                   = false
 aws_xray_sdk_enabled       = true
 
 ## DNS
-alt_domain                 = "notification.alpha.canada.ca"
-domain                     = "notification.canada.ca"
-base_domain                = "notification.canada.ca"
-perf_test_domain           = "https://api.notification.canada.ca"
-ses_custom_sending_domains = ["notification.gov.bc.ca", "notify.novascotia.ca", "chrc-ccdp.gc.ca"]
-
-## LOGGING
-log_retention_period_days           = 0
-sensitive_log_retention_period_days = 7
+alt_domain                 = "staging.alpha.notification.cdssandbox.xyz"
+domain                     = "staging.notification.cdssandbox.xyz"
+base_domain                = "staging.notification.cdssandbox.xyz"
+perf_test_domain           = "https://api.staging.notification.cdssandbox.xyz"
+ses_custom_sending_domains = ["custom-sending-domain.staging.notification.cdssandbox.xyz"]
 
 ## VPC
 vpc_cidr_block = "10.0.0.0/16"
@@ -71,14 +67,19 @@ elasticache_node_count                 = 1
 elasticache_node_number_cache_clusters = 3
 elasticache_node_type                  = "cache.t3.medium"
 
+## LOGGING
+log_retention_period_days           = 365
+sensitive_log_retention_period_days = 14
+
 ## SLACK INTEGRATION
-slack_channel_warning_topic  = "notification-ops"
-slack_channel_critical_topic = "notification-ops"
-slack_channel_general_topic  = "notification-ops"
+slack_channel_warning_topic  = "notification-staging-ops"
+slack_channel_critical_topic = "notification-staging-ops"
+slack_channel_general_topic  = "notification-staging-ops"
 
 ## MONITORING
-athena_workgroup_name    = "primary"
-aws_config_recorder_name = "aws-controltower-BaselineConfigRecorder"
+athena_workgroup_name             = "primary"
+cloudwatch_opsgenie_alarm_webhook = ""
+aws_config_recorder_name          = "aws-controltower-BaselineConfigRecorder"
 
 ## HEARTBEAT
 heartbeat_sms_number = "+16135550123"
@@ -90,45 +91,41 @@ google_cidr_schedule_expression = "rate(1 day)"
 ## RDS
 rds_instance_count                     = 3
 rds_instance_type                      = "db.r6g.xlarge"
-rds_database_name                      = "NotificationCanadaCaproduction"
+rds_database_name                      = "NotificationCanadaCastaging"
 rds_version                            = "16.6"
 platform_data_lake_kms_key_arn         = "arn:aws:kms:ca-central-1:739275439843:key/22f27c88-bb2b-49c3-b731-05123a974af4"
 platform_data_lake_raw_s3_bucket_arn   = "arn:aws:s3:::cds-data-lake-raw-production"
 platform_data_lake_rds_export_role_arn = "arn:aws:iam::739275439843:role/platform-gc-notify-export"
 
-## NOTIFY-API/CELERY
+## NOTIFY-API/CELERY               
 RECREATE_MISSING_LAMBDA_PACKAGE = "false"
 ff_batch_insertion              = "true"
 ff_cloudwatch_metrics_enabled   = "true"
 ff_redis_batch_saving           = "true"
 
 ## SES_RECEIVING_EMAILS
-notify_sending_domain   = "notification.canada.ca"
+notify_sending_domain   = "staging.notification.cdssandbox.xyz"
 sqs_region              = "ca-central-1"
-gc_notify_service_email = "gc.notify.notification.gc@notification.canada.ca"
-
-## PERF TEST (These are not in production)
-aws_pinpoint_region                 = "changeme"
-perf_test_phone_number              = "changeme"
-perf_test_email                     = "changeme"
-perf_test_api_key                   = "changeme"
-perf_test_slack_webhook             = "changeme"
-perf_schedule_expression            = "changeme"
-perf_test_aws_s3_bucket             = "changeme"
-perf_test_csv_directory_path        = "changeme"
-perf_test_sms_template_id_one_var   = "changeme"
-perf_test_email_template_id_one_var = "changeme"
+gc_notify_service_email = "gc.notify.notification.gc@staging.notification.cdssandbox.xyz"
 
 ## SYSTEM STATUS
-system_status_api_url                   = "https://api.notification.canada.ca"
-system_status_bucket_name               = "notification-canada-ca-production-system-status"
-system_status_admin_url                 = "https://notification.canada.ca"
-system_status_schedule_expression       = "rate(5 minutes)"
+system_status_api_url               = "https://api.staging.notification.cdssandbox.xyz"
+system_status_bucket_name           = "notification-canada-ca-staging-system-status"
+system_status_admin_url             = "https://staging.notification.cdssandbox.xyz"
+system_status_schedule_expression   = "rate(5 minutes)"
+
+## PERF TEST
+aws_pinpoint_region          = "ca-central-1"
+perf_test_phone_number       = "16135550123" # INTERNAL_TEST_NUMBER - does not send to AWS
+perf_test_email              = "success@simulator.amazonses.com"
+perf_schedule_expression     = "cron(0 0 * * ? *)"
+perf_test_aws_s3_bucket      = "notify-performance-test-results-staging"
+perf_test_csv_directory_path = "/tmp/notify_performance_test"
 
 ## COMMON
-sns_monthly_spend_limit                                            = 30000
-sns_monthly_spend_limit_us_west_2                                  = 2000
-alarm_warning_document_download_bucket_size_gb                     = 100
+sns_monthly_spend_limit                                            = 100
+sns_monthly_spend_limit_us_west_2                                  = 30
+alarm_warning_document_download_bucket_size_gb                     = 0.5
 alarm_warning_inflight_processed_created_delta_threshold           = 100
 alarm_critical_inflight_processed_created_delta_threshold          = 200
 alarm_warning_priority_inflight_processed_created_delta_threshold  = 100
@@ -161,7 +158,7 @@ sqs_send_sms_high_queue_name                                       = "send-sms-h
 sqs_send_sms_medium_queue_name                                     = "send-sms-medium"
 sqs_send_sms_low_queue_name                                        = "send-sms-low"
 
-# RANDOM DOCKER TAGS (These are only used during BCP processes)
+# RANDOM DOCKER TAGS
 system_status_docker_tag                 = "bootstrap"
 heartbeat_docker_tag                     = "bootstrap"
 google_cidr_docker_tag                   = "bootstrap"


### PR DESCRIPTION
# Summary | Résumé

This was removed in a revert for an incident but was not related, so I'm adding it back.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/580

## Test instructions | Instructions pour tester la modification

TF Apply works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
