### PR TITLE
fix: S3 bucket size script to support pagination

### DIFF
--- a/scripts/s3bucketsize/s3bucketsize.py
+++ b/scripts/s3bucketsize/s3bucketsize.py
@@ -54,10 +54,19 @@ def main():
         # Calculate the total size of the bucket
         total_size = 0
         item_count = 0
-        for obj in s3.list_objects_v2(Bucket=bucket_name)["Contents"]:
-            # print(f"Object: {obj['Key']}, Size: {obj['Size']} bytes")
-            total_size += obj["Size"]
-            item_count += 1
+        is_truncated = True
+        pagination_config = {"Bucket": bucket_name}
+        
+        # Retrieve all objects in the bucket, checking for pagination
+        while is_truncated:
+            response = s3.list_objects_v2(**pagination_config)
+            for obj in response["Contents"]:
+                total_size += obj["Size"]
+                item_count += 1
+            
+            is_truncated = response.get("IsTruncated", False)
+            if is_truncated:
+                pagination_config["ContinuationToken"] = response.get("NextContinuationToken")
 
         print(f"Bucket: {bucket_name}, Size: {total_size} bytes, Items: {item_count}")
         # Append data for each bucket

--- a/scripts/s3bucketsize/s3bucketsize.py
+++ b/scripts/s3bucketsize/s3bucketsize.py
@@ -60,7 +60,7 @@ def main():
         # Retrieve all objects in the bucket, checking for pagination
         while is_truncated:
             response = s3.list_objects_v2(**pagination_config)
-            for obj in response["Contents"]:
+            for obj in response.get("Contents", []):
                 total_size += obj["Size"]
                 item_count += 1
             


### PR DESCRIPTION
# Summary
Update the bucket size script so that it checks if there are multiple pages of S3 object responses.  If there are, it will now continue to retrieve the pages until there are none remaining.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning-core/issues/510
* https://github.com/cds-snc/platform-core-services/issues/659

## Test instructions | Instructions pour tester la modification

After merge, confirm that all S3 objects in the bucket are accounted for rather than just the first page of results.  An easy check is that there should be more than 1000 objects in the bucket.

## Release Instructions | Instructions pour le déploiement

Delete the current `bucket-size.csv` file in the S3 bucket as it contains incorrect data.

## Reviewer checklist | Liste de vérification du réviseur

* [x] This PR does not break existing functionality.
* [x] This PR does not violate GCNotify's privacy policies.
* [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [x] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
