### PR TITLE
Split valkey in dev

### DIFF
--- a/aws/elasticache/cloudwatch_log.tf
+++ b/aws/elasticache/cloudwatch_log.tf
@@ -13,3 +13,15 @@ resource "aws_cloudwatch_log_group" "redis-batch-saving" {
   retention_in_days = var.log_retention_period_days
   kms_key_id        = var.kms_arn
 }
+
+resource "aws_cloudwatch_log_group" "elasticache_queue_cache_slow_logs" {
+  count             = var.env == "dev" ? 1 : 0
+  name              = "/aws/elasticache/notify-${var.env}-queue-cache/slow-logs"
+  retention_in_days = var.log_retention_period_days
+}
+
+resource "aws_cloudwatch_log_group" "elasticache_queue_cache_engine_logs" {
+  count             = var.env == "dev" ? 1 : 0
+  name              = "/aws/elasticache/notify-${var.env}-queue-cache/engine-logs"
+  retention_in_days = var.log_retention_period_days
+}

--- a/aws/elasticache/outputs.tf
+++ b/aws/elasticache/outputs.tf
@@ -8,3 +8,9 @@ output "redis_primary_endpoint_address" {
   value       = aws_elasticache_replication_group.notification-cluster-cache-multiaz-group.primary_endpoint_address
   sensitive   = true
 }
+
+output "elasticache_queue_cache_primary_endpoint_address" {
+  description = "The address of the primary node for the cluster"
+  value       = var.env == "dev" ? aws_elasticache_replication_group.elasticache_queue_cache[0].primary_endpoint_address : null
+  sensitive   = true
+}

--- a/aws/manifest_secrets/secrets.tf
+++ b/aws/manifest_secrets/secrets.tf
@@ -397,7 +397,7 @@ resource "aws_secretsmanager_secret" "manifest_redis_publish_url" {
 
 resource "aws_secretsmanager_secret_version" "manifest_redis_publish_url" {
   secret_id     = aws_secretsmanager_secret.manifest_redis_publish_url.id
-  secret_string = "redis://${var.redis_primary_endpoint_address}"
+  secret_string = var.env == "dev" ? "redis://${var.elasticache_queue_cache_primary_endpoint_address}" : "redis://${var.redis_primary_endpoint_address}"
 }
 
 resource "aws_secretsmanager_secret" "manifest_redis_url" {

--- a/aws/manifest_secrets/variables.tf
+++ b/aws/manifest_secrets/variables.tf
@@ -13,3 +13,7 @@ variable "postgres_cluster_endpoint" {
 variable "redis_primary_endpoint_address" {
   type = string
 }
+
+variable "elasticache_queue_cache_primary_endpoint_address" {
+  type = string
+}

--- a/env/dev/manifest_secrets/terragrunt.hcl
+++ b/env/dev/manifest_secrets/terragrunt.hcl
@@ -21,6 +21,7 @@ dependency "elasticache" {
   mock_outputs_allowed_terraform_commands = ["validate", "plan"]
   mock_outputs = {
     redis_primary_endpoint_address = "thisisamockstring_redis_primary_endpoint_address"
+    elasticache_queue_cache_primary_endpoint_address = "thisisamockstring_elasticache_queue_cache_primary_endpoint_address"
   }
 }
 
@@ -33,4 +34,5 @@ inputs = {
   database_read_write_proxy_endpoint = dependency.rds.outputs.database_read_write_proxy_endpoint
   postgres_cluster_endpoint = dependency.rds.outputs.postgres_cluster_endpoint
   redis_primary_endpoint_address = dependency.elasticache.outputs.redis_primary_endpoint_address
+  elasticache_queue_cache_primary_endpoint_address = dependency.elasticache.outputs.elasticache_queue_cache_primary_endpoint_address
 }


### PR DESCRIPTION
# Summary | Résumé

Splitting the queue and cache for valkey in dev

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/565

## Test instructions | Instructions pour tester la modification

TF Apply works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
