### PR TITLE
Excluding IAM roles and policies needed for SSC's 30 day guardrails

### DIFF
--- a/scripts/awsNuke.cfg
+++ b/scripts/awsNuke.cfg
@@ -69,7 +69,7 @@ accounts:
           value: "(AWSReservedSSO|CloudFormation|Cbs.*|cbs-.*|secops.*|aws-controltower-.*|AWSControlTower|StackSet-AWSControlTowerGuardHook.*|GCComplianceAllowAccess)"
         - property: role:RoleName
           type: regex
-          value: "(AWSReservedSSO|CloudFormation|Cbs.*|cbs-.*|secops.*|aws-controltower-.*|AWSControlTower|StackSet-AWSControlTowerGuardHook.*)"
+          value: "(AWSReservedSSO|CloudFormation|Cbs.*|cbs-.*|secops.*|aws-controltower-.*|AWSControlTower|StackSet-AWSControlTowerGuardHook.*|GCComplianceAllowAccess)"
       IAMRolePolicyAttachment:
         - property: RoleName
           type: regex

--- a/scripts/awsNuke.cfg
+++ b/scripts/awsNuke.cfg
@@ -60,20 +60,20 @@ accounts:
       IAMRole:
         - property: Name
           type: regex
-          value: "(AWSReservedSSO|CloudFormation|Cbs.*|cbs-.*|ConfigTerraform.*|secops.*|OrganizationAccountAccessRole|aws-controltower-.*|AWSAFT.*|AWSNuke|AWSControlTower.*|stacksets-exec-*|terraform-modules-test)"
+          value: "(AWSReservedSSO|CloudFormation|Cbs.*|cbs-.*|ConfigTerraform.*|secops.*|OrganizationAccountAccessRole|aws-controltower-.*|AWSAFT.*|AWSNuke|AWSControlTower.*|stacksets-exec-*|terraform-modules-test|LZ-GCLambdaExecutionRole)"
         - property: "tag:managed_by"
           value: "AFT"
       IAMRolePolicy:
         - property: RoleName
           type: regex
-          value: "(AWSReservedSSO|CloudFormation|Cbs.*|cbs-.*|secops.*|aws-controltower-.*|AWSControlTower|StackSet-AWSControlTowerGuardHook.*)"
+          value: "(AWSReservedSSO|CloudFormation|Cbs.*|cbs-.*|secops.*|aws-controltower-.*|AWSControlTower|StackSet-AWSControlTowerGuardHook.*|GCComplianceAllowAccess)"
         - property: role:RoleName
           type: regex
           value: "(AWSReservedSSO|CloudFormation|Cbs.*|cbs-.*|secops.*|aws-controltower-.*|AWSControlTower|StackSet-AWSControlTowerGuardHook.*)"
       IAMRolePolicyAttachment:
         - property: RoleName
           type: regex
-          value: "(AWSReservedSSO|Cbs.*|cbs-.*|ConfigTerraform.*|secops.*|AWSNuke|aws-controltower.*|AWSAFT.*|OrganizationAccountAccessRole|AWSControlTower.*|stacksets-exec-*|terraform-modules-test)"
+          value: "(AWSReservedSSO|Cbs.*|cbs-.*|ConfigTerraform.*|secops.*|AWSNuke|aws-controltower.*|AWSAFT.*|OrganizationAccountAccessRole|AWSControlTower.*|stacksets-exec-*|terraform-modules-test|LZ-GCLambdaExecutionRole)"
         - property: "tag:role:managed_by"
           value: "AFT"
       IAMUserGroupAttachment:


### PR DESCRIPTION
# Summary | Résumé

Excluding IAM roles and policies from the weekly AWS nuke script. Those roles and policies are needed for the 30 day guardrails. 
