### PR TITLE
Brought recommended changes from recent 1 SMS part constraint for SMS keywords

### DIFF
--- a/scripts/set_sms_keywords/set_sms_keywords.py
+++ b/scripts/set_sms_keywords/set_sms_keywords.py
@@ -20,6 +20,11 @@ keywords_to_set = [
         "KeywordAction": "OPT_IN",
     },
     {
+        "Keyword": "FIN",
+        "KeywordMessage": "Le gouvernement du Canada ne vous textera plus via Notification GC. Textez ABONNER pour reprendre (frais standards de messages/données).",
+        "KeywordAction": "OPT_OUT",
+    },
+    {
         "Keyword": "ARRÊT",
         "KeywordMessage": "Le gouvernement du Canada ne vous textera plus via Notification GC. Textez ABONNER pour reprendre (frais standards de messages/données).",
         "KeywordAction": "OPT_OUT",
@@ -51,22 +56,22 @@ keywords_to_set = [
     },
     {
         "Keyword": "ABONNER",
-        "KeywordMessage": "Inscription réussie aux messages texte de Notification GC. Pour vous désabonner, textez ARRÊT (frais standards de messages/données).",
+        "KeywordMessage": "Inscription réussie aux messages texte de Notification GC. Pour vous désabonner, textez FIN (frais standards de messages/données).",
         "KeywordAction": "OPT_IN",
     },
     {
         "Keyword": "ABONER",
-        "KeywordMessage": "Inscription réussie aux messages texte de Notification GC. Pour vous désabonner, textez ARRÊT (frais standards de messages/données).",
+        "KeywordMessage": "Inscription réussie aux messages texte de Notification GC. Pour vous désabonner, textez FIN (frais standards de messages/données).",
         "KeywordAction": "OPT_IN",
     },
     {
         "Keyword": "ABONNNER",
-        "KeywordMessage": "Inscription réussie aux messages texte de Notification GC. Pour vous désabonner, textez ARRÊT (frais standards de messages/données).",
+        "KeywordMessage": "Inscription réussie aux messages texte de Notification GC. Pour vous désabonner, textez FIN (frais standards de messages/données).",
         "KeywordAction": "OPT_IN",
     },
     {
         "Keyword": "AIDE",
-        "KeywordMessage": "Notification GC: Visitez https://notification.canada.ca/contact Frais de msg/données std applicables. La fréquence des messages peut varier. Textez ARRÊT pour annuler.",
+        "KeywordMessage": "Notification GC: Visitez https://notification.canada.ca/contact Frais de msg/données std applicables. La fréquence des messages peut varier. Textez FIN pour annuler.",
         "KeywordAction": "AUTOMATIC_RESPONSE",
     },
     {
@@ -76,7 +81,7 @@ keywords_to_set = [
     },
     {
         "Keyword": "INFO",
-        "KeywordMessage": "GC Notify: More info at https://notification.canada.ca Data rates apply. Notification GC: Plus d’informations à https://notification.canada.ca Frais de msg/données std applicables.",
+        "KeywordMessage": "GC Notify: More info at https://notification.canada.ca Data rates apply. Notification GC: Plus d'informations à https://notification.canada.ca Frais de msg/données std applicables.",
         "KeywordAction": "AUTOMATIC_RESPONSE",
     }
 ]


### PR DESCRIPTION
# Summary | Résumé

DRAFT: As it stands, the `AIDE` and `INFO` keywords still take 2 multiparts, hence we need to further shorten these.

AWS reported that we are in violation of sending more than 1 SMS parts for supported keywords. Hence content change is necessary to some.

* We are migrating to use `FIN` in French instead of `ARRÊT`.
* We can still support `ARRÊT` as a keyword for some time, as long as we don't recommend it in the content messages.

## Related Issues | Cartes liées

None

## Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
