### PR TITLE
splitting config for valkey

### DIFF
--- a/aws/elasticache/cloudwatch_alarms.tf
+++ b/aws/elasticache/cloudwatch_alarms.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_metric_alarm" "redis-elasticache-medium-cpu-warning" {
-  count               = var.elasticache_node_number_cache_clusters
+  count               = var.elasticache_admin_cache_node_count
   alarm_name          = "redis-elasticache-medium-cpu-warning-CacheCluster00${count.index + 1}CPUUtilization"
   alarm_description   = "Average CPU of Redis ElastiCache >= 50% during 1 minute"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -19,7 +19,7 @@ resource "aws_cloudwatch_metric_alarm" "redis-elasticache-medium-cpu-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-cpu-warning" {
-  count               = var.elasticache_node_number_cache_clusters
+  count               = var.elasticache_admin_cache_node_count
   alarm_name          = "redis-elasticache-high-cpu-warning-CacheCluster00${count.index + 1}CPUUtilization"
   alarm_description   = "Average CPU of Redis ElastiCache >= 70% during 1 minute "
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -38,7 +38,7 @@ resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-cpu-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-db-memory-warning" {
-  count               = var.elasticache_node_number_cache_clusters
+  count               = var.elasticache_admin_cache_node_count
   alarm_name          = "redis-elasticache-high-db-memory-warning-CacheCluster00${count.index + 1}"
   alarm_description   = "Average DB Memory on Redis ElastiCache >= 60% during 1 minute"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -57,7 +57,7 @@ resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-db-memory-warning
 }
 
 resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-db-memory-critical" {
-  count               = var.elasticache_node_number_cache_clusters
+  count               = var.elasticache_admin_cache_node_count
   alarm_name          = "redis-elasticache-high-db-memory-critical-CacheCluster00${count.index + 1}"
   alarm_description   = "Average DB Memory on Redis ElastiCache >= 85% during 1 minute"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -76,7 +76,7 @@ resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-db-memory-critica
 }
 
 resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-connection-warning" {
