### PR TITLE
Added new celery error category for metrics related errors

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -216,11 +216,44 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-job-incomplete-critica
   ok_actions          = [var.sns_alert_critical_arn]
 }
 
+# METRICS
+resource "aws_cloudwatch_metric_alarm" "logs-celery-error-metrics-warning" {
+  count               = var.cloudwatch_enabled ? 1 : 0
+  alarm_name          = "logs-celery-error-metrics-warning"
+  alarm_description   = "30 Celery metrics related error in 1 minute"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.celery-error-metrics[0].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.celery-error-metrics[0].metric_transformation[0].namespace
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 30
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [var.sns_alert_warning_arn]
+  ok_actions          = [var.sns_alert_warning_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "logs-celery-error-metrics-critical" {
+  count               = var.cloudwatch_enabled ? 1 : 0
+  alarm_name          = "logs-celery-error-metrics-critical"
+  alarm_description   = "60 Celery metrics related errors in 1 minute"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.celery-error-metrics[0].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.celery-error-metrics[0].metric_transformation[0].namespace
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 60
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [var.sns_alert_critical_arn]
+  ok_actions          = [var.sns_alert_critical_arn]
+}
+
 # NOTIFICATION_NOT_FOUND
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-notification-not-found-warning" {
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-notification-not-found-warning"
-  alarm_description   = "50 Celery notification not found errors in 1 minute"
+  alarm_description   = "50 Celery notifications not found errors in 1 minute"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = aws_cloudwatch_log_metric_filter.celery-error-notification-not-found[0].metric_transformation[0].name
@@ -236,7 +269,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-notification-not-found
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-notification-not-found-critical" {
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-notification-not-found-critical"
-  alarm_description   = "200 Celery notification not found errors in 1 minute"
+  alarm_description   = "200 Celery notifications not found errors in 1 minute"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = aws_cloudwatch_log_metric_filter.celery-error-notification-not-found[0].metric_transformation[0].name

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -92,6 +92,20 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error-job-incomplete" {
   }
 }
 
+resource "aws_cloudwatch_log_metric_filter" "celery-error-metrics" {
+  # This monitors for incomplete jobs that couldn't be completed within Celery.
+  count          = var.cloudwatch_enabled ? 1 : 0
+  name           = "celery-error-metrics"
+  pattern        = "\"CELERY_KNOWN_ERROR::METRICS\""
+  log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs[0].name
+
+  metric_transformation {
+    name      = "celery-error-job-incomplete"
+    namespace = "LogMetrics"
+    value     = "1"
+  }
+}
+
 resource "aws_cloudwatch_log_metric_filter" "celery-error-notification-not-found" {
   # This monitors for Celery errors when notifications were not found within the system.
   count          = var.cloudwatch_enabled ? 1 : 0


### PR DESCRIPTION
# Summary | Résumé

Added new celery error category for metrics related errors

## Related Issues | Cartes liées

* [Reduce Celery errors with business exception translation layer](https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/634) #634

## Test instructions | Instructions pour tester la modification

Fetch cloudwatch logs and check for the new error category.

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
