### PR TITLE
Staging to valkey

### DIFF
--- a/aws/elasticache/elasticache.tf
+++ b/aws/elasticache/elasticache.tf
@@ -21,54 +21,9 @@ resource "aws_elasticache_replication_group" "notification-cluster-cache-multiaz
   description                 = "Redis/Valkey multiaz cluster with replication group"
   node_type                   = var.elasticache_node_type
   num_cache_clusters          = var.elasticache_node_number_cache_clusters
-  engine                      = "redis"
-  engine_version              = "6.x"
-  parameter_group_name        = "default.redis6.x"
-  port                        = 6379
-  maintenance_window          = "thu:04:00-thu:05:00"
-  multi_az_enabled            = true
-
-  security_group_ids = local.cluster_security_group_ids
-  subnet_group_name  = aws_elasticache_subnet_group.notification-canada-ca-cache-subnet.name
-
-  log_delivery_configuration {
-    destination      = aws_cloudwatch_log_group.notification-canada-ca-elasticache-slow-logs.name
-    destination_type = "cloudwatch-logs"
-    log_format       = "json"
-    log_type         = "slow-log"
-  }
-
-  log_delivery_configuration {
-    destination      = aws_cloudwatch_log_group.notification-canada-ca-elasticache-engine-logs.name
-    destination_type = "cloudwatch-logs"
-    log_format       = "json"
-    log_type         = "engine-log"
-  }
-
-  tags = {
-    CostCenter = "notification-canada-ca-${var.env}"
-  }
-
-  lifecycle {
-    ignore_changes = [num_cache_clusters]
-  }
-}
-
-
-resource "aws_elasticache_replication_group" "notification_valkey_cluster" {
-
-  count = var.elasticache_use_valkey == true ? 1 : 0
-
-  apply_immediately           = true
-  automatic_failover_enabled  = true
-  preferred_cache_cluster_azs = ["ca-central-1b", "ca-central-1d", "ca-central-1a"]
-  replication_group_id        = "notify-${var.env}-cluster-cache-valkey"
-  description                 = "Valkey multiaz cluster with replication group"
-  node_type                   = var.elasticache_node_type
-  num_cache_clusters          = var.elasticache_node_number_cache_clusters
-  engine                      = "valkey"
-  engine_version              = "7.2"
-  parameter_group_name        = "default.valkey7"
+  engine                      = var.elasticache_use_valkey ? "valkey" : "redis"
+  engine_version              = var.elasticache_use_valkey ? "8.0" : "6.x"
+  parameter_group_name        = var.elasticache_use_valkey ? "default.valkey8" : "default.redis6.x"
   port                        = 6379
   maintenance_window          = "thu:04:00-thu:05:00"
   multi_az_enabled            = true

--- a/aws/elasticache/outputs.tf
+++ b/aws/elasticache/outputs.tf
@@ -5,6 +5,6 @@ output "redis_cluster_security_group_id" {
 
 output "redis_primary_endpoint_address" {
   description = "The address of the primary node for the cluster"
-  value       = var.elasticache_use_valkey == true ? aws_elasticache_replication_group.notification_valkey_cluster[0].primary_endpoint_address : aws_elasticache_replication_group.notification-cluster-cache-multiaz-group.primary_endpoint_address
+  value       = aws_elasticache_replication_group.notification-cluster-cache-multiaz-group.primary_endpoint_address
   sensitive   = true
 }

--- a/env/staging_config.tfvars
+++ b/env/staging_config.tfvars
@@ -66,7 +66,7 @@ vpc_cidr_block = "10.0.0.0/16"
 elasticache_node_count                 = 1
 elasticache_node_number_cache_clusters = 3
 elasticache_node_type                  = "cache.t3.medium"
-elasticache_use_valkey                 = false
+elasticache_use_valkey                 = true
 
 ## LOGGING
 log_retention_period_days           = 365


### PR DESCRIPTION
# Summary | Résumé

Convert staging to valkey. 

## Related Issues | Cartes liées

*  https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/437

## Test instructions | Instructions pour tester la modification

Run a load test against staging while merging.

TF Apply works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