-  count               = var.elasticache_node_number_cache_clusters
+  count               = var.elasticache_admin_cache_node_count
   alarm_name          = "redis-elasticache-high-connection-warning-CacheCluster00${count.index + 1}"
   alarm_description   = "Average Number of Connections on Redis ElastiCache >= 1000 connections during 1 minute"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -98,7 +98,7 @@ resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-connection-warnin
 # Queue Cache Alarms
 
 resource "aws_cloudwatch_metric_alarm" "elasticache_queue_medium_cpu_warning" {
-  count               = var.env != "production" ? var.elasticache_node_number_cache_clusters : 0
+  count               = var.env != "production" ? var.elasticache_cache_ops_node_count : 0
   alarm_name          = "elasticache-queue-medium-cpu-warning-CacheCluster00${count.index + 1}CPUUtilization"
   alarm_description   = "Average CPU of Redis ElastiCache >= 50% during 1 minute"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -118,7 +118,7 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_queue_medium_cpu_warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "elasticache_queue_high_cpu_warning" {
-  count               = var.env != "production" ? var.elasticache_node_number_cache_clusters : 0
+  count               = var.env != "production" ? var.elasticache_cache_ops_node_count : 0
   alarm_name          = "elasticache-queue-high-cpu-warning-CacheCluster00${count.index + 1}CPUUtilization"
   alarm_description   = "Average CPU of Redis ElastiCache >= 70% during 1 minute "
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -137,7 +137,7 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_queue_high_cpu_warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "elasticache_queue_high_db_memory_warning" {
-  count               = var.env != "production" ? var.elasticache_node_number_cache_clusters : 0
+  count               = var.env != "production" ? var.elasticache_cache_ops_node_count : 0
   alarm_name          = "elasticache-queue-high-db-memory-warning-CacheCluster00${count.index + 1}"
   alarm_description   = "Average DB Memory on Redis ElastiCache >= 60% during 1 minute"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -156,7 +156,7 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_queue_high_db_memory_warning
 }
 
 resource "aws_cloudwatch_metric_alarm" "elasticache_queue_high_db_memory_critical" {
-  count               = var.env != "production" ? var.elasticache_node_number_cache_clusters : 0
+  count               = var.env != "production" ? var.elasticache_cache_ops_node_count : 0
   alarm_name          = "elasticache-queue-high-db-memory-critical-CacheCluster00${count.index + 1}"
   alarm_description   = "Average DB Memory on Redis ElastiCache >= 85% during 1 minute"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -175,7 +175,7 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_queue_high_db_memory_critica
 }
 
 resource "aws_cloudwatch_metric_alarm" "elasticache_queue_high_db_connection_warning" {
-  count               = var.env != "production" ? var.elasticache_node_number_cache_clusters : 0
+  count               = var.env != "production" ? var.elasticache_cache_ops_node_count : 0
   alarm_name          = "elasticache-queue-high-connection-warning-CacheCluster00${count.index + 1}"
   alarm_description   = "Average Number of Connections on Redis ElastiCache >= 1000 connections during 1 minute"
   comparison_operator = "GreaterThanOrEqualToThreshold"

--- a/aws/elasticache/elasticache.tf
+++ b/aws/elasticache/elasticache.tf
@@ -19,8 +19,8 @@ resource "aws_elasticache_replication_group" "notification-cluster-cache-multiaz
   preferred_cache_cluster_azs = ["ca-central-1b", "ca-central-1d", "ca-central-1a"]
   replication_group_id        = "notify-${var.env}-cluster-cache-az"
   description                 = "Redis/Valkey multiaz cluster with replication group"
-  node_type                   = var.elasticache_node_type
-  num_cache_clusters          = var.elasticache_node_number_cache_clusters
+  node_type                   = var.elasticache_admin_cache_node_type
+  num_cache_clusters          = var.elasticache_admin_cache_node_count
   engine                      = var.elasticache_use_valkey ? "valkey" : "redis"
   engine_version              = var.elasticache_use_valkey ? "8.0" : "6.x"
   parameter_group_name        = var.elasticache_use_valkey ? "default.valkey8" : "default.redis6.x"
@@ -67,8 +67,8 @@ resource "aws_elasticache_replication_group" "elasticache_queue_cache" {
   preferred_cache_cluster_azs = ["ca-central-1b", "ca-central-1d", "ca-central-1a"]
   replication_group_id        = "notify-${var.env}-queue-cache"
   description                 = "Redis/Valkey multiaz cluster with replication group for Celery queues"
-  node_type                   = var.elasticache_node_type
-  num_cache_clusters          = var.elasticache_node_number_cache_clusters
+  node_type                   = var.elasticache_cache_ops_node_type
+  num_cache_clusters          = var.elasticache_cache_ops_node_count
   engine                      = "valkey"
   engine_version              = "8.0"
   parameter_group_name        = "default.valkey8"

--- a/env/dev_config.tfvars
+++ b/env/dev_config.tfvars
@@ -67,9 +67,12 @@ sensitive_log_retention_period_days = 14
 vpc_cidr_block = "10.0.0.0/16"
 
 ## ELASTICACHE
-elasticache_node_count                 = 1
-elasticache_node_number_cache_clusters = 3
-elasticache_node_type                  = "cache.t3.micro"
+elasticache_cache_ops_node_count = 3
+elasticache_cache_ops_node_type  = "cache.t3.micro"
+
+elasticache_admin_cache_node_count = 3
+elasticache_admin_cache_node_type = "cache.t3.micro"
+
 elasticache_use_valkey                 = true
 
 ## SLACK INTEGRATION

--- a/env/production_config.tfvars
+++ b/env/production_config.tfvars
@@ -67,9 +67,12 @@ sensitive_log_retention_period_days = 7
 vpc_cidr_block = "10.0.0.0/16"
 
 ## ELASTICACHE
-elasticache_node_count                 = 1
-elasticache_node_number_cache_clusters = 3
-elasticache_node_type                  = "cache.t3.medium"
+elasticache_cache_ops_node_count = 3
+elasticache_cache_ops_node_type  = "cache.t3.medium"
+
+elasticache_admin_cache_node_count = 3
+elasticache_admin_cache_node_type = "cache.t3.medium"
+
 elasticache_use_valkey                 = true
 
 ## SLACK INTEGRATION

--- a/env/staging_config.tfvars
+++ b/env/staging_config.tfvars
@@ -63,9 +63,12 @@ ses_custom_sending_domains = ["custom-sending-domain.staging.notification.cdssan
 vpc_cidr_block = "10.0.0.0/16"
 
 ## ELASTICACHE
-elasticache_node_count                 = 1
-elasticache_node_number_cache_clusters = 3
-elasticache_node_type                  = "cache.t3.medium"
+elasticache_cache_ops_node_count = 3
+elasticache_cache_ops_node_type  = "cache.t3.medium"
+
+elasticache_admin_cache_node_count = 3
+elasticache_admin_cache_node_type = "cache.t3.medium"
+
 elasticache_use_valkey                 = true
 
 ## LOGGING

--- a/env/variables.tf
+++ b/env/variables.tf
@@ -296,15 +296,19 @@ variable "notify_k8s_namespace" {
   description = "Kubernetes namespace where GC Notify is installed"
 }
 
-variable "elasticache_node_count" {
+variable "elasticache_cache_ops_node_type" {
+  type = string
+}
+
+variable "elasticache_cache_ops_node_count" {
   type = number
 }
 
-variable "elasticache_node_number_cache_clusters" {
+variable "elasticache_admin_cache_node_count" {
   type = number
 }
 
-variable "elasticache_node_type" {
+variable "elasticache_admin_cache_node_type" {
   type = string
 }
 


### PR DESCRIPTION
# Summary | Résumé

Split the config for valkey into two so we can adjust admin and cache_ops elasticaches independently.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/565

## Test instructions | Instructions pour tester la modification

Should be no changes on staging since we're keeping things the same.

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
