### PR TITLE
Fixing KMS permissions for AWS Budget Alerting

### DIFF
--- a/aws/common/budget.tf
+++ b/aws/common/budget.tf
@@ -8,7 +8,7 @@ resource "aws_budgets_budget" "notify_global" {
 
   notification {
     comparison_operator       = "GREATER_THAN"
-    threshold                 = 100
+    threshold                 = 1
     threshold_type            = "PERCENTAGE"
     notification_type         = "FORECASTED"
     subscriber_sns_topic_arns = [aws_sns_topic.notification-canada-ca-alert-general.arn]
@@ -16,7 +16,7 @@ resource "aws_budgets_budget" "notify_global" {
 
   notification {
     comparison_operator       = "GREATER_THAN"
-    threshold                 = 80
+    threshold                 = 1
     threshold_type            = "PERCENTAGE"
     notification_type         = "ACTUAL"
     subscriber_sns_topic_arns = [aws_sns_topic.notification-canada-ca-alert-general.arn]

--- a/aws/common/budget.tf
+++ b/aws/common/budget.tf
@@ -8,7 +8,7 @@ resource "aws_budgets_budget" "notify_global" {
 
   notification {
     comparison_operator       = "GREATER_THAN"
-    threshold                 = 1
+    threshold                 = 100
     threshold_type            = "PERCENTAGE"
     notification_type         = "FORECASTED"
     subscriber_sns_topic_arns = [aws_sns_topic.notification-canada-ca-alert-general.arn]
@@ -16,7 +16,7 @@ resource "aws_budgets_budget" "notify_global" {
 
   notification {
     comparison_operator       = "GREATER_THAN"
-    threshold                 = 1
+    threshold                 = 80
     threshold_type            = "PERCENTAGE"
     notification_type         = "ACTUAL"
     subscriber_sns_topic_arns = [aws_sns_topic.notification-canada-ca-alert-general.arn]

--- a/aws/common/kms.tf
+++ b/aws/common/kms.tf
@@ -5,67 +5,11 @@ resource "aws_kms_key" "notification-canada-ca" {
   enable_key_rotation = true
 
   # This policy allows encryption/decryption in Cloudwatch
-  policy = var.env == "production" ? data.aws_iam_policy_document.standard_kms_policy.json : data.aws_iam_policy_document.encrypted_kms_policy.json
+  policy = data.aws_iam_policy_document.encrypted_kms_policy.json
 
   tags = {
     Name       = "notification-canada-ca"
     CostCenter = "notification-canada-ca-${var.env}"
-  }
-}
-
-data "aws_iam_policy_document" "standard_kms_policy" {
-  statement {
-    sid    = "Enable IAM User Permissions"
-    effect = "Allow"
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
-    }
-    actions   = ["kms:*"]
-    resources = ["*"]
-  }
-
-  statement {
-    effect = "Allow"
-    principals {
-      type        = "Service"
-      identifiers = ["logs.${var.region}.amazonaws.com"]
-    }
-    actions = [
-      "kms:Encrypt*",
-      "kms:Decrypt*",
-      "kms:ReEncrypt*",
-      "kms:GenerateDataKey*",
-      "kms:Describe*"
-    ]
-    resources = ["*"]
-  }
-
-  statement {
-    sid    = "Allow_CloudWatch_for_CMK"
-    effect = "Allow"
-    principals {
-      type        = "Service"
-      identifiers = ["cloudwatch.amazonaws.com"]
-    }
-    actions = [
-      "kms:Decrypt",
-      "kms:GenerateDataKey"
-    ]
-    resources = ["*"]
-  }
-
-  statement {
-    effect = "Allow"
-    principals {
-      type        = "Service"
-      identifiers = ["ses.amazonaws.com"]
-    }
-    actions = [
-      "kms:GenerateDataKey*",
-      "kms:Decrypt"
-    ]
-    resources = ["*"]
   }
 }
 
@@ -145,6 +89,24 @@ data "aws_iam_policy_document" "encrypted_kms_policy" {
       test     = "ArnLike"
       variable = "aws:SourceArn"
       values   = ["arn:aws:budgets:${var.region}:${data.aws_caller_identity.current.account_id}:*"]
+    }
+  }
+  statement {
+    sid    = "AllowBudgetsServiceToUseKey"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["budgets.amazonaws.com"]
+    }
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [var.account_id]
     }
   }
 }


### PR DESCRIPTION
# Summary | Résumé

There was a missing policy to allow the budget alert to use the KMS key. I've added it in. 
I also removed the old policy since it is not used anymore - even in prod.

## Test instructions | Instructions pour tester la modification

TF Apply works
Tested in dev with lowered thresholds - we can try to manually set these thresholds in staging/prod as well to see if it works.

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
