### PR TITLE
Update sms-usage-notifications schedule

### DIFF
--- a/aws/quicksight/dataset_refresh_order.txt
+++ b/aws/quicksight/dataset_refresh_order.txt
@@ -18,4 +18,4 @@ All times are UTC.
 
 0920 - notifications_athena (takes about 3 hours. Rest of tables are under 5 minutes to refresh)
 
-1230 - sms_usage_notifications
+1330 - sms_usage_notifications

--- a/aws/quicksight/dataset_sms_usage_notifications.tf
+++ b/aws/quicksight/dataset_sms_usage_notifications.tf
@@ -99,7 +99,7 @@ resource "aws_quicksight_refresh_schedule" "sms_usage_notifications_schedule" {
 
     schedule_frequency {
       interval        = "DAILY"
-      time_of_the_day = "12:30"
+      time_of_the_day = "13:30"
     }
   }
 


### PR DESCRIPTION
# Summary | Résumé

Push out the sms-usage-notifications refresh schedule by an hour. The refresh is currently occasionally failing waiting for the notifications dataset to refresh.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/835

## Test instructions | Instructions pour tester la modification

tf apply runs

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
