### PR TITLE
task: add preview routes to admin for staging only

### DIFF
--- a/aws/common/waf.tf
+++ b/aws/common/waf.tf
@@ -101,7 +101,7 @@ resource "aws_wafv2_regex_pattern_set" "re_admin2" {
   # Additional regex for the Admin WAF should be added to this pattern set, not in re_admin, which is full.
 
   regular_expression {
-    regex_string = var.env == "production" ? "/sitemap|/plandesite|/agree-terms|/getting-started|/decouvrir-notification-gc|/template-category.*|/template-categories.*|/mettre-en-forme-les-courriels|/find-ids" : "/sitemap|/plandesite|/agree-terms|/getting-started|/decouvrir-notification-gc|/template-category.*|/template-categories.*|/mettre-en-forme-les-courriels|/find-ids|/_storybook.*"
+    regex_string = var.env == "production" ? "/sitemap|/plandesite|/agree-terms|/getting-started|/decouvrir-notification-gc|/template-category.*|/template-categories.*|/mettre-en-forme-les-courriels|/find-ids" : "/sitemap|/plandesite|/agree-terms|/getting-started|/decouvrir-notification-gc|/template-category.*|/template-categories.*|/mettre-en-forme-les-courriels|/find-ids|/_storybook.*|/_preview_.*"
   }
 
   tags = {


### PR DESCRIPTION
# Summary | Résumé

Add WAF rules to staging to allow `/_preview_.*` for enabling a new workflow for designers to test pages and content.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/687

## Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
