### PR TITLE
DNS Alarms Fixup

### DIFF
--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -11,8 +11,8 @@ resource "aws_cloudwatch_metric_alarm" "route53-dns-failures-warning" {
   alarm_name                = "route53-dns-resolution-failures-warning"
   comparison_operator       = "GreaterThanThreshold"
   evaluation_periods        = 3
-  metric_name               = "Route53DNSResolutionFailureCount"
-  namespace                 = "Route53/Resolver"
+  metric_name               = "Route53PublicDNSResolutionFailureCount"
+  namespace                 = "Route53/PublicResolver"
   period                    = 300 # 5 minutes
   statistic                 = "Sum"
   threshold                 = 5
@@ -30,8 +30,8 @@ resource "aws_cloudwatch_metric_alarm" "route53-dns-failures-critical" {
   alarm_name                = "route53-dns-resolution-failures-critical"
   comparison_operator       = "GreaterThanThreshold"
   evaluation_periods        = 5
-  metric_name               = "Route53DNSResolutionFailureCount"
-  namespace                 = "Route53/Resolver"
+  metric_name               = "Route53PublicDNSResolutionFailureCount"
+  namespace                 = "Route53/PublicResolver"
   period                    = 300 # 5 minutes
   statistic                 = "Sum"
   threshold                 = 20

--- a/aws/common/route53.tf
+++ b/aws/common/route53.tf
@@ -2,21 +2,6 @@
 # AWS Route 53 for Notification application
 ###
 
-resource "aws_route53_resolver_query_log_config" "dns_query_log_config" {
-  provider        = aws.us-east-1
-  count           = var.cloudwatch_enabled ? 1 : 0
-  name            = "${var.region}_${var.account_id}_dns_query_log_config"
-  destination_arn = aws_cloudwatch_log_group.route53_resolver_query_log[0].arn
-
-  tags = {
-    CostCenter = "notification-canada-ca-${var.env}"
-  }
-
-  depends_on = [
-    aws_cloudwatch_log_resource_policy.route53_resolver_query_logging_policy
-  ]
-}
-
 # Route53 Resolver Query Logging Configuration
 resource "aws_route53_resolver_query_log_config" "main" {
   provider = aws.us-east-1
@@ -34,14 +19,6 @@ resource "aws_route53_resolver_query_log_config" "main" {
   depends_on = [
     aws_cloudwatch_log_resource_policy.route53_resolver_query_logging_policy
   ]
-}
-
-# Associate query logging with VPCs
-resource "aws_route53_resolver_query_log_config_association" "main" {
-  count = var.cloudwatch_enabled ? length(var.vpc_ids) : 0
-
-  resolver_query_log_config_id = aws_route53_resolver_query_log_config.main[0].id
-  resource_id                  = var.vpc_ids[count.index]
 }
 
 # Metric Filter for NXDOMAIN errors on notification.cdssandbox.ca domain - public DNS only


### PR DESCRIPTION
# Summary | Résumé

Cleaning out unneeded code and setting the references so that the alarms actually work (hopefully)

Changing the region as per the Route53 docs, and adding permissions for Route 53 to write to cloudwatch.

updating the actions to use the us-east-1 ones, and changing the patterns for the filters to use non json based ones specifically for Route53

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/73

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
