### PR TITLE
Cloudwatch alarm to check if an API call is taking over 1000ms

### DIFF
--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -952,33 +952,3 @@ resource "aws_cloudwatch_metric_alarm" "expired-inflight-critical" {
     }
   }
 }
-
-
-resource "aws_cloudwatch_metric_alarm" "api-email-slow-execution-warning" {
-  count               = var.cloudwatch_enabled ? 1 : 0
-  alarm_name          = "api-email-slow-execution-warning"
-  alarm_description   = "API send for email notifications taking longer than 1s"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
-  threshold           = 1
-  treat_missing_data  = "notBreaching"
-  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
-  ok_actions          = [aws_sns_topic.notification-canada-ca-alert-ok.arn]
-  
-  metric_query {
-    id          = "batch_saving_email_slow_execution"
-    expression  = "INSIGHT_RULE_METRIC('batch_saving_email_slow_execution_rule')"
-    label       = "Email batch saving operations taking >1000ms"
-    return_data = "true"
-  }
-}
-
-resource "aws_cloudwatch_insight_rule" "api_send_slow_execution_rule" {
-  name        = "api_send_slow_execution_rule"
-  state       = "ENABLED"
-  rule_body   = jsonencode({
-    Source = "aws/containerinsights/${var.cluster_name}/application"
-    LogGroupNames = [local.eks_application_log_group]
-    QueryString = aws_cloudwatch_query_definition.api-send-greater-than-1s[0].query_string
-  })
-}

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -952,3 +952,33 @@ resource "aws_cloudwatch_metric_alarm" "expired-inflight-critical" {
     }
   }
 }
+
+
+resource "aws_cloudwatch_metric_alarm" "api-email-slow-execution-warning" {
+  count               = var.cloudwatch_enabled ? 1 : 0
+  alarm_name          = "api-email-slow-execution-warning"
+  alarm_description   = "API send for email notifications taking longer than 1s"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
+  ok_actions          = [aws_sns_topic.notification-canada-ca-alert-ok.arn]
+  
+  metric_query {
+    id          = "batch_saving_email_slow_execution"
+    expression  = "INSIGHT_RULE_METRIC('batch_saving_email_slow_execution_rule')"
+    label       = "Email batch saving operations taking >1000ms"
+    return_data = "true"
+  }
+}
+
+resource "aws_cloudwatch_insight_rule" "api_send_slow_execution_rule" {
+  name        = "api_send_slow_execution_rule"
+  state       = "ENABLED"
+  rule_body   = jsonencode({
+    Source = "aws/containerinsights/${var.cluster_name}/application"
+    LogGroupNames = [local.eks_application_log_group]
+    QueryString = aws_cloudwatch_query_definition.api-send-greater-than-1s[0].query_string
+  })
+}

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -1045,3 +1045,32 @@ resource "aws_cloudwatch_metric_alarm" "logs-10-oom-error-5-minute-warning" {
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_warning_arn]
 }
+
+resource "aws_cloudwatch_metric_alarm" "api-email-slow-execution-warning" {
+  count               = var.cloudwatch_enabled ? 1 : 0
+  alarm_name          = "api-email-slow-execution-warning"
+  alarm_description   = "API send for email notifications taking longer than 1s"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
+  ok_actions          = [aws_sns_topic.notification-canada-ca-alert-ok.arn]
+  
+  metric_query {
+    id          = "batch_saving_email_slow_execution"
+    expression  = "INSIGHT_RULE_METRIC('batch_saving_email_slow_execution_rule')"
+    label       = "Email batch saving operations taking >1000ms"
+    return_data = "true"
+  }
+}
+
+resource "aws_cloudwatch_insight_rule" "api_send_slow_execution_rule" {
+  name        = "api_send_slow_execution_rule"
+  state       = "ENABLED"
+  rule_body   = jsonencode({
+    Source = "aws/containerinsights/${var.cluster_name}/application"
+    LogGroupNames = [local.eks_application_log_group]
+    QueryString = aws_cloudwatch_query_definition.api-send-greater-than-1s[0].query_string
+  })
+}

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -1065,7 +1065,7 @@ resource "aws_cloudwatch_metric_alarm" "api-email-slow-execution-warning" {
   }
 }
 
