### PR TITLE
attempting to fix permissions for publishing to topic

### DIFF
--- a/aws/common/sns.tf
+++ b/aws/common/sns.tf
@@ -90,9 +90,6 @@ resource "aws_sns_topic" "notification-canada-ca-alert-general" {
       "Condition": {
         "StringEquals": {
           "aws:SourceAccount": "${var.account_id}"
-        },
-        "ArnLike": {
-          "aws:SourceArn": "arn:aws:budgets::${var.account_id}:*"
         }
       }
     },


### PR DESCRIPTION
# Summary | Résumé

Fixed AWS Budgets SNS Publishing Issue:

✅ Simplified SNS topic policy for alert-general topic
✅ Removed restrictive ArnLike condition that was preventing AWS Budgets from publishing
✅ Maintained security with aws:SourceAccount condition
✅ Preserved existing functionality for all other SNS operations
The policy now allows AWS Budgets to successfully publish budget notifications to your SNS topic while maintaining proper security controls. After applying this Terraform change, your budget notifications should start working correctly.

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/626

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
