### PR TITLE
Adding back redis publish url for now

### DIFF
--- a/aws/manifest_secrets/secrets.tf
+++ b/aws/manifest_secrets/secrets.tf
@@ -400,6 +400,17 @@ resource "aws_secretsmanager_secret_version" "manifest_cache_ops_url" {
   secret_string = var.env != "production" ? "redis://${var.elasticache_queue_cache_primary_endpoint_address}" : "redis://${var.redis_primary_endpoint_address}"
 }
 
+resource "aws_secretsmanager_secret" "manifest_redis_publish_url" {
+  name                    = "MANIFEST_REDIS_PUBLISH_URL"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_redis_publish_url" {
+  secret_id     = aws_secretsmanager_secret.manifest_redis_publish_url.id
+  secret_string = var.env != "production" ? "redis://${var.elasticache_queue_cache_primary_endpoint_address}" : "redis://${var.redis_primary_endpoint_address}"
+}
+
+
 resource "aws_secretsmanager_secret" "manifest_redis_url" {
   name                    = "MANIFEST_REDIS_URL"
   recovery_window_in_days = 0


### PR DESCRIPTION
# Summary | Résumé

Need to add redis publish url back in the interim w/ cache ops url there as well.

## Related Issues | Cartes liées

*  https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/565

## Test instructions | Instructions pour tester la modification

TF Apply works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
