### PR TITLE
Added new alarms around gateway 500s and lambda-api threshold

### DIFF
--- a/aws/lambda-api/cloudwatch_alarms.tf
+++ b/aws/lambda-api/cloudwatch_alarms.tf
@@ -65,7 +65,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda-api-throttle-warning" {
   namespace                 = "AWS/Lambda"
   period                    = "60"
   statistic                 = "Sum"
-  threshold                 = 1
+  threshold                 = 0
   treat_missing_data        = "notBreaching"
   alarm_actions             = [var.sns_alert_warning_arn]
   ok_actions                = [var.sns_alert_warning_arn]
@@ -130,4 +130,26 @@ resource "aws_cloudwatch_metric_alarm" "api-gateway-timeout-5-minute-critical" {
   threshold           = 5
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_critical_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "api-gateway-5xx-error-warning" {
+  count                     = var.cloudwatch_enabled ? 1 : 0
+  alarm_name                = "api-gateway-5xx-error-warning"
+  alarm_description         = "API Gateway is returning 5XX errors"
+  comparison_operator       = "GreaterThanThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "5XXError"
+  namespace                 = "AWS/ApiGateway"
+  period                    = "60"
+  statistic                 = "Sum"
+  threshold                 = 0
+  treat_missing_data        = "notBreaching"
+  alarm_actions             = [var.sns_alert_warning_arn]
+  ok_actions                = [var.sns_alert_warning_arn]
+  insufficient_data_actions = [var.sns_alert_warning_arn]
+
+  dimensions = {
+    ApiName = aws_api_gateway_rest_api.api.name
+    Stage   = aws_api_gateway_stage.api.stage_name
+  }
 }

--- a/aws/lambda-api/cloudwatch_alarms.tf
+++ b/aws/lambda-api/cloudwatch_alarms.tf
@@ -55,6 +55,27 @@ resource "aws_cloudwatch_metric_alarm" "logs-1-error-1-minute-warning-salesforce
   insufficient_data_actions = [var.sns_alert_warning_arn]
 }
 
+resource "aws_cloudwatch_metric_alarm" "lambda-api-throttle-warning" {
+  count                     = var.cloudwatch_enabled ? 1 : 0
+  alarm_name                = "lambda-api-throttle-warning"
+  alarm_description         = "API Lambda function is being throttled"
+  comparison_operator       = "GreaterThanThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "Throttles"
+  namespace                 = "AWS/Lambda"
+  period                    = "60"
+  statistic                 = "Sum"
+  threshold                 = 1
+  treat_missing_data        = "notBreaching"
+  alarm_actions             = [var.sns_alert_warning_arn]
+  ok_actions                = [var.sns_alert_warning_arn]
+  insufficient_data_actions = [var.sns_alert_warning_arn]
+
+  dimensions = {
+    FunctionName = aws_lambda_function.api.function_name
+  }
+}
+
 module "lambda_no_log_detection" {
   count                 = var.cloudwatch_enabled ? 1 : 0
   source                = "github.com/cds-snc/terraform-modules/empty_log_group_alarm"


### PR DESCRIPTION
# Summary | Résumé

In the context of our current incident, where we saw a resource exhaustion of our lambda-api lambda, we are adding two new alarms to help us detect faster a similar scenario:

1. A catch all alarm at the API gateway level for HTTP class status of 500s. 
2. A lambda rate throttle alarm for when the lambda-api is going over its reserved concurrency number. 

These two alarms are only at the warning level at the moment, for testing purposes, but should be transformed into critical ones with proper thresholds once the dust settle in.

## Related Issues | Cartes liées

Incident #incident-2025-08-21-500s-on-admin

## Test instructions | Instructions pour tester la modification

Make sure the plan is proper and that this is deployed in staging as expected.

## Release Instructions | Instructions pour le déploiement

Make sure this is deployed in staging as expected.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
