### PR TITLE
CoreDNS Logging and Alerting

### DIFF
--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -4,6 +4,22 @@
 #
 # There are also alarms defined in aws/eks/cloudwatch_alarms.tf
 
+resource "aws_cloudwatch_metric_alarm" "coredns-nxdomain-notification-warning" {
+  count               = var.cloudwatch_enabled ? 1 : 0
+  alarm_name          = "coredns-nxdomain-notification-warning"
+  alarm_description   = "More than 30 NXDOMAIN responses containing 'notification' in CoreDNS logs in 5 minutes"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "CoreDNSNXDOMAINNotificationCount"
+  namespace           = "NotificationCanadaCa/DNS"
+  period              = 300 # 5 minutes
+  statistic           = "Sum"
+  threshold           = 30
+  alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
+  ok_actions          = [aws_sns_topic.notification-canada-ca-alert-ok.arn]
+  treat_missing_data  = "notBreaching"
+}
+
 # CloudWatch Alarm for Route53 DNS resolution failures (Warning)
 resource "aws_cloudwatch_metric_alarm" "route53-dns-failures-warning" {
   provider                  = aws.us-east-1

--- a/aws/common/dns.tf
+++ b/aws/common/dns.tf
@@ -1,4 +1,21 @@
 ###
+# CORE DNS resources for Notification application
+###
+
+resource "aws_cloudwatch_log_metric_filter" "coredns-nxdomain-notification-filter" {
+  count          = var.cloudwatch_enabled ? 1 : 0
+  name           = "CoreDNSNXDOMAINNotificationFilter"
+  log_group_name = "/aws/containerinsights/${var.eks_cluster_name}/application"
+  pattern        = "{ $.log = \"*notification*\" && $.log = \"*NXDOMAIN*\" }"
+
+  metric_transformation {
+    name      = "CoreDNSNXDOMAINNotificationCount"
+    namespace = "NotificationCanadaCa/DNS"
+    value     = "1"
+  }
+}
+
+###
 # AWS Route 53 for Notification application
 ###
 

--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -184,6 +184,13 @@ resource "aws_eks_addon" "coredns" {
     corefile = <<-EOF
       .:53 {
           errors
+          log . {
+              class denial
+              class error
+              class success {
+                  name regex .*\.notification-canada-ca\.svc\.cluster\.local\.
+              }
+          }
           health {
               lameduck 5s
             }
@@ -193,7 +200,9 @@ resource "aws_eks_addon" "coredns" {
             fallthrough in-addr.arpa ip6.arpa
           }
           prometheus :9153
-          forward . /etc/resolv.conf
+          forward . /etc/resolv.conf {
+              except cluster.local
+          }
           cache 60
           loop
           reload

--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -184,20 +184,16 @@ resource "aws_eks_addon" "coredns" {
     corefile = <<-EOF
       .:53 {
           errors
-          log . {
+          log . notification {
               class denial
-              class error
-              class success {
-                  name regex .*\.notification-canada-ca\.svc\.cluster\.local\.
-              }
           }
           health {
               lameduck 5s
-            }
+          }
           ready
           kubernetes cluster.local in-addr.arpa ip6.arpa {
-            pods insecure
-            fallthrough in-addr.arpa ip6.arpa
+              pods insecure
+              fallthrough in-addr.arpa ip6.arpa
           }
           prometheus :9153
           forward . /etc/resolv.conf {
@@ -238,3 +234,4 @@ resource "aws_eks_addon" "ebs_driver" {
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"
 }
+


### PR DESCRIPTION
# Summary | Résumé

PR to adjust the log plugin for core DNS so that we are getting nxdomains -- also adding an alert and filter to trigger on logs containing "notification" and "nxdomain".  This is too sensitive as is, so we will have to discuss more precise targets.

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/607

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
