### PR TITLE
run delete dev env on friday and saturday

### DIFF
--- a/.github/workflows/terragrunt_destroy_environment.yml
+++ b/.github/workflows/terragrunt_destroy_environment.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     # 17:00 UTC = 22:00 EST
-    - cron: "0 22 * * 5"
+    - cron: "0 22 * * 5,6"
 
 defaults:
   run:


### PR DESCRIPTION
# Summary | Résumé

Create Dev env seems to fail because of existing resources on Sunday... all I do is re-run the delete script and it works, so obviously something is getting locked/missed in the original runs. Lets just have it run twice, once on Friday and once on Saturday to see if that clears it out.

## Related Issues | Cartes liées

Adhoc

## Test instructions | Instructions pour tester la modification

Create dev env works next week.

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
