### PR TITLE
Resetting 500 Alarm (post hacker one)

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -400,14 +400,14 @@ resource "aws_cloudwatch_metric_alarm" "logs-1-500-error-1-minute-warning" {
 resource "aws_cloudwatch_metric_alarm" "logs-10-500-error-5-minutes-critical" {
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-10-500-error-5-minutes-critical"
-  alarm_description   = "Fifty 500 errors in 5 minutes"
+  alarm_description   = "Ten 500 errors in 5 minutes"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = aws_cloudwatch_log_metric_filter.web-500-errors[0].metric_transformation[0].name
   namespace           = aws_cloudwatch_log_metric_filter.web-500-errors[0].metric_transformation[0].namespace
   period              = 300
   statistic           = "Sum"
-  threshold           = 50 # Temporary value until end of HackerOne March 2026: revert to 20 afterwards
+  threshold           = 10
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_critical_arn]
   ok_actions          = [var.sns_alert_critical_arn]


### PR DESCRIPTION
# Summary | Résumé

This pull request updates the configuration for the `logs-10-500-error-5-minutes-critical` CloudWatch alarm to make its threshold and description more accurate and sensitive.

CloudWatch alarm configuration:

* Updated the `alarm_description` to state "Ten 500 errors in 5 minutes" instead of "Fifty 500 errors in 5 minutes" for clarity and accuracy.
* Lowered the `threshold` from 50 to 10, making the alarm trigger on fewer 500 errors within the 5-minute period.

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/811

## Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
