### PR TITLE
Elasticache Split Again

### DIFF
--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -39,7 +39,7 @@ jobs:
       dns: ${{ steps.filter.outputs.dns }}
       ses_validation_dns_entries: ${{ steps.filter.outputs.ses_validation_dns_entries }}
       eks: ${{ steps.filter.outputs.eks }}
-      elasticache: $${{ steps.filter.outputs.elasticache }}
+      elasticache: ${{ steps.filter.outputs.elasticache }}
       aws-auth: ${{ steps.filter.outputs.aws-auth }}
       rds: ${{ steps.filter.outputs.rds }}
       lambda-api: ${{ steps.filter.outputs.lambda-api }}
@@ -512,7 +512,7 @@ jobs:
       !contains(needs.*.result, 'cancelled') ||
       needs.terragrunt-filter.outputs.config == 'true'
     runs-on: ubuntu-latest  
-    needs: [terragrunt-filter,terragrunt-plan-common,terragrunt-plan-eks]
+    needs: [terragrunt-filter]
     env:
       COMPONENT: "elasticache"
     steps:

--- a/aws/elasticache/cloudwatch_alarms.tf
+++ b/aws/elasticache/cloudwatch_alarms.tf
@@ -93,3 +93,102 @@ resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-connection-warnin
     CacheClusterId = "${aws_elasticache_replication_group.notification-cluster-cache-multiaz-group.id}-00${count.index + 1}"
   }
 }
