### PR TITLE
adding cron back to create dev

### DIFF
--- a/.github/workflows/terragrunt_create_dev_environment.yml
+++ b/.github/workflows/terragrunt_create_dev_environment.yml
@@ -3,9 +3,8 @@ name: "Create Dev Environment"
 
 on:
   workflow_dispatch:
-  #schedule:
-    # 17:00 UTC = 22:00 EST
-    #- cron: "0 17 * * 0"
+  schedule:
+    - cron: "0 17 * * 0"
 
 defaults:
   run:


### PR DESCRIPTION
# Summary | Résumé

Somehow my add of the cron back to create dev got squashed. Adding it back here.

## Related Issues | Cartes liées

adhoc

## Test instructions | Instructions pour tester la modification

Create dev runs next week.

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
