### PR TITLE
Fix ami patch

### DIFF
--- a/aws/github/iam_policies.tf
+++ b/aws/github/iam_policies.tf
@@ -931,6 +931,14 @@ data "aws_iam_policy_document" "notification_terraform_check_eks_ami_update" {
       "arn:aws:ssm:${var.region}::parameter/aws/service/eks/optimized-ami/*"
     ]
   }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeImages"
+    ]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "notification_terraform_check_eks_cluster_update" {

--- a/aws/heartbeat/lambda.tf
+++ b/aws/heartbeat/lambda.tf
@@ -15,7 +15,7 @@ module "heartbeat" {
 
   environment_variables = {
     heartbeat_api_key    = var.heartbeat_api_key
-    heartbeat_base_url   = "['https://api-lambda.${var.base_domain}', 'https://api-k8s.${var.base_domain}']"
+    heartbeat_base_url   = "['https://api.${var.base_domain}']"
     heartbeat_sms_number = var.heartbeat_sms_number
   }
 }


### PR DESCRIPTION
# Summary | Résumé

We introduced an issue when moving to discrete OIDC roles where the AMI patch job could no longer read the karpenter version of the AMIs. This IAM fix should resolve this.

## Related Issues | Cartes liées

Ad-hoc debugging

## Test instructions | Instructions pour tester la modification

TF Apply
Re-run the check AMI updates action and verify it was successful

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
