### PR TITLE
Adding more Missing Roles for Manifests IAM 

### DIFF
--- a/aws/github/iam_policies.tf
+++ b/aws/github/iam_policies.tf
@@ -58,6 +58,12 @@ data "aws_iam_policy_document" "notification_manifests_helmfile_apply" {
       "arn:aws:s3:::notification-canada-ca-staging-tf/*"
     ]
   }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["dynamodb:DescribeTable", "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:DeleteItem", "dynamodb:UpdateItem"]
+    resources = ["arn:aws:dynamodb:${var.region}:${var.account_id}:table/terraform-state-lock-dynamo"]
+  }
 }
 
 #
@@ -115,6 +121,12 @@ data "aws_iam_policy_document" "notification_manifests_helmfile_apply_production
       "arn:aws:s3:::notification-canada-ca-production-tf/*"
     ]
   }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["dynamodb:DescribeTable", "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:DeleteItem", "dynamodb:UpdateItem"]
+    resources = ["arn:aws:dynamodb:${var.region}:${var.account_id}:table/terraform-state-lock-dynamo"]
+  }
 }
 
 #
@@ -163,6 +175,12 @@ data "aws_iam_policy_document" "notification_manifests_database_migration" {
       "arn:aws:s3:::notification-canada-ca-staging-tf/*"
     ]
   }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["dynamodb:DescribeTable", "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:DeleteItem", "dynamodb:UpdateItem"]
+    resources = ["arn:aws:dynamodb:${var.region}:${var.account_id}:table/terraform-state-lock-dynamo"]
+  }
 }
 
 #
@@ -210,6 +228,12 @@ data "aws_iam_policy_document" "notification_manifests_database_migration_produc
       "arn:aws:s3:::notification-canada-ca-production-tf",
       "arn:aws:s3:::notification-canada-ca-production-tf/*"
     ]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["dynamodb:DescribeTable", "dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:DeleteItem", "dynamodb:UpdateItem"]
+    resources = ["arn:aws:dynamodb:${var.region}:${var.account_id}:table/terraform-state-lock-dynamo"]
   }
 }
 

