### PR TITLE
Elasticache Queue

### DIFF
--- a/aws/elasticache/cloudwatch_alarms.tf
+++ b/aws/elasticache/cloudwatch_alarms.tf
@@ -98,7 +98,7 @@ resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-connection-warnin
 # Queue Cache Alarms
 
 resource "aws_cloudwatch_metric_alarm" "elasticache_queue_medium_cpu_warning" {
-  count               = var.elasticache_node_number_cache_clusters
+  count               = var.env != "production" ? var.elasticache_node_number_cache_clusters : 0
   alarm_name          = "elasticache-queue-medium-cpu-warning-CacheCluster00${count.index + 1}CPUUtilization"
   alarm_description   = "Average CPU of Redis ElastiCache >= 50% during 1 minute"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -118,7 +118,7 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_queue_medium_cpu_warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "elasticache_queue_high_cpu_warning" {
-  count               = var.elasticache_node_number_cache_clusters
+  count               = var.env != "production" ? var.elasticache_node_number_cache_clusters : 0
   alarm_name          = "elasticache-queue-high-cpu-warning-CacheCluster00${count.index + 1}CPUUtilization"
   alarm_description   = "Average CPU of Redis ElastiCache >= 70% during 1 minute "
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -137,7 +137,7 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_queue_high_cpu_warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "elasticache_queue_high_db_memory_warning" {
-  count               = var.elasticache_node_number_cache_clusters
+  count               = var.env != "production" ? var.elasticache_node_number_cache_clusters : 0
   alarm_name          = "elasticache-queue-high-db-memory-warning-CacheCluster00${count.index + 1}"
   alarm_description   = "Average DB Memory on Redis ElastiCache >= 60% during 1 minute"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -156,7 +156,7 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_queue_high_db_memory_warning
 }
 
 resource "aws_cloudwatch_metric_alarm" "elasticache_queue_high_db_memory_critical" {
-  count               = var.elasticache_node_number_cache_clusters
+  count               = var.env != "production" ? var.elasticache_node_number_cache_clusters : 0
   alarm_name          = "elasticache-queue-high-db-memory-critical-CacheCluster00${count.index + 1}"
   alarm_description   = "Average DB Memory on Redis ElastiCache >= 85% during 1 minute"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -175,7 +175,7 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_queue_high_db_memory_critica
 }
 
 resource "aws_cloudwatch_metric_alarm" "elasticache_queue_high_db_connection_warning" {
-  count               = var.elasticache_node_number_cache_clusters
+  count               = var.env != "production" ? var.elasticache_node_number_cache_clusters : 0
   alarm_name          = "elasticache-queue-high-connection-warning-CacheCluster00${count.index + 1}"
   alarm_description   = "Average Number of Connections on Redis ElastiCache >= 1000 connections during 1 minute"
   comparison_operator = "GreaterThanOrEqualToThreshold"

--- a/aws/elasticache/cloudwatch_alarms.tf
+++ b/aws/elasticache/cloudwatch_alarms.tf
@@ -93,3 +93,102 @@ resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-connection-warnin
     CacheClusterId = "${aws_elasticache_replication_group.notification-cluster-cache-multiaz-group.id}-00${count.index + 1}"
   }
 }
+
+
+# Queue Cache Alarms
+
+resource "aws_cloudwatch_metric_alarm" "elasticache_queue_medium_cpu_warning" {
+  count               = var.elasticache_node_number_cache_clusters
+  alarm_name          = "elasticache-queue-medium-cpu-warning-CacheCluster00${count.index + 1}CPUUtilization"
+  alarm_description   = "Average CPU of Redis ElastiCache >= 50% during 1 minute"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ElastiCache"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = 50
+  alarm_actions       = [var.sns_alert_warning_arn]
+  ok_actions          = [var.sns_alert_warning_arn]
+  treat_missing_data  = "breaching"
+
+  dimensions = {
+    CacheClusterId = "${aws_elasticache_replication_group.notification-cluster-cache-multiaz-group.id}-00${count.index + 1}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "elasticache_queue_high_cpu_warning" {
+  count               = var.elasticache_node_number_cache_clusters
+  alarm_name          = "elasticache-queue-high-cpu-warning-CacheCluster00${count.index + 1}CPUUtilization"
+  alarm_description   = "Average CPU of Redis ElastiCache >= 70% during 1 minute "
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ElastiCache"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = 70
+  alarm_actions       = [var.sns_alert_warning_arn]
+  ok_actions          = [var.sns_alert_warning_arn]
+  treat_missing_data  = "breaching"
+  dimensions = {
+    CacheClusterId = "${aws_elasticache_replication_group.notification-cluster-cache-multiaz-group.id}-00${count.index + 1}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "elasticache_queue_high_db_memory_warning" {
+  count               = var.elasticache_node_number_cache_clusters
+  alarm_name          = "elasticache-queue-high-db-memory-warning-CacheCluster00${count.index + 1}"
+  alarm_description   = "Average DB Memory on Redis ElastiCache >= 60% during 1 minute"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "DatabaseMemoryUsagePercentage"
+  namespace           = "AWS/ElastiCache"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = 60
+  alarm_actions       = [var.sns_alert_warning_arn]
+  ok_actions          = [var.sns_alert_warning_arn]
+  treat_missing_data  = "missing"
+  dimensions = {
+    CacheClusterId = "${aws_elasticache_replication_group.notification-cluster-cache-multiaz-group.id}-00${count.index + 1}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "elasticache_queue_high_db_memory_critical" {
+  count               = var.elasticache_node_number_cache_clusters
+  alarm_name          = "elasticache-queue-high-db-memory-critical-CacheCluster00${count.index + 1}"
+  alarm_description   = "Average DB Memory on Redis ElastiCache >= 85% during 1 minute"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "DatabaseMemoryUsagePercentage"
+  namespace           = "AWS/ElastiCache"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = 85
+  alarm_actions       = [var.sns_alert_critical_arn]
+  ok_actions          = [var.sns_alert_critical_arn]
+  treat_missing_data  = "missing"
+  dimensions = {
+    CacheClusterId = "${aws_elasticache_replication_group.notification-cluster-cache-multiaz-group.id}-00${count.index + 1}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "elasticache_queue_high_db_connection_warning" {
+  count               = var.elasticache_node_number_cache_clusters
+  alarm_name          = "elasticache-queue-high-connection-warning-CacheCluster00${count.index + 1}"
+  alarm_description   = "Average Number of Connections on Redis ElastiCache >= 1000 connections during 1 minute"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "CurrConnections"
+  namespace           = "AWS/ElastiCache"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = 1000
+  alarm_actions       = [var.sns_alert_warning_arn]
+  ok_actions          = [var.sns_alert_warning_arn]
+  treat_missing_data  = "missing"
+  dimensions = {
+    CacheClusterId = "${aws_elasticache_replication_group.notification-cluster-cache-multiaz-group.id}-00${count.index + 1}"
+  }
+}

--- a/aws/elasticache/cloudwatch_log.tf
+++ b/aws/elasticache/cloudwatch_log.tf
@@ -15,13 +15,13 @@ resource "aws_cloudwatch_log_group" "redis-batch-saving" {
 }
 
 resource "aws_cloudwatch_log_group" "elasticache_queue_cache_slow_logs" {
-  count             = var.env == "dev" ? 1 : 0
+  count             = var.env != "production" ? 1 : 0
   name              = "/aws/elasticache/notify-${var.env}-queue-cache/slow-logs"
   retention_in_days = var.log_retention_period_days
 }
 
 resource "aws_cloudwatch_log_group" "elasticache_queue_cache_engine_logs" {
-  count             = var.env == "dev" ? 1 : 0
+  count             = var.env != "production" ? 1 : 0
   name              = "/aws/elasticache/notify-${var.env}-queue-cache/engine-logs"
   retention_in_days = var.log_retention_period_days
 }


### PR DESCRIPTION
# Summary | Résumé

Adding new elasticache queue with resource monitoring alarms. This re-implements the revert that we did yesterday that I think was just because I didn't restart the celery pods.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/565

## Test instructions | Instructions pour tester la modification

TF Apply works
Restart celery pods
Verify alarms are good

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
