### PR TITLE
Removing lambda from heartbeat

### DIFF
--- a/aws/heartbeat/lambda.tf
+++ b/aws/heartbeat/lambda.tf
@@ -15,7 +15,7 @@ module "heartbeat" {
 
   environment_variables = {
     heartbeat_api_key    = var.heartbeat_api_key
-    heartbeat_base_url   = "['https://api-lambda.${var.base_domain}', 'https://api-k8s.${var.base_domain}']"
+    heartbeat_base_url   = "['https://api.${var.base_domain}']"
     heartbeat_sms_number = var.heartbeat_sms_number
   }
 }


### PR DESCRIPTION
# Summary | Résumé

The heartbeat was still calling the k8s and lambda functions individually. Since we're moving away from Lambdas, removing this, and setting it to only hit the api.base_domain since we don't need it to hit both anymore.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/770

## Test instructions | Instructions pour tester la modification

TF Apply works
Verify no more calls to Lambda from heartbeat

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
