### PR TITLE
API k8s 75-25

### DIFF
--- a/aws/eks/dns.tf
+++ b/aws/eks/dns.tf
@@ -142,7 +142,7 @@ resource "aws_route53_record" "api-weighted-0-scratch-notification-A" {
   }
 
   weighted_routing_policy {
-    weight = 50
+    weight = 75
   }
 }
 

--- a/aws/lambda-api/dns.tf
+++ b/aws/lambda-api/dns.tf
@@ -32,7 +32,7 @@ resource "aws_route53_record" "api-weighted-100-notification-A" {
   }
 
   weighted_routing_policy {
-    weight = 50
+    weight = 25
   }
 }
 


### PR DESCRIPTION
# Summary | Résumé

Send 75% of API traffic to K8s

## Related Issues | Cartes liées

*  https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/770

## Test instructions | Instructions pour tester la modification

TF Apply works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
