### PR TITLE
fix: missing a period in the metric alarm

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -1056,12 +1056,13 @@ resource "aws_cloudwatch_metric_alarm" "api-email-slow-execution-warning" {
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_warning_arn]
   ok_actions          = [var.sns_alert_warning_arn]
-  period              = 300
+
   metric_query {
     id          = "batch_saving_email_slow_execution"
     expression  = "INSIGHT_RULE_METRIC('batch_saving_email_slow_execution_rule')"
     label       = "Email batch saving operations taking >1000ms"
     return_data = "true"
+    period      = 300
   }
 }
 


### PR DESCRIPTION
# Summary | Résumé

Missing a period in the metric alarm

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1
* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/1

## Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