-resource "aws_cloudwatch_insight_rule" "api_send_slow_execution_rule" {
+resource "aws_cloudwatch_metric_insight_rule" "api_send_slow_execution_rule" {
   name  = "api_send_slow_execution_rule"
   state = "ENABLED"
   rule_body = jsonencode({

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -1054,9 +1054,8 @@ resource "aws_cloudwatch_metric_alarm" "api-email-slow-execution-warning" {
   evaluation_periods  = "1"
   threshold           = 1
   treat_missing_data  = "notBreaching"
-  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
-  ok_actions          = [aws_sns_topic.notification-canada-ca-alert-ok.arn]
-
+  alarm_actions       = [var.sns_alert_warning_arn]
+  ok_actions          = [var.sns_alert_ok_arn]
   metric_query {
     id          = "batch_saving_email_slow_execution"
     expression  = "INSIGHT_RULE_METRIC('batch_saving_email_slow_execution_rule')"
@@ -1065,12 +1064,8 @@ resource "aws_cloudwatch_metric_alarm" "api-email-slow-execution-warning" {
   }
 }
 
-resource "aws_cloudwatch_metric_insight_rule" "api_send_slow_execution_rule" {
-  name  = "api_send_slow_execution_rule"
-  state = "ENABLED"
-  rule_body = jsonencode({
-    Source        = "aws/containerinsights/${var.cluster_name}/application"
-    LogGroupNames = [local.eks_application_log_group]
-    QueryString   = aws_cloudwatch_query_definition.api-send-greater-than-1s[0].query_string
-  })
+resource "aws_cloudwatch_query_definition" "api_send_slow_execution_rule" {
+  name            = "api_send_slow_execution_rule"
+  query_string    = aws_cloudwatch_query_definition.api-send-greater-than-1s[0].query_string
+  log_group_names = [local.eks_application_log_group]
 }

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -1055,7 +1055,7 @@ resource "aws_cloudwatch_metric_alarm" "api-email-slow-execution-warning" {
   threshold           = 1
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_warning_arn]
-  ok_actions          = [var.sns_alert_ok_arn]
+  ok_actions          = [var.sns_alert_warning_arn]
   metric_query {
     id          = "batch_saving_email_slow_execution"
     expression  = "INSIGHT_RULE_METRIC('batch_saving_email_slow_execution_rule')"

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -1056,7 +1056,7 @@ resource "aws_cloudwatch_metric_alarm" "api-email-slow-execution-warning" {
   treat_missing_data  = "notBreaching"
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
   ok_actions          = [aws_sns_topic.notification-canada-ca-alert-ok.arn]
-  
+
   metric_query {
     id          = "batch_saving_email_slow_execution"
     expression  = "INSIGHT_RULE_METRIC('batch_saving_email_slow_execution_rule')"
@@ -1066,11 +1066,11 @@ resource "aws_cloudwatch_metric_alarm" "api-email-slow-execution-warning" {
 }
 
 resource "aws_cloudwatch_insight_rule" "api_send_slow_execution_rule" {
-  name        = "api_send_slow_execution_rule"
-  state       = "ENABLED"
-  rule_body   = jsonencode({
-    Source = "aws/containerinsights/${var.cluster_name}/application"
+  name  = "api_send_slow_execution_rule"
+  state = "ENABLED"
+  rule_body = jsonencode({
+    Source        = "aws/containerinsights/${var.cluster_name}/application"
     LogGroupNames = [local.eks_application_log_group]
-    QueryString = aws_cloudwatch_query_definition.api-send-greater-than-1s[0].query_string
+    QueryString   = aws_cloudwatch_query_definition.api-send-greater-than-1s[0].query_string
   })
 }

--- a/aws/eks/cloudwatch_queries.tf
+++ b/aws/eks/cloudwatch_queries.tf
@@ -356,7 +356,7 @@ resource "aws_cloudwatch_query_definition" "api-send-greater-than-1s" {
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "API / API send is greater than 1s"
 
-  log_group_name = [
+  log_group_names = [
     local.eks_application_log_group
   ]
 


### PR DESCRIPTION
# Summary | Résumé

Added a cloudwatch alarm to check if an API call is taking over a 1000ms 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1652

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
