### PR TITLE
adjust timing on quicksight data refreshes

### DIFF
--- a/aws/quicksight/dataset_notifications.tf
+++ b/aws/quicksight/dataset_notifications.tf
@@ -204,7 +204,7 @@ resource "aws_quicksight_refresh_schedule" "notifications_athena" {
 
     schedule_frequency {
       interval        = "DAILY"
-      time_of_the_day = "05:20"
+      time_of_the_day = "09:20"
     }
   }
 }

--- a/aws/quicksight/dataset_refresh_order.txt
+++ b/aws/quicksight/dataset_refresh_order.txt
@@ -6,8 +6,6 @@ All times are UTC.
 
 0500 - sms_usage
 
-0520 - notifications_athena (takes about 3 hours. Rest of tables are under 5 minutes to refresh)
-
 0715 - jobs
 0720 - templates
 
@@ -18,4 +16,6 @@ All times are UTC.
 0740 - users
 0745 - ft_billing
 
-0900 - sms_usage_notifications
+0920 - notifications_athena (takes about 3 hours. Rest of tables are under 5 minutes to refresh)
+
+1200 - sms_usage_notifications

--- a/aws/quicksight/dataset_sms_usage_notifications.tf
+++ b/aws/quicksight/dataset_sms_usage_notifications.tf
@@ -99,7 +99,7 @@ resource "aws_quicksight_refresh_schedule" "sms-usage-notifications" {
 
     schedule_frequency {
       interval        = "DAILY"
-      time_of_the_day = "09:00"
+      time_of_the_day = "12:00"
     }
   }
 }

--- a/aws/quicksight/step_function.tf
+++ b/aws/quicksight/step_function.tf
@@ -69,7 +69,7 @@ resource "aws_sfn_state_machine" "athena_update_table_location" {
 resource "aws_cloudwatch_event_rule" "step_function_daily_trigger" {
   name                = "daily-athena-update-table-location"
   description         = "Daily trigger to update Athena table locations"
-  schedule_expression = "cron(10 5 * * ? *)" # daily at 05:10 UTC
+  schedule_expression = "cron(10 9 * * ? *)" # daily at 09:10 UTC
 }
 
 resource "aws_iam_role" "eventbridge_role" {


### PR DESCRIPTION
# Summary | Résumé

Adjust the timing on quicksight refreshes to align with recent changes on when the data lake gets refreshed. 

notifications_athena + 4hrs
sms_usage_notifications + 3hrs

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/835

## Test instructions | Instructions pour tester la modification

tf apply runs

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
