### PR TITLE
upping vpn module back up to latest

### DIFF
--- a/aws/eks/vpn.tf
+++ b/aws/eks/vpn.tf
@@ -29,7 +29,7 @@ module "vpn" {
 
 # GHA VPN
 module "gha_vpn" {
-  source = "github.com/cds-snc/terraform-modules//client_vpn?ref=v9.6.4"
+  source = "github.com/cds-snc/terraform-modules//client_vpn?ref=v10.6.0"
 
   endpoint_name   = "gha-vpn"
   access_group_id = var.client_vpn_access_group_id


### PR DESCRIPTION
# Summary | Résumé

Upping VPN back up to latest - I have confirmed this works in dev. It is possible the reason why it didn't work in staging before was because the certificate had already expired.

## Related Issues | Cartes liées

adhoc

## Test instructions | Instructions pour tester la modification

TF Apply in staging
verify that github actions VPN still works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
