### PR TITLE
Adding Role Rights to fix Prod S3 Workflow (system status frontend)

### DIFF
--- a/aws/github/iam_policies.tf
+++ b/aws/github/iam_policies.tf
@@ -466,6 +466,12 @@ data "aws_iam_policy_document" "notification_system_status_frontend_upload_to_s3
 
   statement {
     effect    = "Allow"
+    actions   = ["s3:GetBucketTagging", "s3:PutBucketTagging"]
+    resources = ["arn:aws:s3:::notification-canada-ca-staging-system-status"]
+  }
+
+  statement {
+    effect    = "Allow"
     actions   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
     resources = ["arn:aws:s3:::notification-canada-ca-staging-system-status/*"]
   }
@@ -494,6 +500,12 @@ data "aws_iam_policy_document" "notification_system_status_frontend_prod_upload_
   statement {
     effect    = "Allow"
     actions   = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::notification-canada-ca-production-system-status"]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:GetBucketTagging", "s3:PutBucketTagging"]
     resources = ["arn:aws:s3:::notification-canada-ca-production-system-status"]
   }
 


### PR DESCRIPTION
# Summary | Résumé

This pull request updates IAM policy documents to grant additional S3 bucket permissions for both the staging and production system status environments. The main change is to allow the frontend to get and set S3 bucket tagging, which may be required for new features or compliance.

**IAM policy updates:**

* Added `s3:GetBucketTagging` and `s3:PutBucketTagging` permissions to the `notification-canada-ca-staging-system-status` S3 bucket in the `notification_system_status_frontend_upload_to_s3` policy.
* Added `s3:GetBucketTagging` and `s3:PutBucketTagging` permissions to the `notification-canada-ca-production-system-status` S3 bucket in the `notification_system_status_frontend_prod_upload_` policy.

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
