### PR TITLE
Disable NR

### DIFF
--- a/aws/common/newrelic.tf
+++ b/aws/common/newrelic.tf
@@ -301,7 +301,8 @@ resource "aws_iam_role_policy_attachment" "newrelic_configuration_recorder" {
 
 
 resource "aws_config_configuration_recorder_status" "newrelic_recorder_status" {
-  count      = var.enable_new_relic && var.env != "production" ? 1 : 0
+  # We have an explicit deny on deleting this, so keeping it set to true
+  count      = var.env != "production" ? 1 : 0
   name       = var.aws_config_recorder_name
   is_enabled = true
 }

--- a/env/dev_config.tfvars
+++ b/env/dev_config.tfvars
@@ -39,7 +39,7 @@ new_relic_distribution_tracing_enabled = "true"
 notification_queue_prefix              = "eks-notification-canada-ca"
 
 # ENVIRONMENT
-enable_new_relic           = true
+enable_new_relic           = false
 create_cbs_bucket          = true
 force_destroy_s3           = true
 force_delete_ecr           = true

--- a/env/production_config.tfvars
+++ b/env/production_config.tfvars
@@ -39,7 +39,7 @@ new_relic_distribution_tracing_enabled = "true"
 notification_queue_prefix              = "eks-notification-canada-ca"
 
 # ENVIRONMENT
-enable_new_relic           = true
+enable_new_relic           = false
 create_cbs_bucket          = false
 force_destroy_s3           = false
 force_delete_ecr           = false
@@ -47,7 +47,7 @@ force_destroy_athena       = false
 bootstrap                  = false
 enable_sentinel_forwarding = true
 enable_delete_protection   = true
-api_enable_new_relic       = true
+api_enable_new_relic       = false
 cloudwatch_enabled         = true
 recovery                   = false
 aws_xray_sdk_enabled       = true

--- a/env/staging_config.tfvars
+++ b/env/staging_config.tfvars
@@ -39,7 +39,7 @@ new_relic_distribution_tracing_enabled = "true"
 notification_queue_prefix              = "eks-notification-canada-ca"
 
 # ENVIRONMENT
-enable_new_relic           = true
+enable_new_relic           = false
 create_cbs_bucket          = false
 force_destroy_s3           = false
 force_delete_ecr           = false
@@ -47,7 +47,7 @@ force_destroy_athena       = false
 bootstrap                  = false
 enable_sentinel_forwarding = true
 enable_delete_protection   = true
-api_enable_new_relic       = true
+api_enable_new_relic       = false
 cloudwatch_enabled         = true
 recovery                   = false
 aws_xray_sdk_enabled       = true


### PR DESCRIPTION
# Summary | Résumé

This will disable NR in staging and dev - we will have to manually unlink prod since it is not managed by TF yet. Once we unlink it, we can link it back in via TF.

## Related Issues | Cartes liées

Adhoc

## Test instructions | Instructions pour tester la modification

TF Apply works
Verify NR data ingest is reduced/eliminated

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
