### PR TITLE
Fix for logical table map notifications-with-services

### DIFF
--- a/aws/quicksight/dataset_notifications_refreshed.tf
+++ b/aws/quicksight/dataset_notifications_refreshed.tf
@@ -152,13 +152,31 @@ resource "aws_quicksight_data_set" "notifications_refreshed" {
   }
 
   logical_table_map {
+    logical_table_map_id = "logical-notifications"
+    alias                = "Notifications"
+
+    source {
+      physical_table_id = "notifications"
+    }
+  }
+
+  logical_table_map {
+    logical_table_map_id = "logical-services"
+    alias                = "Services"
+
+    source {
+      physical_table_id = "services"
+    }
+  }
+
+  logical_table_map {
     logical_table_map_id = "notifications-with-services"
     alias                = "Notifications with Services"
 
     source {
       join_instruction {
-        left_operand  = "notifications"
-        right_operand = "services"
+        left_operand  = "logical-notifications"
+        right_operand = "logical-services"
 
         type = "INNER" # can also be LEFT, RIGHT, OUTER, etc.
 


### PR DESCRIPTION
# Summary | Résumé

Fix for logical table map notifications-with-services. 

This also brings back all of the QuickSight previous artifacts that were removed by previous revert https://github.com/cds-snc/notification-terraform/pull/2076

This PR is part of several ones to debug the Quicksight configuration to enable incremental refresh of the *Notifications* dataset.

## Related Issues | Cartes liées

* [SPIKE - Quicksight Data Refresh](https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/642)

## Test instructions | Instructions pour tester la modification

Run the terraform apply step!

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
