### PR TITLE
Removing the critical external/route53 bad DNS Alarm

### DIFF
--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -23,25 +23,6 @@ resource "aws_cloudwatch_metric_alarm" "route53-dns-failures-warning" {
   treat_missing_data        = "notBreaching"
 }
 
-# CloudWatch Alarm for Route53 DNS resolution failures (Critical)
-resource "aws_cloudwatch_metric_alarm" "route53-dns-failures-critical" {
-  provider                  = aws.us-east-1
-  count                     = var.cloudwatch_enabled ? 1 : 0
-  alarm_name                = "route53-dns-resolution-failures-critical"
-  comparison_operator       = "GreaterThanThreshold"
-  evaluation_periods        = 5
-  metric_name               = "Route53PublicDNSResolutionFailureCount"
-  namespace                 = "Route53/PublicResolver"
-  period                    = 300 # 5 minutes
-  statistic                 = "Sum"
-  threshold                 = 20
-  alarm_description         = "Alarm for Route53 DNS resolution failures exceeding threshold"
-  alarm_actions             = [aws_sns_topic.notification-canada-ca-alert-warning-us-east-1.arn]
-  insufficient_data_actions = [aws_sns_topic.notification-canada-ca-alert-warning-us-east-1.arn]
-  ok_actions                = [aws_sns_topic.notification-canada-ca-alert-ok-us-east-1.arn]
-  treat_missing_data        = "notBreaching"
-}
-
 resource "aws_cloudwatch_metric_alarm" "sqs-priority-queue-delay-warning" {
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-priority-queue-delay-warning"


### PR DESCRIPTION
# Summary | Résumé

Just removing an alarm we don't need

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/73

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
