### PR TITLE
Fix for cloudwatch dns stuff

### DIFF
--- a/aws/common/route53.tf
+++ b/aws/common/route53.tf
@@ -17,12 +17,6 @@ resource "aws_route53_resolver_query_log_config" "dns_query_log_config" {
   ]
 }
 
-resource "aws_route53_resolver_query_log_config_association" "dns_query_log_config_association" {
-  count                        = var.cloudwatch_enabled ? 1 : 0
-  resolver_query_log_config_id = aws_route53_resolver_query_log_config.dns_query_log_config[0].id
-  resource_id                  = aws_vpc.notification-canada-ca.id
-}
-
 # Route53 Resolver Query Logging Configuration
 resource "aws_route53_resolver_query_log_config" "main" {
   provider = aws.us-east-1

--- a/aws/common/route53.tf
+++ b/aws/common/route53.tf
@@ -3,6 +3,7 @@
 ###
 
 resource "aws_route53_resolver_query_log_config" "dns_query_log_config" {
+  provider        = aws.us-east-1
   count           = var.cloudwatch_enabled ? 1 : 0
   name            = "${var.region}_${var.account_id}_dns_query_log_config"
   destination_arn = aws_cloudwatch_log_group.route53_resolver_query_log[0].arn
@@ -24,8 +25,9 @@ resource "aws_route53_resolver_query_log_config_association" "dns_query_log_conf
 
 # Route53 Resolver Query Logging Configuration
 resource "aws_route53_resolver_query_log_config" "main" {
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "route53-query-logging"
+  provider = aws.us-east-1
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "route53-query-logging"
 
   destination_arn = aws_cloudwatch_log_group.route53_resolver_query_log[0].arn
 


### PR DESCRIPTION
# Summary | Résumé

Running into some issues with dns query configs, this fixes part of it but the association is failing due to cross region resources. Will have to investigate that more.

## Related Issues | Cartes liées

*  https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/73

## Test instructions | Instructions pour tester la modification

TF Apply works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
