### PR TITLE
Adding  proper BASE_DOMAIN Variables for DNS Alarm

### DIFF
--- a/aws/common/route53.tf
+++ b/aws/common/route53.tf
@@ -45,7 +45,7 @@ resource "aws_cloudwatch_log_metric_filter" "route53_nxdomain_notification" {
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Route53NXDOMAINNotificationDomain"
   # Simplified pattern that should be compatible with CloudWatch
-  pattern        = "{ $.rcode = \"NXDOMAIN\" && $.query_name = \"*.notification.cdssandbox.ca\" }"
+  pattern        = "{ $.rcode = \"NXDOMAIN\" && $.query_name = \"*.${var.base_domain}\" }"
   log_group_name = aws_cloudwatch_log_group.route53_resolver_query_log[0].name
 
   metric_transformation {
@@ -60,7 +60,7 @@ resource "aws_cloudwatch_log_metric_filter" "route53_servfail_notification" {
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Route53SERVFAILNotificationDomain"
   # Simplified pattern that should be compatible with CloudWatch
-  pattern        = "{ $.rcode = \"SERVFAIL\" && $.query_name = \"*.notification.cdssandbox.ca\" }"
+  pattern        = "{ $.rcode = \"SERVFAIL\" && $.query_name = \"*.${var.base_domain}\" }"
   log_group_name = aws_cloudwatch_log_group.route53_resolver_query_log[0].name
 
   metric_transformation {


### PR DESCRIPTION
# Summary | Résumé

Changing a (problematic) hardcoded domain to use the variables for our new DNS alarms we are testing

## Related Issues | Cartes liées
https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/73/board?repos=614416930,zh-Z2lkOi8vcmFwdG9yL1JlcG9zaXRvcnkvMTMzODg2NjU5

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