+
+
+# Queue Cache Alarms
+
+resource "aws_cloudwatch_metric_alarm" "elasticache_queue_medium_cpu_warning" {
+  count               = var.env != "production" ? var.elasticache_node_number_cache_clusters : 0
+  alarm_name          = "elasticache-queue-medium-cpu-warning-CacheCluster00${count.index + 1}CPUUtilization"
+  alarm_description   = "Average CPU of Redis ElastiCache >= 50% during 1 minute"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ElastiCache"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = 50
+  alarm_actions       = [var.sns_alert_warning_arn]
+  ok_actions          = [var.sns_alert_warning_arn]
+  treat_missing_data  = "breaching"
+
+  dimensions = {
+    CacheClusterId = "${aws_elasticache_replication_group.notification-cluster-cache-multiaz-group.id}-00${count.index + 1}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "elasticache_queue_high_cpu_warning" {
+  count               = var.env != "production" ? var.elasticache_node_number_cache_clusters : 0
+  alarm_name          = "elasticache-queue-high-cpu-warning-CacheCluster00${count.index + 1}CPUUtilization"
+  alarm_description   = "Average CPU of Redis ElastiCache >= 70% during 1 minute "
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ElastiCache"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = 70
+  alarm_actions       = [var.sns_alert_warning_arn]
+  ok_actions          = [var.sns_alert_warning_arn]
+  treat_missing_data  = "breaching"
+  dimensions = {
+    CacheClusterId = "${aws_elasticache_replication_group.notification-cluster-cache-multiaz-group.id}-00${count.index + 1}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "elasticache_queue_high_db_memory_warning" {
+  count               = var.env != "production" ? var.elasticache_node_number_cache_clusters : 0
+  alarm_name          = "elasticache-queue-high-db-memory-warning-CacheCluster00${count.index + 1}"
+  alarm_description   = "Average DB Memory on Redis ElastiCache >= 60% during 1 minute"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "DatabaseMemoryUsagePercentage"
+  namespace           = "AWS/ElastiCache"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = 60
+  alarm_actions       = [var.sns_alert_warning_arn]
+  ok_actions          = [var.sns_alert_warning_arn]
+  treat_missing_data  = "missing"
+  dimensions = {
+    CacheClusterId = "${aws_elasticache_replication_group.notification-cluster-cache-multiaz-group.id}-00${count.index + 1}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "elasticache_queue_high_db_memory_critical" {
+  count               = var.env != "production" ? var.elasticache_node_number_cache_clusters : 0
+  alarm_name          = "elasticache-queue-high-db-memory-critical-CacheCluster00${count.index + 1}"
+  alarm_description   = "Average DB Memory on Redis ElastiCache >= 85% during 1 minute"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "DatabaseMemoryUsagePercentage"
+  namespace           = "AWS/ElastiCache"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = 85
+  alarm_actions       = [var.sns_alert_critical_arn]
+  ok_actions          = [var.sns_alert_critical_arn]
+  treat_missing_data  = "missing"
+  dimensions = {
+    CacheClusterId = "${aws_elasticache_replication_group.notification-cluster-cache-multiaz-group.id}-00${count.index + 1}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "elasticache_queue_high_db_connection_warning" {
+  count               = var.env != "production" ? var.elasticache_node_number_cache_clusters : 0
+  alarm_name          = "elasticache-queue-high-connection-warning-CacheCluster00${count.index + 1}"
+  alarm_description   = "Average Number of Connections on Redis ElastiCache >= 1000 connections during 1 minute"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "CurrConnections"
+  namespace           = "AWS/ElastiCache"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = 1000
+  alarm_actions       = [var.sns_alert_warning_arn]
+  ok_actions          = [var.sns_alert_warning_arn]
+  treat_missing_data  = "missing"
+  dimensions = {
+    CacheClusterId = "${aws_elasticache_replication_group.notification-cluster-cache-multiaz-group.id}-00${count.index + 1}"
+  }
+}

--- a/aws/elasticache/elasticache.tf
+++ b/aws/elasticache/elasticache.tf
@@ -60,7 +60,7 @@ resource "aws_elasticache_replication_group" "notification-cluster-cache-multiaz
 
 resource "aws_elasticache_replication_group" "elasticache_queue_cache" {
 
-  count = var.env == "dev" ? 1 : 0
+  count = var.env != "production" ? 1 : 0
 
   apply_immediately           = true
   automatic_failover_enabled  = true

--- a/aws/elasticache/outputs.tf
+++ b/aws/elasticache/outputs.tf
@@ -11,6 +11,6 @@ output "redis_primary_endpoint_address" {
 
 output "elasticache_queue_cache_primary_endpoint_address" {
   description = "The address of the primary node for the cluster"
-  value       = var.env == "dev" ? aws_elasticache_replication_group.elasticache_queue_cache[0].primary_endpoint_address : null
+  value       = var.env != "production" ? aws_elasticache_replication_group.elasticache_queue_cache[0].primary_endpoint_address : null
   sensitive   = true
 }

--- a/aws/manifest_secrets/secrets.tf
+++ b/aws/manifest_secrets/secrets.tf
@@ -397,7 +397,7 @@ resource "aws_secretsmanager_secret" "manifest_redis_publish_url" {
 
 resource "aws_secretsmanager_secret_version" "manifest_redis_publish_url" {
   secret_id     = aws_secretsmanager_secret.manifest_redis_publish_url.id
-  secret_string = var.env == "dev" ? "redis://${var.elasticache_queue_cache_primary_endpoint_address}" : "redis://${var.redis_primary_endpoint_address}"
+  secret_string = var.env != "production" ? "redis://${var.elasticache_queue_cache_primary_endpoint_address}" : "redis://${var.redis_primary_endpoint_address}"
 }
 
 resource "aws_secretsmanager_secret" "manifest_redis_url" {

--- a/env/dev/manifest_secrets/terragrunt.hcl
+++ b/env/dev/manifest_secrets/terragrunt.hcl
@@ -18,7 +18,8 @@ dependency "rds" {
 
 dependency "elasticache" {
   config_path = "../elasticache"
-  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
   mock_outputs = {
     redis_primary_endpoint_address = "thisisamockstring_redis_primary_endpoint_address"
     elasticache_queue_cache_primary_endpoint_address = "thisisamockstring_elasticache_queue_cache_primary_endpoint_address"

--- a/env/staging/manifest_secrets/terragrunt.hcl
+++ b/env/staging/manifest_secrets/terragrunt.hcl
@@ -18,9 +18,11 @@ dependency "rds" {
 
 dependency "elasticache" {
   config_path = "../elasticache"
-  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
   mock_outputs = {
     redis_primary_endpoint_address = "thisisamockstring_redis_primary_endpoint_address"
+    elasticache_queue_cache_primary_endpoint_address = "thisisamockstring_elasticache_queue_cache_primary_endpoint_address"
   }
 }
 
@@ -33,4 +35,5 @@ inputs = {
   database_read_write_proxy_endpoint = dependency.rds.outputs.database_read_write_proxy_endpoint
   postgres_cluster_endpoint = dependency.rds.outputs.postgres_cluster_endpoint
   redis_primary_endpoint_address = dependency.elasticache.outputs.redis_primary_endpoint_address
+  elasticache_queue_cache_primary_endpoint_address = dependency.elasticache.outputs.elasticache_queue_cache_primary_endpoint_address
 }


### PR DESCRIPTION
# Summary | Résumé

Splitting elasticache back into two so I can debug this in staging.

## Related Issues | Cartes liées

*  https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/565

## Test instructions | Instructions pour tester la modification

TF Apply
Smoke Tests
Debug!

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
