### PR TITLE
OK Actions for Alarms missing them

### DIFF
--- a/.github/workflows/terragrunt_plan_production.yml
+++ b/.github/workflows/terragrunt_plan_production.yml
@@ -5,8 +5,6 @@ on:
   pull_request:
     paths:
       - ".github/workflows/infrastructure_version.txt"
-      - "env/production/**"
-      - "env/production_config.tfvars"
 
 permissions:
   id-token: write

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -1291,6 +1291,7 @@ resource "aws_cloudwatch_metric_alarm" "service-callback-too-many-failures-criti
   threshold           = 100
   treat_missing_data  = "notBreaching"
   alarm_actions       = [var.sns_alert_critical_arn]
+  ok_actions          = [var.sns_alert_ok_arn]
 }
 
 

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -22,6 +22,10 @@ variable "sns_alert_critical_arn" {
   type = string
 }
 
+variable "sns_alert_ok_arn" {
+  type = string
+}
+
 variable "sns_alert_general_arn" {
   type = string
 }

--- a/aws/rds/cloudwatch_alarms.tf
+++ b/aws/rds/cloudwatch_alarms.tf
@@ -34,6 +34,7 @@ resource "aws_cloudwatch_metric_alarm" "high-dbload-critical" {
   statistic           = "Average"
   threshold           = 100
   alarm_actions       = [var.sns_alert_critical_arn]
+  ok_actions          = [var.sns_alert_ok_arn]
   treat_missing_data  = "notBreaching"
   dimensions = {
     DBInstanceIdentifier = aws_rds_cluster_instance.notification-canada-ca-instances[count.index].identifier
@@ -109,6 +110,7 @@ resource "aws_cloudwatch_metric_alarm" "low-db-memory-critical" {
   statistic           = "Average"
   threshold           = 2 * 1024 * 1024 * 1024
   alarm_actions       = [var.sns_alert_critical_arn]
+  ok_actions          = [var.sns_alert_ok_arn]
   treat_missing_data  = "notBreaching"
   dimensions = {
     DBInstanceIdentifier = aws_rds_cluster_instance.notification-canada-ca-instances[count.index].identifier
@@ -145,6 +147,7 @@ resource "aws_cloudwatch_metric_alarm" "db-free-local-storage-critical" {
   statistic           = "Average"
   threshold           = 10 * 1024 * 1024 * 1024
   alarm_actions       = [var.sns_alert_critical_arn]
+  ok_actions          = [var.sns_alert_ok_arn]
   treat_missing_data  = "notBreaching"
   dimensions = {
     DBInstanceIdentifier = aws_rds_cluster_instance.notification-canada-ca-instances[count.index].identifier

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -32,6 +32,10 @@ variable "sns_alert_critical_arn" {
   type = string
 }
 
+variable "sns_alert_ok_arn" {
+  type = string
+}
+
 variable "platform_data_lake_kms_key_arn" {
   type        = string
   description = "Platform Data Lake KMS key ARN used for encrypting RDS snapshot exports"

--- a/env/dev/eks/terragrunt.hcl
+++ b/env/dev/eks/terragrunt.hcl
@@ -46,6 +46,7 @@ dependency "common" {
     sns_alert_warning_arn                     = ""
     sns_alert_critical_arn                    = ""
     sns_alert_general_arn                     = ""
+    sns_alert_ok_arn                          = ""
     firehose_waf_logs_iam_role_arn            = ""
     ip_blocklist_arn                          = ""
     re_admin_arn                              = ""
@@ -104,6 +105,7 @@ inputs = {
   sns_alert_warning_arn                     = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                    = dependency.common.outputs.sns_alert_critical_arn
   sns_alert_general_arn                     = dependency.common.outputs.sns_alert_general_arn
+  sns_alert_ok_arn                          = dependency.common.outputs.sns_alert_ok_arn
   firehose_waf_logs_iam_role_arn            = dependency.common.outputs.firehose_waf_logs_iam_role_arn
   cloudfront_assets_arn                     = dependency.cloudfront.outputs.cloudfront_assets_arn
   ip_blocklist_arn                          = dependency.common.outputs.ip_blocklist_arn

--- a/env/dev/rds/terragrunt.hcl
+++ b/env/dev/rds/terragrunt.hcl
@@ -22,6 +22,7 @@ dependency "common" {
     sns_alert_general_arn = ""
     sns_alert_critical_arn = ""
     sns_alert_warning_arn = ""
+    sns_alert_ok_arn = ""
   }
 }
 
@@ -49,6 +50,7 @@ inputs = {
   sns_alert_general_arn     = dependency.common.outputs.sns_alert_general_arn
   sns_alert_critical_arn    = dependency.common.outputs.sns_alert_critical_arn
   sns_alert_warning_arn     = dependency.common.outputs.sns_alert_warning_arn
+  sns_alert_ok_arn          = dependency.common.outputs.sns_alert_ok_arn
   sentinel_forwarder_cloudwatch_lambda_arn  = dependency.eks.outputs.sentinel_forwarder_cloudwatch_lambda_arn
   sentinel_forwarder_cloudwatch_lambda_name = dependency.eks.outputs.sentinel_forwarder_cloudwatch_lambda_name
 }

--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -46,6 +46,7 @@ dependency "common" {
     sns_alert_warning_arn                     = ""
     sns_alert_critical_arn                    = ""
     sns_alert_general_arn                     = ""
+    sns_alert_ok_arn                          = ""
     firehose_waf_logs_iam_role_arn            = ""
     ip_blocklist_arn                          = ""
     re_admin_arn                              = ""
@@ -104,6 +105,7 @@ inputs = {
   sns_alert_warning_arn                     = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                    = dependency.common.outputs.sns_alert_critical_arn
   sns_alert_general_arn                     = dependency.common.outputs.sns_alert_general_arn
+  sns_alert_ok_arn                          = dependency.common.outputs.sns_alert_ok_arn
   firehose_waf_logs_iam_role_arn            = dependency.common.outputs.firehose_waf_logs_iam_role_arn
   cloudfront_assets_arn                     = dependency.cloudfront.outputs.cloudfront_assets_arn
   ip_blocklist_arn                          = dependency.common.outputs.ip_blocklist_arn

--- a/env/production/rds/terragrunt.hcl
+++ b/env/production/rds/terragrunt.hcl
@@ -22,6 +22,7 @@ dependency "common" {
     sns_alert_general_arn = ""
     sns_alert_critical_arn = ""
     sns_alert_warning_arn = ""
+    sns_alert_ok_arn = ""
   }
 }
 
@@ -49,6 +50,7 @@ inputs = {
   sns_alert_general_arn     = dependency.common.outputs.sns_alert_general_arn
   sns_alert_critical_arn    = dependency.common.outputs.sns_alert_critical_arn
   sns_alert_warning_arn     = dependency.common.outputs.sns_alert_warning_arn
+  sns_alert_ok_arn          = dependency.common.outputs.sns_alert_ok_arn
   sentinel_forwarder_cloudwatch_lambda_arn  = dependency.eks.outputs.sentinel_forwarder_cloudwatch_lambda_arn
   sentinel_forwarder_cloudwatch_lambda_name = dependency.eks.outputs.sentinel_forwarder_cloudwatch_lambda_name
 }

--- a/env/sandbox/eks/terragrunt.hcl
+++ b/env/sandbox/eks/terragrunt.hcl
@@ -46,6 +46,7 @@ dependency "common" {
     sns_alert_warning_arn                     = ""
     sns_alert_critical_arn                    = ""
     sns_alert_general_arn                     = ""
+    sns_alert_ok_arn                          = ""
     firehose_waf_logs_iam_role_arn            = ""
     ip_blocklist_arn                          = ""
     re_admin_arn                              = ""
@@ -104,6 +105,7 @@ inputs = {
   sns_alert_warning_arn                     = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                    = dependency.common.outputs.sns_alert_critical_arn
   sns_alert_general_arn                     = dependency.common.outputs.sns_alert_general_arn
+  sns_alert_ok_arn                          = dependency.common.outputs.sns_alert_ok_arn
   firehose_waf_logs_iam_role_arn            = dependency.common.outputs.firehose_waf_logs_iam_role_arn
   cloudfront_assets_arn                     = dependency.cloudfront.outputs.cloudfront_assets_arn
   ip_blocklist_arn                          = dependency.common.outputs.ip_blocklist_arn

--- a/env/sandbox/rds/terragrunt.hcl
+++ b/env/sandbox/rds/terragrunt.hcl
@@ -22,6 +22,7 @@ dependency "common" {
     sns_alert_general_arn = ""
     sns_alert_critical_arn = ""
     sns_alert_warning_arn = ""
+    sns_alert_ok_arn = ""
   }
 }
 
@@ -49,6 +50,7 @@ inputs = {
   sns_alert_general_arn     = dependency.common.outputs.sns_alert_general_arn
   sns_alert_critical_arn    = dependency.common.outputs.sns_alert_critical_arn
   sns_alert_warning_arn     = dependency.common.outputs.sns_alert_warning_arn
+  sns_alert_ok_arn          = dependency.common.outputs.sns_alert_ok_arn
   sentinel_forwarder_cloudwatch_lambda_arn  = dependency.eks.outputs.sentinel_forwarder_cloudwatch_lambda_arn
   sentinel_forwarder_cloudwatch_lambda_name = dependency.eks.outputs.sentinel_forwarder_cloudwatch_lambda_name
 }

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -46,6 +46,7 @@ dependency "common" {
     sns_alert_warning_arn                     = ""
     sns_alert_critical_arn                    = ""
     sns_alert_general_arn                     = ""
+    sns_alert_ok_arn                          = ""
     firehose_waf_logs_iam_role_arn            = ""
     ip_blocklist_arn                          = ""
     re_admin_arn                              = ""
@@ -104,6 +105,7 @@ inputs = {
   sns_alert_warning_arn                     = dependency.common.outputs.sns_alert_warning_arn
   sns_alert_critical_arn                    = dependency.common.outputs.sns_alert_critical_arn
   sns_alert_general_arn                     = dependency.common.outputs.sns_alert_general_arn
+  sns_alert_ok_arn                          = dependency.common.outputs.sns_alert_ok_arn
   firehose_waf_logs_iam_role_arn            = dependency.common.outputs.firehose_waf_logs_iam_role_arn
   cloudfront_assets_arn                     = dependency.cloudfront.outputs.cloudfront_assets_arn
   ip_blocklist_arn                          = dependency.common.outputs.ip_blocklist_arn

--- a/env/staging/rds/terragrunt.hcl
+++ b/env/staging/rds/terragrunt.hcl
@@ -22,6 +22,7 @@ dependency "common" {
     sns_alert_general_arn = ""
     sns_alert_critical_arn = ""
     sns_alert_warning_arn = ""
+    sns_alert_ok_arn = ""
   }
 }
 
@@ -49,6 +50,7 @@ inputs = {
   sns_alert_general_arn     = dependency.common.outputs.sns_alert_general_arn
   sns_alert_critical_arn    = dependency.common.outputs.sns_alert_critical_arn
   sns_alert_warning_arn     = dependency.common.outputs.sns_alert_warning_arn
+  sns_alert_ok_arn          = dependency.common.outputs.sns_alert_ok_arn
   sentinel_forwarder_cloudwatch_lambda_arn  = dependency.eks.outputs.sentinel_forwarder_cloudwatch_lambda_arn
   sentinel_forwarder_cloudwatch_lambda_name = dependency.eks.outputs.sentinel_forwarder_cloudwatch_lambda_name
 }


### PR DESCRIPTION
# Summary | Résumé
This pull request adds support for sending "OK" notifications via SNS when AWS CloudWatch alarms return to a normal state, in addition to the existing critical alerts. To achieve this, a new variable for the SNS OK alert ARN is introduced and propagated through Terraform and Terragrunt configurations for both EKS and RDS environments across all deployment stages (dev, sandbox, staging, production).

Key changes include:

**CloudWatch Alarm Enhancements:**
- Added the `ok_actions` property to multiple CloudWatch alarm resources in both `aws/eks/cloudwatch_alarms.tf` and `aws/rds/cloudwatch_alarms.tf` to send notifications when alarms return to OK state, using the new `sns_alert_ok_arn` variable. [[1]](diffhunk://#diff-729fe753d032127c6ae901aeeabdd46b304e2d96fc31996757771b3430647e1dR1294) [[2]](diffhunk://#diff-a9e7b3bf744d372b41a180ec3f349531d0479096ac4f7d6e90c562c63a3139f1R37) [[3]](diffhunk://#diff-a9e7b3bf744d372b41a180ec3f349531d0479096ac4f7d6e90c562c63a3139f1R113) [[4]](diffhunk://#diff-a9e7b3bf744d372b41a180ec3f349531d0479096ac4f7d6e90c562c63a3139f1R150)

**Terraform Variable Updates:**
- Introduced a new `sns_alert_ok_arn` variable in both `aws/eks/variables.tf` and `aws/rds/variables.tf` to allow configuration of the SNS topic for OK notifications. [[1]](diffhunk://#diff-f34bd6dbc63f5715fff9cd3aae7bc3b61b47c068bd98eca7178f81f5f7a63215R25-R28) [[2]](diffhunk://#diff-17ed5fab5d1a37d1ab36cf331502f5b660255596f9c67bc5b7c71bb4ed80afeaR35-R38)

**Terragrunt Configuration Propagation:**
- Updated all environment-specific Terragrunt configuration files (`env/*/eks/terragrunt.hcl` and `env/*/rds/terragrunt.hcl`) to include the new `sns_alert_ok_arn` variable in both the `dependency "common"` blocks and the `inputs` sections, ensuring the value is passed through to Terraform modules in every environment. [[1]](diffhunk://#diff-0d6c2e054c9788da67332aae6db0f0f1f57cfb3e2a9fc19d2d47d9e17c18c04dR49) [[2]](diffhunk://#diff-0d6c2e054c9788da67332aae6db0f0f1f57cfb3e2a9fc19d2d47d9e17c18c04dR108) [[3]](diffhunk://#diff-0c95a1feaa462baaeda36964dd27b85cad83cab4170ea306cc0d57858d6fb3ceR25) [[4]](diffhunk://#diff-0c95a1feaa462baaeda36964dd27b85cad83cab4170ea306cc0d57858d6fb3ceR53)

These changes ensure that teams are notified not only when alarms are triggered, but also when systems recover, improving operational visibility and alerting completeness.

## Related Issues | Cartes liées
https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/838

## Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

## Release Instructions | Instructions pour le déploiement

None.
## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
