### PR TITLE
fixing docker build paths

### DIFF
--- a/aws/ecr-us-east/images.tf
+++ b/aws/ecr-us-east/images.tf
@@ -24,7 +24,7 @@ resource "null_resource" "build_ses_receiving_emails_docker_image" {
   ]
 
   provisioner "local-exec" {
-    command = "cd /var/tmp/notification-lambdas/ && docker build -t ${aws_ecr_repository.ses_receiving_emails.repository_url}:bootstrap -f /var/tmp/notification-lambdas/sesreceivingemails/Dockerfile ."
+    command = "cd /var/tmp/notification-lambdas/sesreceivingemails && docker build -t ${aws_ecr_repository.ses_receiving_emails.repository_url}:bootstrap ."
   }
 
 }

--- a/aws/ecr/images.tf
+++ b/aws/ecr/images.tf
@@ -112,7 +112,7 @@ resource "null_resource" "build_heartbeat_docker_image" {
   ]
 
   provisioner "local-exec" {
-    command = "cd /var/tmp/notification-lambdas/heartbeat && docker build -t ${aws_ecr_repository.heartbeat.repository_url}:bootstrap -f /var/tmp/notification-lambdas/heartbeat/Dockerfile ."
+    command = "cd /var/tmp/notification-lambdas/heartbeat && docker build -t ${aws_ecr_repository.heartbeat.repository_url}:bootstrap ."
   }
 
 }
@@ -141,7 +141,7 @@ resource "null_resource" "build_google_cidr_docker_image" {
   ]
 
   provisioner "local-exec" {
-    command = "cd /var/tmp/notification-lambdas/google-cidr && docker build -t ${aws_ecr_repository.google-cidr.repository_url}:bootstrap -f /var/tmp/notification-lambdas/google-cidr/Dockerfile ."
+    command = "cd /var/tmp/notification-lambdas/google-cidr && docker build -t ${aws_ecr_repository.google-cidr.repository_url}:bootstrap ."
   }
 
 }
@@ -170,7 +170,7 @@ resource "null_resource" "build_ses_to_sqs_email_callbacks_docker_image" {
   ]
 
   provisioner "local-exec" {
-    command = "cd /var/tmp/notification-lambdas/sesemailcallbacks && docker build -t ${aws_ecr_repository.ses_to_sqs_email_callbacks.repository_url}:bootstrap -f /var/tmp/notification-lambdas/sesemailcallbacks/Dockerfile ."
+    command = "cd /var/tmp/notification-lambdas/sesemailcallbacks && docker build -t ${aws_ecr_repository.ses_to_sqs_email_callbacks.repository_url}:bootstrap ."
   }
 
 }
@@ -199,7 +199,7 @@ resource "null_resource" "build_sns_to_sqs_sms_callbacks_docker_image" {
   ]
 
   provisioner "local-exec" {
-    command = "cd /var/tmp/notification-lambdas/ && docker build -t ${aws_ecr_repository.sns_to_sqs_sms_callbacks.repository_url}:bootstrap -f /var/tmp/notification-lambdas/snssmscallbacks/Dockerfile ."
+    command = "cd /var/tmp/notification-lambdas/snssmscallbacks && docker build -t ${aws_ecr_repository.sns_to_sqs_sms_callbacks.repository_url}:bootstrap ."
   }
 
 }
@@ -228,7 +228,7 @@ resource "null_resource" "build_system_status_docker_image" {
   ]
 
   provisioner "local-exec" {
-    command = "cd /var/tmp/notification-lambdas/system_status && docker build -t ${aws_ecr_repository.system_status.repository_url}:bootstrap -f /var/tmp/notification-lambdas/system_status/Dockerfile ."
+    command = "cd /var/tmp/notification-lambdas/system_status && docker build -t ${aws_ecr_repository.system_status.repository_url}:bootstrap ."
   }
 }
 
@@ -256,7 +256,7 @@ resource "null_resource" "build_pinpoint_to_sqs_sms_callbacks_docker_image" {
   ]
 
   provisioner "local-exec" {
-    command = "docker build -t ${aws_ecr_repository.pinpoint_to_sqs_sms_callbacks.repository_url}:bootstrap -f /var/tmp/notification-lambdas/pinpointsmscallbacks/Dockerfile /var/tmp/notification-lambdas"
+    command = "cd /var/tmp/notification-lambdas/pinpointsmscallbacks && docker build -t ${aws_ecr_repository.pinpoint_to_sqs_sms_callbacks.repository_url}:bootstrap ."
   }
 }
 


### PR DESCRIPTION
# Summary | Résumé

The Dockerfile changes for notification-lambdas broke the bootstrap builds. Fixing.

## Related Issues | Cartes liées

*  https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/480

## Test instructions | Instructions pour tester la modification

TF apply works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
