### PR TITLE
Adding DB role for Helmfile Secrets

### DIFF
--- a/aws/eks/manifests-iam.tf
+++ b/aws/eks/manifests-iam.tf
@@ -358,3 +358,57 @@ resource "aws_iam_role_policy_attachment" "celery_worker" {
   policy_arn = aws_iam_policy.notification-worker-policy.arn
   role       = aws_iam_role.celery.name
 }
+
+#
+# Database
+#
+#
+# NOTIFY-Database
+#
+
+data "aws_iam_policy_document" "assume_role_policy_database" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(aws_iam_openid_connect_provider.notification-canada-ca.url, "https://", "")}:sub"
+      values   = ["system:serviceaccount:notification-canada-ca:notify-database"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(aws_iam_openid_connect_provider.notification-canada-ca.url, "https://", "")}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    principals {
+      identifiers = [aws_iam_openid_connect_provider.notification-canada-ca.arn]
+      type        = "Federated"
+    }
+  }
+}
+
+# Role
+resource "aws_iam_role" "database" {
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy_database.json
+  name               = "secrets-csi-role-database"
+}
+
+# Policy Attachment
+resource "aws_iam_role_policy_attachment" "secrets_csi_database" {
+  policy_arn = aws_iam_policy.secrets_csi.arn
+  role       = aws_iam_role.database.name
+}
+
+# Policy Attachment
+resource "aws_iam_role_policy_attachment" "parameters_csi_database" {
+  policy_arn = aws_iam_policy.parameters_csi.arn
+  role       = aws_iam_role.database.name
+}
+
+resource "aws_iam_role_policy_attachment" "database_worker" {
+  policy_arn = aws_iam_policy.notification-worker-policy.arn
+  role       = aws_iam_role.database.name
+}


### PR DESCRIPTION
# Summary | Résumé

Adding the role required for the creation and reading of K8s Secrets by the DB upgrade job in manifests.  This is for discrete creation and access of secrets for the Database deployment so that it no longer relies upon the api deployment, and they will not go out of sync.

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/631

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
