### PR TITLE
Bringing further fixes on potential alias conflicts

### DIFF
--- a/aws/quicksight/dataset_notifications_refreshed.tf
+++ b/aws/quicksight/dataset_notifications_refreshed.tf
@@ -164,6 +164,12 @@ resource "aws_quicksight_data_set" "notifications_refreshed" {
         new_column_name = "notification_id"
       }
     }
+    data_transforms {
+      rename_column_operation {
+        column_name     = "service_id"
+        new_column_name = "service_id_fk"
+      }
+    }
   }
 
   logical_table_map {
@@ -198,7 +204,7 @@ resource "aws_quicksight_data_set" "notifications_refreshed" {
 
         type = "INNER" # can also be LEFT, RIGHT, OUTER, etc.
 
-        on_clause = "notifications.service_id = services.service_id"
+        on_clause = "notifications.service_id_fk = services.service_id"
       }
     }
   }


### PR DESCRIPTION
# Summary | Résumé

Bringing further fixes on potential alias conflicts, on `service_id` which is found in both `notifications` and `services` table this time.

This PR is part of several ones to debug the Quicksight configuration to enable incremental refresh of the Notifications dataset.


## Related Issues | Cartes liées

* [SPIKE - Quicksight Data Refresh](https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/642)

## Test instructions | Instructions pour tester la modification

Run the terraform apply step!

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
