### PR TITLE
reverting staging db size

### DIFF
--- a/aws/rds/cloudwatch_alarms.tf
+++ b/aws/rds/cloudwatch_alarms.tf
@@ -88,7 +88,7 @@ resource "aws_cloudwatch_metric_alarm" "low-db-memory-warning" {
   namespace           = "AWS/RDS"
   period              = 60
   statistic           = "Average"
-  threshold           = var.env == "production" ? 4 * 1024 * 1024 * 1024 : 2 * 1024 * 1024 * 1024
+  threshold           = 4 * 1024 * 1024 * 1024
   alarm_actions       = [var.sns_alert_warning_arn]
   treat_missing_data  = "notBreaching"
   dimensions = {
@@ -107,7 +107,7 @@ resource "aws_cloudwatch_metric_alarm" "low-db-memory-critical" {
   namespace           = "AWS/RDS"
   period              = 60
   statistic           = "Average"
-  threshold           = var.env == "production" ? 2 * 1024 * 1024 * 1024 : 1 * 1024 * 1024 * 1024
+  threshold           = 2 * 1024 * 1024 * 1024
   alarm_actions       = [var.sns_alert_critical_arn]
   treat_missing_data  = "notBreaching"
   dimensions = {

--- a/env/staging_config.tfvars
+++ b/env/staging_config.tfvars
@@ -97,7 +97,7 @@ google_cidr_schedule_expression = "rate(1 day)"
 
 ## RDS
 rds_instance_count                     = 3
-rds_instance_type                      = "db.r6g.large"
+rds_instance_type                      = "db.r6g.xlarge"
 rds_database_name                      = "NotificationCanadaCastaging"
 rds_version                            = "16.6"
 platform_data_lake_kms_key_arn         = "arn:aws:kms:ca-central-1:739275439843:key/22f27c88-bb2b-49c3-b731-05123a974af4"


### PR DESCRIPTION
# Summary | Résumé

After running a perf test with the lowered DB values, we decided it would not be a good idea to downgrade the database size since we are going to be doing cost recovery soon. The perf test against the downgraded DB showed a 75% usage of CPU and memory, and since we'll be getting more traffic soon, it's not a good idea to downgrade.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/779

## Test instructions | Instructions pour tester la modification

TF Apply

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
