### PR TITLE
adjust the expired in flights alarms to be more meaningful

### DIFF
--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -858,7 +858,7 @@ resource "aws_cloudwatch_metric_alarm" "bulk-bulk-not-being-processed-critical" 
 
 resource "aws_cloudwatch_metric_alarm" "expired-inflight-poisoned-message-warning" {
   count               = var.cloudwatch_enabled ? 1 : 0
-  alarm_name          = "expired-inflight-any"
+  alarm_name          = "expired-inflight-poisoned-message-warning"
   alarm_description   = "Possible poisoned message - inflights are expiring. Investigate if this is repeated. Check the Redis-batch-saving dashboard"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -856,6 +856,29 @@ resource "aws_cloudwatch_metric_alarm" "bulk-bulk-not-being-processed-critical" 
   }
 }
 
+resource "aws_cloudwatch_metric_alarm" "expired-inflight-poisoned-message-warning" {
+  count               = var.cloudwatch_enabled ? 1 : 0
+  alarm_name          = "expired-inflight-any"
+  alarm_description   = "Possible poisoned message - inflights are expiring. Investigate if this is repeated. Check the Redis-batch-saving dashboard"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
+
+  metric_name = "batch_saving_inflight"
+  namespace   = "NotificationCanadaCa"
+  period      = "60"
+  statistic   = "Sum"
+  unit        = "Count"
+  dimensions = {
+    expired           = "True"
+    notification_type = "any"
+    priority          = "any"
+  }
+}
+
 resource "aws_cloudwatch_metric_alarm" "expired-inflight-warning" {
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "expired-inflight-warning"
@@ -968,3 +991,4 @@ resource "aws_cloudwatch_metric_alarm" "expired-inflight-critical" {
     return_data = "true"
   }
 }
+

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -869,7 +869,7 @@ resource "aws_cloudwatch_metric_alarm" "expired-inflight-poisoned-message-warnin
 
   metric_name = "batch_saving_inflight"
   namespace   = "NotificationCanadaCa"
