### PR TITLE
Adding terragrunt init -upgrade

### DIFF
--- a/.github/workflows/merge_to_main_production.yml
+++ b/.github/workflows/merge_to_main_production.yml
@@ -50,6 +50,7 @@ jobs:
       - name: terragrunt apply COMMON
         run: |
           cd env/${{env.ENVIRONMENT}}/common
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-ecr:
@@ -91,6 +92,7 @@ jobs:
       - name: terragrunt apply ECR
         run: |
           cd env/${{env.ENVIRONMENT}}/ecr
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-ecr-us-east:
@@ -132,6 +134,7 @@ jobs:
       - name: terragrunt apply ECR
         run: |
           cd env/${{env.ENVIRONMENT}}/ecr-us-east
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-ses_receiving_emails:
@@ -163,6 +166,7 @@ jobs:
       - name: terragrunt apply ses_receiving_emails
         run: |
           cd env/${{env.ENVIRONMENT}}/ses_receiving_emails
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-dns:
@@ -194,6 +198,7 @@ jobs:
       - name: terragrunt apply dns
         run: |
           cd env/${{env.ENVIRONMENT}}/dns
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-ses_validation_dns_entries:
@@ -225,6 +230,7 @@ jobs:
       - name: terragrunt apply ses_validation_dns_entries
         run: |
           cd env/${{env.ENVIRONMENT}}/ses_validation_dns_entries
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
 
@@ -257,6 +263,7 @@ jobs:
       - name: terragrunt apply cloudfront
         run: |
           cd env/${{env.ENVIRONMENT}}/cloudfront
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-eks:
@@ -288,6 +295,7 @@ jobs:
       - name: terragrunt apply eks
         run: |
           cd env/${{env.ENVIRONMENT}}/eks
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-aws-auth:
@@ -331,6 +339,7 @@ jobs:
           cd aws
           op read op://ppnxsriom3alsxj4ogikyjxlzi/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars
           cd ../env/${{env.ENVIRONMENT}}/eks
+          terragrunt init -upgrade
           ENDPOINT_ID=$(terragrunt output --raw gha_vpn_id)
           CERT=$(terragrunt output --raw gha_vpn_certificate)
           KEY=$(terragrunt output --raw gha_vpn_key)
@@ -363,6 +372,7 @@ jobs:
       - name: terragrunt apply aws-auth
         run: |
           cd env/${{env.ENVIRONMENT}}/aws-auth
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-elasticache:
@@ -394,6 +404,7 @@ jobs:
       - name: terragrunt apply elasticache
         run: |
           cd env/${{env.ENVIRONMENT}}/elasticache
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-rds:
@@ -425,6 +436,7 @@ jobs:
       - name: terragrunt apply rds
         run: |
           cd env/${{env.ENVIRONMENT}}/rds
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-lambda-api:
@@ -456,6 +468,7 @@ jobs:
       - name: terragrunt apply lambda-api
         run: |
           cd env/${{env.ENVIRONMENT}}/lambda-api
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-heartbeat:
@@ -487,6 +500,7 @@ jobs:
       - name: terragrunt apply heartbeat
         run: |
           cd env/${{env.ENVIRONMENT}}/heartbeat
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-database-tools:
@@ -518,6 +532,7 @@ jobs:
       - name: terragrunt apply database-tools
         run: |
           cd env/${{env.ENVIRONMENT}}/database-tools
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-lambda-google-cidr:
@@ -549,6 +564,7 @@ jobs:
       - name: terragrunt apply lambda-google-cidr
         run: |
           cd env/${{env.ENVIRONMENT}}/lambda-google-cidr
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-ses_to_sqs_email_callbacks:
@@ -580,6 +596,7 @@ jobs:
       - name: terragrunt apply ses_to_sqs_email_callbacks
         run: |
           cd env/${{env.ENVIRONMENT}}/ses_to_sqs_email_callbacks
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-sns_to_sqs_sms_callbacks:
@@ -611,6 +628,7 @@ jobs:
       - name: terragrunt apply sns_to_sqs_sms_callbacks
         run: |
           cd env/${{env.ENVIRONMENT}}/sns_to_sqs_sms_callbacks
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-pinpoint_to_sqs_sms_callbacks:
@@ -642,6 +660,7 @@ jobs:
       - name: terragrunt apply pinpoint_to_sqs_sms_callbacks
         run: |
           cd env/${{env.ENVIRONMENT}}/pinpoint_to_sqs_sms_callbacks
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-system_status:
@@ -673,6 +692,7 @@ jobs:
       - name: terragrunt apply system_status
         run: |
           cd env/${{env.ENVIRONMENT}}/system_status
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-system_status_static_site:
@@ -704,6 +724,7 @@ jobs:
       - name: terragrunt apply system_status_static_site
         run: |
           cd env/${{env.ENVIRONMENT}}/system_status_static_site
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-newrelic:
@@ -735,6 +756,7 @@ jobs:
       - name: terragrunt apply newrelic
         run: |
           cd env/${{env.ENVIRONMENT}}/newrelic
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-manifest_secrets:
@@ -766,6 +788,7 @@ jobs:
       - name: terragrunt apply manifest_secrets
         run: |
           cd env/${{env.ENVIRONMENT}}/manifest_secrets
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve      
 
   terragrunt-apply-github:
