### PR TITLE
adding secret so that lambda can access it

### DIFF
--- a/aws/lambda-api/iam.tf
+++ b/aws/lambda-api/iam.tf
@@ -89,7 +89,8 @@ data "aws_iam_policy_document" "api_policies" {
       "secretsmanager:GetSecretValue",
     ]
     resources = [
-      aws_secretsmanager_secret_version.new-relic-license-key.arn
+      aws_secretsmanager_secret_version.new-relic-license-key.arn,
+      aws_secretsmanager_secret_version.lambda-new-relic-license-key.arn
     ]
   }
 


### PR DESCRIPTION
# Summary | Résumé

adding iam access for the lambda to access the lambda new relic license key secret

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
