### PR TITLE
increase execution limit

### DIFF
--- a/aws/lambda-api/lambda.tf
+++ b/aws/lambda-api/lambda.tf
@@ -11,7 +11,7 @@ resource "aws_lambda_function" "api" {
   image_uri    = "${var.api_lambda_ecr_repository_url}:${local.image_tag}"
 
   timeout                        = 60
-  reserved_concurrent_executions = 850
+  reserved_concurrent_executions = 1250
   memory_size                    = 1024
 
   tracing_config {


### PR DESCRIPTION
# Summary | Résumé

We hit a rate execution limit on the API Lambda. Increasing the limit.

## Related Issues | Cartes liées

Ad-Hoc

## Test instructions | Instructions pour tester la modification

TF Apply Works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
