### PR TITLE
DNS Alarm Filters Take 3

### DIFF
--- a/aws/common/route53.tf
+++ b/aws/common/route53.tf
@@ -10,6 +10,10 @@ resource "aws_route53_resolver_query_log_config" "dns_query_log_config" {
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
   }
+
+  depends_on = [
+    aws_cloudwatch_log_resource_policy.route53_resolver_query_logging_policy
+  ]
 }
 
 resource "aws_route53_resolver_query_log_config_association" "dns_query_log_config_association" {
@@ -30,6 +34,10 @@ resource "aws_route53_resolver_query_log_config" "main" {
     CostCenter  = "notification-canada-ca-${var.env}"
     Service     = "dns-monitoring"
   }
+
+  depends_on = [
+    aws_cloudwatch_log_resource_policy.route53_resolver_query_logging_policy
+  ]
 }
 
 # Associate query logging with VPCs


### PR DESCRIPTION
# Summary | Résumé

Adding Depends On!

Attempting to adjust our filter so that it actually finds the proper records.  🤞🏻 

Changing the region as per the Route53 docs, and adding permissions for Route 53 to write to cloudwatch.

updating the actions to use the us-east-1 ones, and changing the patterns for the filters to use non json based ones specifically for Route53

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/73

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
