### PR TITLE
API 100% to k8s

### DIFF
--- a/aws/eks/dns.tf
+++ b/aws/eks/dns.tf
@@ -126,8 +126,12 @@ resource "aws_route53_record" "api-k8s-scratch-notification-CNAME" {
   records = [aws_alb.notification-canada-ca.dns_name]
 }
 
-resource "aws_route53_record" "api-weighted-0-scratch-notification-A" {
-  # Send no API traffic to K8s
+moved {
+  from = aws_route53_record.api-weighted-0-scratch-notification-A
+  to   = aws_route53_record.api-weighted-notification-A
+}
+
+resource "aws_route53_record" "api-weighted-notification-A" {
   provider        = aws.dns
   zone_id         = var.route53_zone_id
   name            = "api.${var.domain}"
@@ -142,7 +146,7 @@ resource "aws_route53_record" "api-weighted-0-scratch-notification-A" {
   }
 
   weighted_routing_policy {
-    weight = 75
+    weight = 100
   }
 }
 

--- a/aws/lambda-api/dns.tf
+++ b/aws/lambda-api/dns.tf
@@ -15,7 +15,12 @@ resource "aws_route53_record" "api-lambda-notification-A" {
 
 }
 
-resource "aws_route53_record" "api-weighted-100-notification-A" {
+moved {
+  from = aws_route53_record.api-weighted-100-notification-A
+  to   = aws_route53_record.api-weighted-notification-A
+}
+
+resource "aws_route53_record" "api-weighted-notification-A" {
   # Send all API traffic to Lambda
   provider = aws.dns
 
@@ -32,7 +37,7 @@ resource "aws_route53_record" "api-weighted-100-notification-A" {
   }
 
   weighted_routing_policy {
-    weight = 25
+    weight = 0
   }
 }
 

--- a/aws/lambda-api/dns.tf
+++ b/aws/lambda-api/dns.tf
@@ -21,7 +21,7 @@ moved {
 }
 
 resource "aws_route53_record" "api-weighted-notification-A" {
-  # Send all API traffic to Lambda
+  # Weighted record configured to send 0% of API traffic to Lambda
   provider = aws.dns
 
   zone_id         = var.route53_zone_id


### PR DESCRIPTION
# Summary | Résumé

Moving 100% of the traffic to API K8s

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/770

## Test instructions | Instructions pour tester la modification

TF Apply works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
