### PR TITLE
Added service restricted and research_mode columns into quicksight dataset

### DIFF
--- a/aws/quicksight/dataset_notifications.tf
+++ b/aws/quicksight/dataset_notifications.tf
@@ -68,6 +68,8 @@ resource "aws_quicksight_data_set" "notifications" {
           select
             s.id as service_id,
             s.active as service_active,
+            s.restricted as service_restricted,
+            s.research_mode as service_research_mode,
             count_as_live as service_count_as_live,
             s.go_live_at as service_go_live_at,
             s.name as service_name,
@@ -159,6 +161,14 @@ resource "aws_quicksight_data_set" "notifications" {
       }
       columns {
         name = "service_active"
+        type = "BOOLEAN"
+      }
+      columns {
+        name = "service_restricted"
+        type = "BOOLEAN"
+      }
+      columns {
+        name = "service_research_mode"
         type = "BOOLEAN"
       }
       columns {


### PR DESCRIPTION
# Summary | Résumé

Added both column `restricted` and `research_mode` from the `services` table into the *Notifications* QuickSight dataset. This should allow us to get the chunk of notifications that are derived from these.

## Related Issues | Cartes liées

None

## Test instructions | Instructions pour tester la modification

Build a QuickSight widget with these new fields from the *Notifications* data set.

## Release Instructions | Instructions pour le déploiement

Make sure the QuickSight import does not crash the database. **The merge into main will trigger the QuickSight refresh**.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
