### PR TITLE
fix(waf): Update regex patterns for admin WAF to include new endpoints

### DIFF
--- a/aws/common/waf.tf
+++ b/aws/common/waf.tf
@@ -101,7 +101,11 @@ resource "aws_wafv2_regex_pattern_set" "re_admin2" {
   # Additional regex for the Admin WAF should be added to this pattern set, not in re_admin, which is full.
 
   regular_expression {
-    regex_string = var.env == "production" ? "/sitemap|/plandesite|/agree-terms|/getting-started|/decouvrir-notification-gc|/template-category.*|/template-categories.*|/mettre-en-forme-les-courriels|/find-ids|/by-for-gc|/par-et-pour-gc" : "/sitemap|/plandesite|/agree-terms|/getting-started|/decouvrir-notification-gc|/template-category.*|/template-categories.*|/mettre-en-forme-les-courriels|/find-ids|/_storybook.*|/_preview_.*|/by-for-gc|/par-et-pour-gc"
+    regex_string = var.env == "production" ? "/sitemap|/plandesite|/agree-terms|/getting-started|/decouvrir-notification-gc|/template-category.*|/template-categories.*|/mettre-en-forme-les-courriels|/find-ids" : "/sitemap|/plandesite|/agree-terms|/getting-started|/decouvrir-notification-gc|/template-category.*|/template-categories.*|/mettre-en-forme-les-courriels|/find-ids|/_storybook.*|/_preview_.*"
+  }
+
+  regular_expression {
+    regex_string = "/by-for-gc|/par-et-pour-gc"
   }
 
   tags = {


### PR DESCRIPTION
# Summary | Résumé

This PR adds two new endpoints to the WAF for new GCA pages:

- `/by-for-gc`
- `/par-et-pour-gc`


## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/1984

## Test instructions | Instructions pour tester la modification
- Ensure pages can be accessed in staging and prod

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