-  period      = "60"
+  period      = "300"
   statistic   = "Sum"
   unit        = "Count"
   dimensions = {

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -859,7 +859,7 @@ resource "aws_cloudwatch_metric_alarm" "bulk-bulk-not-being-processed-critical" 
 resource "aws_cloudwatch_metric_alarm" "expired-inflight-warning" {
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "expired-inflight-warning"
-  alarm_description   = "An inflight has expired. Check the Redis-batch-saving dashboard"
+  alarm_description   = "Inflights are expiring faster than they are being acknowledged in 5 minutes - queue is deteriorating. Check the Redis-batch-saving dashboard"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   threshold           = 1
@@ -867,42 +867,12 @@ resource "aws_cloudwatch_metric_alarm" "expired-inflight-warning" {
 
   alarm_actions = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
 
+  # Warn when the queue is losing ground: more inflights are expiring than celery
+  # is acknowledging. This is distinct from the critical alarm (zero throughput) and
+  # from normal high-load bursts where celery processes far more than it drops.
   metric_query {
-    id          = "expired_inflights_1_minute"
-    label       = "Expired inflights in one minute"
-    return_data = "true"
-
-    metric {
-      metric_name = "batch_saving_inflight"
-      namespace   = "NotificationCanadaCa"
-      period      = "60"
-      stat        = "Sum"
-      unit        = "Count"
-      dimensions = {
-        expired           = "True"
-        notification_type = "any"
-        priority          = "any"
-      }
-    }
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "expired-inflight-critical" {
-  count               = var.cloudwatch_enabled ? 1 : 0
-  alarm_name          = "expired-inflight-critical"
-  alarm_description   = "More than ${var.alarm_critical_expired_inflights_threshold} inflights expired in 5 minutes, check the Redis-batch-saving dashboard"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
-  threshold           = var.alarm_critical_expired_inflights_threshold
-  treat_missing_data  = "notBreaching"
-
-  alarm_actions = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
-  ok_actions    = [aws_sns_topic.notification-canada-ca-alert-ok.arn]
-
-  metric_query {
-    id          = "expired_inflights_5_minutes"
-    label       = "Expired inflights in 5 minutes"
-    return_data = "true"
+    id    = "expired_inflights"
+    label = "Expired inflights in 5 minutes"
 
     metric {
       metric_name = "batch_saving_inflight"
@@ -916,5 +886,85 @@ resource "aws_cloudwatch_metric_alarm" "expired-inflight-critical" {
         priority          = "any"
       }
     }
+  }
+
+  metric_query {
+    id    = "inflight_processed"
+    label = "Inflights acknowledged in 5 minutes"
+
+    metric {
+      metric_name = "batch_saving_inflight"
+      namespace   = "NotificationCanadaCa"
+      period      = "300"
+      stat        = "Sum"
+      unit        = "Count"
+      dimensions = {
+        acknowledged = "True"
+      }
+    }
+  }
+
+  metric_query {
+    id          = "alarm_condition"
+    expression  = "IF(expired_inflights >= 1, 1, 0) * IF(FILL(inflight_processed, 0) < expired_inflights, 1, 0)"
+    label       = "Expiries outnumber acknowledgments"
+    return_data = "true"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "expired-inflight-critical" {
+  count               = var.cloudwatch_enabled ? 1 : 0
+  alarm_name          = "expired-inflight-critical"
+  alarm_description   = "More than ${var.alarm_critical_expired_inflights_threshold} inflights expired in 5 minutes AND celery acknowledgment throughput is zero - system is stuck, check the Redis-batch-saving dashboard"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
+  ok_actions    = [aws_sns_topic.notification-canada-ca-alert-ok.arn]
+
+  # Only alarm when inflights are expiring AND nothing is being acknowledged.
+  # This avoids false positives during high-load bursts (many bulk requests) where
+  # celery is actively processing but cannot keep up with the inflow rate.
+  metric_query {
+    id    = "expired_inflights"
+    label = "Expired inflights in 5 minutes"
+
+    metric {
+      metric_name = "batch_saving_inflight"
+      namespace   = "NotificationCanadaCa"
+      period      = "300"
+      stat        = "Sum"
+      unit        = "Count"
+      dimensions = {
+        expired           = "True"
+        notification_type = "any"
+        priority          = "any"
+      }
+    }
+  }
+
+  metric_query {
+    id    = "inflight_processed"
+    label = "Inflights acknowledged in 5 minutes"
+
+    metric {
+      metric_name = "batch_saving_inflight"
+      namespace   = "NotificationCanadaCa"
+      period      = "300"
+      stat        = "Sum"
+      unit        = "Count"
+      dimensions = {
+        acknowledged = "True"
+      }
+    }
+  }
+
+  metric_query {
+    id          = "alarm_condition"
+    expression  = "IF(expired_inflights >= ${var.alarm_critical_expired_inflights_threshold}, 1, 0) * IF(FILL(inflight_processed, 0) < 1, 1, 0)"
+    label       = "Expiries over threshold with zero throughput"
+    return_data = "true"
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Improved expired-inflight alarms to reduce false positives during high-load bursts

The previous alarms fired whenever inflights expired, which also triggered during normal high-load scenarios (e.g. many bulk requests in a short window) where celery was actively processing but couldn't keep up with inflow. These pages were not actionable.

Both alarms were reworked to distinguish between "busy but healthy" and "actually broken":

Warning (expired-inflight-warning): Now fires when expiries are outpacing acknowledgments over a 5-minute window (i.e. the queue is losing ground). Previously fired on any single expiry in 1 minute, which was too sensitive.

Critical (expired-inflight-critical): Now fires only when expiries exceed the threshold and celery acknowledgment throughput has dropped to zero — meaning the system is truly stalled. Previously fired on expiry count alone, which was indistinguishable from a burst load event.

This creates a meaningful escalation path: warning = degrading, critical = stuck.

Also duplicating the old warning alarm's functionality to warn us (but not page us) on possible poisoned messages.

## Related Issues | Cartes liées

Ad-hoc

## Test instructions | Instructions pour tester la modification

TF Apply Works (tested in dev)
Run a load test, see if warning triggers
Run a load test, break celery, see if critical triggers

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
