### PR TITLE
removing import that's no longer used

### DIFF
--- a/aws/lambda-api/cloudwatch_logs.tf
+++ b/aws/lambda-api/cloudwatch_logs.tf
@@ -2,11 +2,6 @@
 # API Gateway CloudWatch logging
 #
 
-import {
-  to = aws_cloudwatch_log_group.api_gateway_execution_log_group
-  id = "API-Gateway-Execution-Logs_${aws_api_gateway_rest_api.api.id}/${aws_api_gateway_stage.api.stage_name}"
-}
-
 resource "aws_cloudwatch_log_group" "api_gateway_log_group" {
   name              = "api_gateway_log_group"
   retention_in_days = var.log_retention_period_days


### PR DESCRIPTION
# Summary | Résumé

Need to remove this import so that dev can recreate. 

## Test instructions | Instructions pour tester la modification

TF Apply works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
