### PR TITLE
100 Message Guard for SMS Success Rate

### DIFF
--- a/aws/common/cloudwatch_alarms_sms.tf
+++ b/aws/common/cloudwatch_alarms_sms.tf
@@ -147,21 +147,52 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-us
 resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-critical" {
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sns-sms-success-rate-canadian-numbers-critical"
-  alarm_description   = "SMS success rate to Canadian numbers is below 25% over 2 consecutive periods of 12 hours"
+  alarm_description   = "SMS success rate to Canadian numbers is below 25% with at least 100 messages over 2 consecutive periods of 12 hours"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "2"
   datapoints_to_alarm = "2"
-  metric_name         = "SMSSuccessRate"
-  namespace           = "AWS/SNS"
-  period              = 60 * 60 * 12
-  statistic           = "Average"
-  threshold           = 25 / 100
+  threshold           = 1
   alarm_actions       = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
   ok_actions          = [aws_sns_topic.notification-canada-ca-alert-ok.arn]
   treat_missing_data  = "notBreaching"
-  dimensions = {
-    SMSType = "Transactional"
-    Country = "CA"
+
+  metric_query {
+    id          = "successRate"
+    label       = "Success Rate"
+    return_data = false
+    metric {
+      namespace   = "AWS/SNS"
+      metric_name = "SMSSuccessRate"
+      period      = 60 * 60 * 12
+      stat        = "Average"
+      dimensions = {
+        SMSType = "Transactional"
+        Country = "CA"
+      }
+    }
+  }
+
+  metric_query {
+    id          = "messagesPublished"
+    label       = "Messages Published"
+    return_data = false
+    metric {
+      namespace   = "AWS/SNS"
+      metric_name = "NumberOfMessagesPublished"
+      period      = 60 * 60 * 12
+      stat        = "Sum"
+      dimensions = {
+        SMSType = "Transactional"
+        Country = "CA"
+      }
+    }
+  }
+
+  metric_query {
+    id          = "alarmCondition"
+    label       = "Guarded Alarm Condition"
+    return_data = true
+    expression  = "IF(successRate < 0.25 AND messagesPublished > 100, 0, 1)"
   }
 }
 

--- a/aws/common/cloudwatch_alarms_sms.tf
+++ b/aws/common/cloudwatch_alarms_sms.tf
@@ -147,7 +147,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-us
 resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-critical" {
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sns-sms-success-rate-canadian-numbers-critical"
-  alarm_description   = "SMS success rate to Canadian numbers is below 25% with at least 100 messages over 2 consecutive periods of 12 hours"
+  alarm_description   = "SMS success rate to Canadian numbers is below 25% with at least 25 messages over 2 consecutive periods of 12 hours"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "2"
   datapoints_to_alarm = "2"
@@ -192,7 +192,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-cr
     id          = "alarmCondition"
     label       = "Guarded Alarm Condition"
     return_data = true
-    expression  = "IF(successRate < 0.25 AND messagesPublished > 100, 0, 1)"
+    expression  = "IF(successRate < 0.25 AND messagesPublished > 25, 0, 1)"
   }
 }
 


### PR DESCRIPTION
# Summary | Résumé

Added a traffic floor to the critical Canadian SMS success-rate alarm only:

sns-sms-success-rate-canadian-numbers-critical now uses metric math instead of a single metric.
Alarm fires only when the 12‑hour success rate drops below 25 % and more than 100 transactional SMS were published in that same 12‑hour window (configurable via the expression messagesPublished > 100).
Warning alarm remains untouched.

## Related Issues | Cartes liées

https://opsg.in/a/i/cds-snc/168b8ab2-25e6-4ccf-ba2b-73a28fb29b86-1759025301672

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
