### PR TITLE
Reduce staging to db.r6g.large

### DIFF
--- a/env/staging_config.tfvars
+++ b/env/staging_config.tfvars
@@ -97,7 +97,7 @@ google_cidr_schedule_expression = "rate(1 day)"
 
 ## RDS
 rds_instance_count                     = 3
-rds_instance_type                      = "db.r6g.xlarge"
+rds_instance_type                      = "db.r6g.large"
 rds_database_name                      = "NotificationCanadaCastaging"
 rds_version                            = "16.6"
 platform_data_lake_kms_key_arn         = "arn:aws:kms:ca-central-1:739275439843:key/22f27c88-bb2b-49c3-b731-05123a974af4"


### PR DESCRIPTION
# Summary | Résumé

Reducing the staging database size to db.r6g.large since we no longer max out the database when doing quicksight data loads. We currently see a peak of ~25% CPU usage on our production database. Reducing this to r6g.large should now mean we see ~50% under full load, which leaves plenty of breathing room for spikes as well as for when cost recovery comes into play.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/779

## Test instructions | Instructions pour tester la modification

TF Apply works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
