### PR TITLE
adding secret to TERRAFORM :/

### DIFF
--- a/aws/github/terraform-secrets.tf
+++ b/aws/github/terraform-secrets.tf
@@ -51,3 +51,10 @@ resource "github_actions_secret" "rds_snapshot_identifier" {
   secret_name     = "${upper(var.env)}_SHARED_RDS_SNAPSHOT_IDENTIFIER"
   plaintext_value = var.rds_snapshot_identifier
 }
+
+resource "github_actions_secret" "terraform_github_manifests_workflow_token" {
+  count           = var.env == "staging" ? 1 : 0
+  repository      = data.github_repository.notification_terraform.name
+  secret_name     = "MANIFESTS_WORKFLOW_TOKEN"
+  plaintext_value = var.github_manifests_workflow_token
+}


### PR DESCRIPTION
# Summary | Résumé

adding the proper secret to terraform repo as it's the repo calling.

## Related Issues | Cartes liées
https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/648

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
