### PR TITLE
run always for setting retention period

### DIFF
--- a/aws/lambda-api/cloudwatch_logs.tf
+++ b/aws/lambda-api/cloudwatch_logs.tf
@@ -6,6 +6,10 @@
 resource "null_resource" "api_gateway_cloudwatch_logging" {
   count = var.cloudwatch_enabled ? 1 : 0
 
+  triggers = {
+    always_run = "${timestamp()}"
+  }
+
   provisioner "local-exec" {
     command = <<EOT
       aws logs put-retention-policy --log-group-name "API-Gateway-Execution-Logs_${aws_api_gateway_rest_api.api.id}/${aws_api_gateway_stage.api.stage_name}" --retention-in-days ${var.sensitive_log_retention_period_days}


### PR DESCRIPTION
# Summary | Résumé

Just so that we don't have to worry about it, I'm setting the null resource command that sets the api gateway execution log retention period to run every release. That way we can be sure that it's always set properly.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/624

## Test instructions | Instructions pour tester la modification

TF Apply works, shows that the null resource will run.

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