@@ -797,4 +820,5 @@ jobs:
       - name: terragrunt apply github
         run: |
           cd env/${{env.ENVIRONMENT}}/github
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve      

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -760,7 +760,7 @@ jobs:
 
       - name: terragrunt apply pinpoint_to_sqs_sms_callbacks
         run: |
-          cd env/${{env.ENVIRONMENT}}/pinpoint_to_sqs_sms_callback
+          cd env/${{env.ENVIRONMENT}}/pinpoint_to_sqs_sms_callbacks
           terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -728,7 +728,7 @@ jobs:
 
       - name: terragrunt apply sns_to_sqs_sms_callbacks
         run: |
-          cd env/${{env.ENVIRONMENT}}/sns_to_sqs_sms_callbacks'
+          cd env/${{env.ENVIRONMENT}}/sns_to_sqs_sms_callbacks
           terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 

--- a/.github/workflows/merge_to_main_staging.yml
+++ b/.github/workflows/merge_to_main_staging.yml
@@ -54,6 +54,7 @@ jobs:
       - name: terragrunt apply COMMON
         run: |
           cd env/${{env.ENVIRONMENT}}/common
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-ecr:
@@ -95,6 +96,7 @@ jobs:
       - name: terragrunt apply ECR
         run: |
           cd env/${{env.ENVIRONMENT}}/ecr
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-ecr-us-east:
@@ -136,6 +138,7 @@ jobs:
       - name: terragrunt apply ECR
         run: |
           cd env/${{env.ENVIRONMENT}}/ecr-us-east
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
 
@@ -168,6 +171,7 @@ jobs:
       - name: terragrunt apply ses_receiving_emails
         run: |
           cd env/${{env.ENVIRONMENT}}/ses_receiving_emails
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-dns:
@@ -199,6 +203,7 @@ jobs:
       - name: terragrunt apply dns
         run: |
           cd env/${{env.ENVIRONMENT}}/dns
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-ses_validation_dns_entries:
@@ -230,6 +235,7 @@ jobs:
       - name: terragrunt apply ses_validation_dns_entries
         run: |
           cd env/${{env.ENVIRONMENT}}/ses_validation_dns_entries
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
 
@@ -262,6 +268,7 @@ jobs:
       - name: terragrunt apply cloudfront
         run: |
           cd env/${{env.ENVIRONMENT}}/cloudfront
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-eks:
@@ -293,6 +300,7 @@ jobs:
       - name: terragrunt apply eks
         run: |
           cd env/${{env.ENVIRONMENT}}/eks
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-aws-auth:
@@ -336,6 +344,7 @@ jobs:
           cd aws
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars
           cd ../env/${{env.ENVIRONMENT}}/eks
+          terragrunt init -upgrade
           ENDPOINT_ID=$(terragrunt output --raw gha_vpn_id)
           CERT=$(terragrunt output --raw gha_vpn_certificate)
           KEY=$(terragrunt output --raw gha_vpn_key)
