### PR TITLE
Reduce SNS us-west-2 critical alarm threshold to 50%

### DIFF
--- a/aws/common/cloudwatch_alarms_sms.tf
+++ b/aws/common/cloudwatch_alarms_sms.tf
@@ -178,7 +178,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-us
   namespace           = "AWS/SNS"
   period              = 60 * 60 * 12
   statistic           = "Average"
-  threshold           = 75 / 100
+  threshold           = 50 / 100
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical-us-west-2.arn]
   ok_actions          = [aws_sns_topic.notification-canada-ca-alert-ok-us-west-2.arn]
   treat_missing_data  = "notBreaching"


### PR DESCRIPTION
# Summary | Résumé

We have so few dedicated long code numbers in us-west-2 that a single run by a client has the potential to trigger this alarm. We often get paged at 12-1am in the morning for this, which is not good. Reducing this threshold to 50% so that we can be alerted of larger failures but don't have to worry about individual success rates off hours.

## Related Issues | Cartes liées

Ad-hoc

## Test instructions | Instructions pour tester la modification

TF Apply works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
