### PR TITLE
Parameterize ALB and Target Groups for Performance Bottleneck Dashboard

### DIFF
--- a/aws/eks/performance_bottleneck_dashboard.tf
+++ b/aws/eks/performance_bottleneck_dashboard.tf
@@ -511,7 +511,7 @@ resource "aws_cloudwatch_dashboard" "performance_bottlenecks" {
                 "legend": {
                     "position": "bottom"
                 },
-                "title": "EKS Cluser Node Count",
+                "title": "EKS Cluster Node Count",
                 "yAxis": {
                     "left": {
                         "showUnits": false,


### PR DESCRIPTION
# Summary | Résumé

I missed parameterizing the alb and target groups for the new dashboard.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/667

## Test instructions | Instructions pour tester la modification

TF Apply works
Check dashboard in staging

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
