### PR TITLE
ignore start_after_date_time to update schedules

### DIFF
--- a/aws/quicksight/dataset_notifications.tf
+++ b/aws/quicksight/dataset_notifications.tf
@@ -207,4 +207,10 @@ resource "aws_quicksight_refresh_schedule" "notifications_athena" {
       time_of_the_day = "09:20"
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      schedule[0].start_after_date_time
+    ]
+  }
 }

--- a/aws/quicksight/dataset_sms_usage_notifications.tf
+++ b/aws/quicksight/dataset_sms_usage_notifications.tf
@@ -102,4 +102,10 @@ resource "aws_quicksight_refresh_schedule" "sms-usage-notifications" {
       time_of_the_day = "12:00"
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      schedule[0].start_after_date_time
+    ]
+  }
 }


### PR DESCRIPTION
# Summary | Résumé

Tell terraform to ignore start_after_date_time field so that the daily schedule can be updated.

Currently throws this error:
InvalidParameterValueException: Schedules cannot start in the past: passed

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/835

## Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
