### PR TITLE
Prod primary node upgrade

### DIFF
--- a/env/production_config.tfvars
+++ b/env/production_config.tfvars
@@ -7,7 +7,7 @@ billing_tag_key      = "CostCenter"
 
 ## EKS
 primary_worker_desired_size     = 8
-primary_worker_instance_types   = ["r5.large"]
+primary_worker_instance_types   = ["c7i.xlarge"]
 secondary_worker_instance_types = ["c7i.xlarge"]
 node_upgrade                    = true
 force_upgrade                   = false


### PR DESCRIPTION
# Summary | Résumé

Upgrade the primary node group to c7i.xlarge

The workload has been cordoned/drained off of these nodes for this upgrade.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/580

## Test instructions | Instructions pour tester la modification

TF Apply works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