@@ -368,6 +377,7 @@ jobs:
       - name: terragrunt apply aws-auth
         run: |
           cd env/${{env.ENVIRONMENT}}/aws-auth
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-elasticache:
@@ -399,6 +409,7 @@ jobs:
       - name: terragrunt apply elasticache
         run: |
           cd env/${{env.ENVIRONMENT}}/elasticache
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-rds:
@@ -430,6 +441,7 @@ jobs:
       - name: terragrunt apply rds
         run: |
           cd env/${{env.ENVIRONMENT}}/rds
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-lambda-api:
@@ -461,6 +473,7 @@ jobs:
       - name: terragrunt apply lambda-api
         run: |
           cd env/${{env.ENVIRONMENT}}/lambda-api
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-lambda-admin-pr:
@@ -492,6 +505,7 @@ jobs:
       - name: terragrunt apply lambda-admin-pr
         run: |
           cd env/${{env.ENVIRONMENT}}/lambda-admin-pr
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-performance-test:
@@ -555,6 +569,7 @@ jobs:
       - name: terragrunt apply heartbeat
         run: |
           cd env/${{env.ENVIRONMENT}}/heartbeat
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-database-tools:
@@ -586,6 +601,7 @@ jobs:
       - name: terragrunt apply database-tools
         run: |
           cd env/${{env.ENVIRONMENT}}/database-tools
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-quicksight:
@@ -617,6 +633,7 @@ jobs:
       - name: terragrunt apply quicksight
         run: |
           cd env/${{env.ENVIRONMENT}}/quicksight
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-lambda-google-cidr:
@@ -648,6 +665,7 @@ jobs:
       - name: terragrunt apply lambda-google-cidr
         run: |
           cd env/${{env.ENVIRONMENT}}/lambda-google-cidr
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-ses_to_sqs_email_callbacks:
@@ -679,6 +697,7 @@ jobs:
       - name: terragrunt apply ses_to_sqs_email_callbacks
         run: |
           cd env/${{env.ENVIRONMENT}}/ses_to_sqs_email_callbacks
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-sns_to_sqs_sms_callbacks:
@@ -709,7 +728,8 @@ jobs:
 
       - name: terragrunt apply sns_to_sqs_sms_callbacks
         run: |
-          cd env/${{env.ENVIRONMENT}}/sns_to_sqs_sms_callbacks
+          cd env/${{env.ENVIRONMENT}}/sns_to_sqs_sms_callbacks'
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-pinpoint_to_sqs_sms_callbacks:
@@ -740,7 +760,8 @@ jobs:
 
       - name: terragrunt apply pinpoint_to_sqs_sms_callbacks
         run: |
-          cd env/${{env.ENVIRONMENT}}/pinpoint_to_sqs_sms_callbacks
+          cd env/${{env.ENVIRONMENT}}/pinpoint_to_sqs_sms_callback
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-system_status:
@@ -772,6 +793,7 @@ jobs:
       - name: terragrunt apply system_status
         run: |
           cd env/${{env.ENVIRONMENT}}/system_status
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-system_status_static_site:
@@ -803,6 +825,7 @@ jobs:
       - name: terragrunt apply system_status_static_site
         run: |
           cd env/${{env.ENVIRONMENT}}/system_status_static_site
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-newrelic:
@@ -834,6 +857,7 @@ jobs:
       - name: terragrunt apply newrelic
         run: |
           cd env/${{env.ENVIRONMENT}}/newrelic
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
   terragrunt-apply-manifest_secrets:
@@ -865,6 +889,7 @@ jobs:
       - name: terragrunt apply manifest_secrets
         run: |
           cd env/${{env.ENVIRONMENT}}/manifest_secrets
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve      
  
   terragrunt-apply-github:
@@ -896,6 +921,7 @@ jobs:
       - name: terragrunt apply github
         run: |
           cd env/${{env.ENVIRONMENT}}/github
+          terragrunt init -upgrade
           terragrunt apply --terragrunt-non-interactive -auto-approve      
 
   bump-version-and-push-tag:

--- a/.github/workflows/terragrunt_plan_dev.yml
+++ b/.github/workflows/terragrunt_plan_dev.yml
@@ -423,6 +423,7 @@ jobs:
           cd aws
           op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars
           cd ../env/${{env.ENVIRONMENT}}/eks
+          terragrunt init -upgrade
           ENDPOINT_ID=$(terragrunt output --raw gha_vpn_id)
           CERT=$(terragrunt output --raw gha_vpn_certificate)
           KEY=$(terragrunt output --raw gha_vpn_key)

--- a/.github/workflows/terragrunt_plan_production.yml
+++ b/.github/workflows/terragrunt_plan_production.yml
@@ -319,6 +319,7 @@ jobs:
           cd aws
           op read op://ppnxsriom3alsxj4ogikyjxlzi/"TERRAFORM_SECRETS_${{env.ENVIRONMENT}}"/notesPlain > ${{env.ENVIRONMENT}}.tfvars
           cd ../env/${{env.ENVIRONMENT}}/eks
+          terragrunt init -upgrade
           ENDPOINT_ID=$(terragrunt output --raw gha_vpn_id)
           CERT=$(terragrunt output --raw gha_vpn_certificate)
           KEY=$(terragrunt output --raw gha_vpn_key)


### PR DESCRIPTION
# Summary | Résumé

All of the github TF Apply workflows need terragrunt init -upgrade

## Related Issues | Cartes liées

*  https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/644

## Test instructions | Instructions pour tester la modification

TF Apply works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