--- a/aws/github/iam_policies.tf
+++ b/aws/github/iam_policies.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "notification_manifests_helmfile_apply" {
 
   statement {
     effect  = "Allow"
-    actions = ["s3:GetObject", "s3:ListBucket", "s3:GetBucketVersioning"]
+    actions = ["s3:GetObject", "s3:ListBucket", "s3:GetBucketVersioning", "s3:GetEncryptionConfiguration", "s3:GetBucket*"]
     resources = [
       "arn:aws:s3:::notification-canada-ca-staging-tf",
       "arn:aws:s3:::notification-canada-ca-staging-tf/*"
@@ -109,7 +109,7 @@ data "aws_iam_policy_document" "notification_manifests_helmfile_apply_production
 
   statement {
     effect  = "Allow"
-    actions = ["s3:GetObject", "s3:ListBucket", "s3:GetBucketVersioning"]
+    actions = ["s3:GetObject", "s3:ListBucket", "s3:GetBucketVersioning", "s3:GetEncryptionConfiguration", "s3:GetBucket*"]
     resources = [
       "arn:aws:s3:::notification-canada-ca-production-tf",
       "arn:aws:s3:::notification-canada-ca-production-tf/*"
@@ -157,7 +157,7 @@ data "aws_iam_policy_document" "notification_manifests_database_migration" {
 
   statement {
     effect  = "Allow"
-    actions = ["s3:GetObject", "s3:ListBucket", "s3:GetBucketVersioning"]
+    actions = ["s3:GetObject", "s3:ListBucket", "s3:GetBucketVersioning", "s3:GetEncryptionConfiguration", "s3:GetBucket*"]
     resources = [
       "arn:aws:s3:::notification-canada-ca-staging-tf",
       "arn:aws:s3:::notification-canada-ca-staging-tf/*"
@@ -205,7 +205,7 @@ data "aws_iam_policy_document" "notification_manifests_database_migration_produc
 
   statement {
     effect  = "Allow"
-    actions = ["s3:GetObject", "s3:ListBucket", "s3:GetBucketVersioning"]
+    actions = ["s3:GetObject", "s3:ListBucket", "s3:GetBucketVersioning", "s3:GetEncryptionConfiguration", "s3:GetBucket*"]
     resources = [
       "arn:aws:s3:::notification-canada-ca-production-tf",
       "arn:aws:s3:::notification-canada-ca-production-tf/*"

--- a/aws/github/iam_roles.tf
+++ b/aws/github/iam_roles.tf
@@ -633,11 +633,43 @@ resource "aws_iam_role_policy_attachment" "notification_manifests_helmfile_stagi
   depends_on = [module.github_workflow_roles_notification_manifests_staging]
 }
 
+resource "aws_iam_role_policy_attachment" "notification_manifests_helmfile_staging_apply_read_only" {
+  count = var.env == "staging" ? 1 : 0
+
+  role       = local.notification_manifests_helmfile_staging_apply
+  policy_arn = data.aws_iam_policy.readonly.arn
+  depends_on = [module.github_workflow_roles_notification_manifests_staging]
+}
+
+resource "aws_iam_role_policy_attachment" "notification_manifests_helmfile_staging_apply_oidc_plan_policy" {
+  count = var.env == "staging" ? 1 : 0
+
+  role       = local.notification_manifests_helmfile_staging_apply
+  policy_arn = data.aws_iam_policy.oidcplanpolicy.arn
+  depends_on = [module.github_workflow_roles_notification_manifests_staging]
+}
+
 resource "aws_iam_role_policy_attachment" "notification_manifests_database_migration_staging" {
   count = var.env == "staging" ? 1 : 0
 
   role       = local.notification_manifests_database_migration_staging
   policy_arn = aws_iam_policy.notification_manifests_database_migration[0].arn
+  depends_on = [module.github_workflow_roles_notification_manifests_staging]
+}
+
+resource "aws_iam_role_policy_attachment" "notification_manifests_database_migration_staging_read_only" {
+  count = var.env == "staging" ? 1 : 0
+
+  role       = local.notification_manifests_database_migration_staging
+  policy_arn = data.aws_iam_policy.readonly.arn
+  depends_on = [module.github_workflow_roles_notification_manifests_staging]
+}
+
+resource "aws_iam_role_policy_attachment" "notification_manifests_database_migration_staging_oidc_plan_policy" {
+  count = var.env == "staging" ? 1 : 0
+
+  role       = local.notification_manifests_database_migration_staging
+  policy_arn = data.aws_iam_policy.oidcplanpolicy.arn
   depends_on = [module.github_workflow_roles_notification_manifests_staging]
 }
 
@@ -649,11 +681,43 @@ resource "aws_iam_role_policy_attachment" "notification_manifests_helmfile_produ
   depends_on = [module.github_workflow_roles_notification_manifests_production]
 }
 
+resource "aws_iam_role_policy_attachment" "notification_manifests_helmfile_production_apply_read_only" {
+  count = var.env == "production" ? 1 : 0
+
+  role       = local.notification_manifests_helmfile_production_apply
+  policy_arn = data.aws_iam_policy.readonly.arn
+  depends_on = [module.github_workflow_roles_notification_manifests_production]
+}
+
+resource "aws_iam_role_policy_attachment" "notification_manifests_helmfile_production_apply_oidc_plan_policy" {
+  count = var.env == "production" ? 1 : 0
+
+  role       = local.notification_manifests_helmfile_production_apply
+  policy_arn = data.aws_iam_policy.oidcplanpolicy.arn
+  depends_on = [module.github_workflow_roles_notification_manifests_production]
+}
+
 resource "aws_iam_role_policy_attachment" "notification_manifests_database_migration_production" {
   count = var.env == "production" ? 1 : 0
 
   role       = local.notification_manifests_database_migration_production
   policy_arn = aws_iam_policy.notification_manifests_database_migration_production[0].arn
+  depends_on = [module.github_workflow_roles_notification_manifests_production]
+}
+
+resource "aws_iam_role_policy_attachment" "notification_manifests_database_migration_production_read_only" {
+  count = var.env == "production" ? 1 : 0
+
+  role       = local.notification_manifests_database_migration_production
+  policy_arn = data.aws_iam_policy.readonly.arn
+  depends_on = [module.github_workflow_roles_notification_manifests_production]
+}
+
+resource "aws_iam_role_policy_attachment" "notification_manifests_database_migration_production_oidc_plan_policy" {
+  count = var.env == "production" ? 1 : 0
+
+  role       = local.notification_manifests_database_migration_production
+  policy_arn = data.aws_iam_policy.oidcplanpolicy.arn
   depends_on = [module.github_workflow_roles_notification_manifests_production]
 }
 


### PR DESCRIPTION
# Summary | Résumé

This pull request updates IAM policies and role attachments for both staging and production environments to enhance permissions and modularize policy assignments. The main changes are the expansion of S3 and DynamoDB permissions, and the addition of modular policy attachments for read-only and OIDC plan policies.

**IAM Policy Updates:**

* Expanded S3 permissions to include `s3:GetEncryptionConfiguration` and `s3:GetBucket*` actions for all relevant policies, enabling broader access to S3 bucket configurations. [[1]](diffhunk://#diff-f22bbf8fd6ca57fafc0b5c2ec634bea58a1c1d0a50d96a1a81aae9843da14263L55-R66) [[2]](diffhunk://#diff-f22bbf8fd6ca57fafc0b5c2ec634bea58a1c1d0a50d96a1a81aae9843da14263L112-R129) [[3]](diffhunk://#diff-f22bbf8fd6ca57fafc0b5c2ec634bea58a1c1d0a50d96a1a81aae9843da14263L160-R183) [[4]](diffhunk://#diff-f22bbf8fd6ca57fafc0b5c2ec634bea58a1c1d0a50d96a1a81aae9843da14263L208-R237)
* Added DynamoDB permissions (`DescribeTable`, `GetItem`, `PutItem`, `DeleteItem`, `UpdateItem`) for the `terraform-state-lock-dynamo` table to support state locking operations. [[1]](diffhunk://#diff-f22bbf8fd6ca57fafc0b5c2ec634bea58a1c1d0a50d96a1a81aae9843da14263L55-R66) [[2]](diffhunk://#diff-f22bbf8fd6ca57fafc0b5c2ec634bea58a1c1d0a50d96a1a81aae9843da14263L112-R129) [[3]](diffhunk://#diff-f22bbf8fd6ca57fafc0b5c2ec634bea58a1c1d0a50d96a1a81aae9843da14263L160-R183) [[4]](diffhunk://#diff-f22bbf8fd6ca57fafc0b5c2ec634bea58a1c1d0a50d96a1a81aae9843da14263L208-R237)

**IAM Role Attachments (Modularization):**

* Added new role policy attachments for both staging and production environments to assign the `readonly` and `oidcplanpolicy` policies to Helmfile apply and database migration roles, improving modularity and clarity in policy management. [[1]](diffhunk://#diff-d159fb1919852b1b5fe639219cd4dfe7d914134030b2a0b7b45aa1347d9f4ce8R636-R651) [[2]](diffhunk://#diff-d159fb1919852b1b5fe639219cd4dfe7d914134030b2a0b7b45aa1347d9f4ce8R660-R675) [[3]](diffhunk://#diff-d159fb1919852b1b5fe639219cd4dfe7d914134030b2a0b7b45aa1347d9f4ce8R684-R699) [[4]](diffhunk://#diff-d159fb1919852b1b5fe639219cd4dfe7d914134030b2a0b7b45aa1347d9f4ce8R708-R723)

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1
* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/1

## Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
