### PR TITLE
tune alarms for lower db instance

### DIFF
--- a/aws/rds/cloudwatch_alarms.tf
+++ b/aws/rds/cloudwatch_alarms.tf
@@ -88,7 +88,7 @@ resource "aws_cloudwatch_metric_alarm" "low-db-memory-warning" {
   namespace           = "AWS/RDS"
   period              = 60
   statistic           = "Average"
-  threshold           = 4 * 1024 * 1024 * 1024
+  threshold           = var.env == "production" ? 4 * 1024 * 1024 * 1024 : 2 * 1024 * 1024 * 1024
   alarm_actions       = [var.sns_alert_warning_arn]
   treat_missing_data  = "notBreaching"
   dimensions = {
@@ -107,7 +107,7 @@ resource "aws_cloudwatch_metric_alarm" "low-db-memory-critical" {
   namespace           = "AWS/RDS"
   period              = 60
   statistic           = "Average"
-  threshold           = 2 * 1024 * 1024 * 1024
+  threshold           = var.env == "production" ? 2 * 1024 * 1024 * 1024 : 1 * 1024 * 1024 * 1024
   alarm_actions       = [var.sns_alert_critical_arn]
   treat_missing_data  = "notBreaching"
   dimensions = {


### PR DESCRIPTION
# Summary | Résumé

We are reducing the db size since we've streamlined quicksight. We need to lower the alarm threshold for low db memory to account for this. 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/779

## Test instructions | Instructions pour tester la modification

TF Apply works
No alarms on staging

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
