### PR TITLE
Allow alt domain to K8s API

### DIFF
--- a/aws/common/waf.tf
+++ b/aws/common/waf.tf
@@ -186,6 +186,13 @@ resource "aws_wafv2_regex_pattern_set" "notification_base_url" {
     regex_string = "${var.domain}$"
   }
 
+  dynamic "regular_expression" {
+    for_each = var.alt_domain != null && trimspace(var.alt_domain) != "" ? [var.alt_domain] : []
+    content {
+      regex_string = regular_expression.value
+    }
+  }
+
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
   }

--- a/aws/common/waf.tf
+++ b/aws/common/waf.tf
@@ -189,7 +189,7 @@ resource "aws_wafv2_regex_pattern_set" "notification_base_url" {
   dynamic "regular_expression" {
     for_each = var.alt_domain != null && trimspace(var.alt_domain) != "" ? [var.alt_domain] : []
     content {
-      regex_string = regular_expression.value
+      regex_string = "${regular_expression.value}$"
     }
   }
 


### PR DESCRIPTION
# Summary | Résumé

When using api.notification.alpha.canada.ca we had an issue where it was getting a 403 since we check host headers to prevent header injections. Adding the alt domain (alpha) so that we can receive traffic from here as well.

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/770

## Test instructions | Instructions pour tester la modification

Set hosts file to resolve api.notification.alpha.canada.ca to the eks alb and verify you don't get a 403 in your browser/curl

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
