### PR TITLE
Remove wildcard for DNS domains

### DIFF
--- a/aws/eks/dns.tf
+++ b/aws/eks/dns.tf
@@ -28,22 +28,6 @@ resource "aws_route53_record" "notification-www-root" {
 }
 
 
-resource "aws_route53_record" "notificatio-root-WC" {
-
-  provider        = aws.dns
-  name            = "*.${var.domain}"
-  zone_id         = var.route53_zone_id
-  type            = "A"
-  allow_overwrite = true
-
-  alias {
-    name                   = aws_alb.notification-canada-ca.dns_name
-    zone_id                = aws_alb.notification-canada-ca.zone_id
-    evaluate_target_health = false
-  }
-
-}
-
 resource "aws_route53_record" "doc-notification-canada-ca-cname" {
   provider        = aws.dns
   zone_id         = var.route53_zone_id


### PR DESCRIPTION
# Summary | Résumé

Removing the wildcard CNAME for *.notification.canada.ca (or *.env.notification.cdssandbox.xyz) so that you can't resolve things like staging.notification.canada.ca 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/519

## Test instructions | Instructions pour tester la modification

- [ ] TF Apply works
- [ ] Verify you can still hit staging.notification.canada.ca
- [ ] Verify that you can not hit someurl.staging.notification.canada.ca

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
