### PR TITLE
Increasing staging spend limit

### DIFF
--- a/env/staging_config.tfvars
+++ b/env/staging_config.tfvars
@@ -127,8 +127,8 @@ perf_test_aws_s3_bucket      = "notify-performance-test-results-staging"
 perf_test_csv_directory_path = "/tmp/notify_performance_test"
 
 ## COMMON
-sns_monthly_spend_limit                                            = 100
-sns_monthly_spend_limit_us_west_2                                  = 30
+sns_monthly_spend_limit                                            = 400
+sns_monthly_spend_limit_us_west_2                                  = 300
 alarm_warning_document_download_bucket_size_gb                     = 0.5
 alarm_warning_inflight_processed_created_delta_threshold           = 100
 alarm_critical_inflight_processed_created_delta_threshold          = 200


### PR DESCRIPTION
# Summary | Résumé

Need to increase the staging spend limit in prep for SMS perf testing.

## Related Issues | Cartes liées

*  https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/666

## Test instructions | Instructions pour tester la modification

TF Apply works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
