### PR TITLE
Secondary elasticache cluster for queues

### DIFF
--- a/aws/elasticache/cloudwatch_log.tf
+++ b/aws/elasticache/cloudwatch_log.tf
@@ -13,3 +13,15 @@ resource "aws_cloudwatch_log_group" "redis-batch-saving" {
   retention_in_days = var.log_retention_period_days
   kms_key_id        = var.kms_arn
 }
+
+resource "aws_cloudwatch_log_group" "elasticache_queue_cache_slow_logs" {
+  count             = var.env == "dev" ? 1 : 0
+  name              = "/aws/elasticache/notify-${var.env}-queue-cache/slow-logs"
+  retention_in_days = var.log_retention_period_days
+}
+
+resource "aws_cloudwatch_log_group" "elasticache_queue_cache_engine_logs" {
+  count             = var.env == "dev" ? 1 : 0
+  name              = "/aws/elasticache/notify-${var.env}-queue-cache/engine-logs"
+  retention_in_days = var.log_retention_period_days
+}


### PR DESCRIPTION
# Summary | Résumé

This will create a secondary elasticache valkey cluster in dev in preparation for splitting the celery queues from admin/api valkey.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/565

## Test instructions | Instructions pour tester la modification

Staging/prod show no changes

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
