### PR TITLE
chore: add and organize cloudwatch queries

### DIFF
--- a/aws/eks/cloudwatch_queries.tf
+++ b/aws/eks/cloudwatch_queries.tf
@@ -212,6 +212,26 @@ fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as
 QUERY
 }
 
+resource "aws_cloudwatch_query_definition" "admin-slow-dashboards" {
+  count = var.cloudwatch_enabled ? 1 : 0
+  name  = "Admin / Slow Dashboards"
+
+  log_group_names = [
+    local.eks_application_log_group
+  ]
+
+  query_string = <<QUERY
+fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as pod_name, @logStream
+| filter kubernetes.container_name like /notify-admin/
+| filter @message like /MING: Total get_dashboard_partial/ and @message like 'dashboard.json'
+| parse @message "TIMING: Total get_dashboard_partials execution took *ms [Request details: time_taken: *ms full_path: '/services/*/dashboard.json?" @response_time, @discard, @service_id
+| stats avg(@response_time) as avg_response_time, max(@response_time) as max_response_time by @service_id
+| sort max_response_time desc
+| limit 100
+
+QUERY
+}
+
 resource "aws_cloudwatch_query_definition" "api-50X-errors" {
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "API / 50X errors"

--- a/aws/lambda-api/cloudwatch_queries.tf
+++ b/aws/lambda-api/cloudwatch_queries.tf
@@ -30,7 +30,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "api-gateway-504-timeouts" {
-  name = "API Gateway 504 timeouts grouped by hour"
+  name = "API Gateway / 504 timeouts grouped by hour"
 
   log_group_names = [
     local.api_gateway_log_group
@@ -47,7 +47,7 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "api_gateway_response_code_counts" {
   count = var.cloudwatch_enabled ? 1 : 0
-  name  = "API Gateway Response Code Counts"
+  name  = "API Gateway / Response Code Counts"
 
   log_group_names = [
     local.api_gateway_log_group
@@ -61,7 +61,7 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "api_gateway_count_requests_by_minute" {
   count = var.cloudwatch_enabled ? 1 : 0
-  name  = "API Gateway Requests By Minute"
+  name  = "API Gateway / Requests By Minute"
 
   log_group_names = [
     local.api_gateway_log_group
@@ -74,5 +74,70 @@ fields @timestamp, @message, @logStream, @log, status, httpMethod
 | stats (count(*)) by httpmethod, bin(1m) as minute
 | order by minute asc
 | limit 100
+QUERY
+}
+
+resource "aws_cloudwatch_query_definition" "get-trace-by-notification-id" {
+  count = var.cloudwatch_enabled ? 1 : 0
+  name  = "API / Get Trace By Notification ID"
+
+  log_group_names = [
+    local.api_lambda_log_group,
+    "API-Gateway-Execution-Logs_71oj6jax35"
+  ]
+
+  query_string = <<QUERY
+fields @timestamp, @message, @logStream
+| filter @message like /d9cc47e6-b1a3-4c83-8d3c-ab40874307b1/
+| filter @message like 'X-Amzn-Trace-Id'
+| parse "\"X-Amzn-Trace-Id\": [\"*\"]" as @trace_id
+| sort @timestamp asc
+| limit 100
+QUERY
+}
+
+resource "aws_cloudwatch_query_definition" "api-sending-times-aggregate" {
+  count = var.cloudwatch_enabled ? 1 : 0
+  name  = "API / API send times aggregate"
+
+  log_group_names = [
+    local.api_lambda_log_group
+  ]
+
+  query_string = <<QUERY
+fields @timestamp, @message, @logStream
+| filter @message like /time_taken/ and @message like /Batch saving/
+| parse @message "time_taken: *ms" as duration
+| parse @message "full_path: '/v2/notifications/*'" as send_type
+| parse @message "template_id: '*'" as template_id
+| sort @timestamp desc
+| stats 
+    count(*) as total_sends,
+    sum(if(duration <= 400, 1, 0)) as requests_under_400ms,
+    sum(if(duration > 400 and duration <= 1000, 1, 0)) as requests_under_1s,
+    sum(if(duration > 1000, 1, 0)) as requests_over_1s,
+    (sum(if(duration <= 400, 1, 0)) * 100.0 / count(*)) as percent_under_400ms,
+    (sum(if(duration > 400 and duration <= 1000, 1, 0)) * 100.0 / count(*)) as percent_under_1s, 
+    (sum(if(duration > 1000, 1, 0)) * 100.0 / count(*)) as percent_over_1s
+| limit 20
+QUERY
+}
+
+resource "aws_cloudwatch_query_definition" "api-slowest-sends" {
+  count = var.cloudwatch_enabled ? 1 : 0
+  name  = "API / API slowest sends"
+
+  log_group_names = [
+    local.api_lambda_log_group
+  ]
+
+  query_string = <<QUERY
+fields @timestamp, @message, @logStream
+| filter @message like /time_taken/ and @message like /Batch saving/
+| parse @message "time_taken: *ms" as duration
+| parse @message "full_path: '/v2/notifications/*'" as send_type
+| parse @message "template_id: '*'" as template_id
+| sort duration desc
+| limit 20
 QUERY
 }


### PR DESCRIPTION
# Summary | Résumé

This PR adds the following queries to help with troubleshooting issues:
- Admin / Slow Dashboards
- API / Get Trace By Notification ID
- API / API send times aggregate
- API / API slowest sends

And organizes the following queries into folders:
 - API Gateway / 504 timeouts grouped by hour
 - API Gateway / Response Code Counts
 - API Gateway / Requests By Minute

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/1919

## Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
