### PR TITLE
Fixing OIDC Role Bugs

### DIFF
--- a/aws/github/iam_policies.tf
+++ b/aws/github/iam_policies.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "notification_manifests_helmfile_apply" {
 
   statement {
     effect  = "Allow"
-    actions = ["s3:GetObject", "s3:ListBucket"]
+    actions = ["s3:GetObject", "s3:ListBucket", "s3:GetBucketVersioning"]
     resources = [
       "arn:aws:s3:::notification-canada-ca-staging-tf",
       "arn:aws:s3:::notification-canada-ca-staging-tf/*"
@@ -109,7 +109,7 @@ data "aws_iam_policy_document" "notification_manifests_helmfile_apply_production
 
   statement {
     effect  = "Allow"
-    actions = ["s3:GetObject", "s3:ListBucket"]
+    actions = ["s3:GetObject", "s3:ListBucket", "s3:GetBucketVersioning"]
     resources = [
       "arn:aws:s3:::notification-canada-ca-production-tf",
       "arn:aws:s3:::notification-canada-ca-production-tf/*"
@@ -157,7 +157,7 @@ data "aws_iam_policy_document" "notification_manifests_database_migration" {
 
   statement {
     effect  = "Allow"
-    actions = ["s3:GetObject", "s3:ListBucket"]
+    actions = ["s3:GetObject", "s3:ListBucket", "s3:GetBucketVersioning"]
     resources = [
       "arn:aws:s3:::notification-canada-ca-staging-tf",
       "arn:aws:s3:::notification-canada-ca-staging-tf/*"
@@ -205,7 +205,7 @@ data "aws_iam_policy_document" "notification_manifests_database_migration_produc
 
   statement {
     effect  = "Allow"
-    actions = ["s3:GetObject", "s3:ListBucket"]
+    actions = ["s3:GetObject", "s3:ListBucket", "s3:GetBucketVersioning"]
     resources = [
       "arn:aws:s3:::notification-canada-ca-production-tf",
       "arn:aws:s3:::notification-canada-ca-production-tf/*"

--- a/aws/github/iam_roles.tf
+++ b/aws/github/iam_roles.tf
@@ -786,7 +786,7 @@ module "github_workflow_roles_notification_system_status_production" {
     {
       name      = local.notification_system_status_frontend_prod_upload_to_s3
       repo_name = "notification-system-status-frontend"
-      claim     = "ref:refs/tags/*"
+      claim     = "ref:refs/heads/main"
     }
   ]
 }

--- a/aws/github/iam_roles.tf
+++ b/aws/github/iam_roles.tf
@@ -786,7 +786,7 @@ module "github_workflow_roles_notification_system_status_production" {
     {
       name      = local.notification_system_status_frontend_prod_upload_to_s3
       repo_name = "notification-system-status-frontend"
-      claim     = "ref:refs/heads/main"
+      claim     = "ref:refs/tags/*"
     }
   ]
 }

--- a/aws/github/iam_roles.tf
+++ b/aws/github/iam_roles.tf
@@ -786,7 +786,7 @@ module "github_workflow_roles_notification_system_status_production" {
     {
       name      = local.notification_system_status_frontend_prod_upload_to_s3
       repo_name = "notification-system-status-frontend"
-      claim     = "ref:refs/tags/*"
+      claim     = "ref:refs/*"
     }
   ]
 }


### PR DESCRIPTION
# Summary | Résumé

This pull request makes a targeted change to the IAM role configuration for the `notification-system-status-frontend` repository in production. The main update is to restrict the deployment permissions to only the `main` branch, instead of all tags.

* IAM Role Permissions:
  * In `aws/github/iam_roles.tf`, updated the `claim` for the `notification-system-status-frontend` role from `"ref:refs/tags/*"` to `"ref:refs/heads/main"`, ensuring that only pushes to the `main` branch can trigger uploads to S3 in production.

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
