### PR TITLE
remake refresh schedule in new resource

### DIFF
--- a/aws/quicksight/dataset_sms_usage_notifications.tf
+++ b/aws/quicksight/dataset_sms_usage_notifications.tf
@@ -89,9 +89,9 @@ resource "aws_cloudformation_stack" "sms-usage-notifications" {
 }
 
 
-resource "aws_quicksight_refresh_schedule" "sms_usage_notifications_schedule" {
+resource "aws_quicksight_refresh_schedule" "sms_usage_notifications" {
   data_set_id = "sms-usage-notifications"
-  schedule_id = "schedule-sms-usage-notifications-v2"
+  schedule_id = "schedule-sms-usage-notifications"
   depends_on  = [aws_cloudformation_stack.sms-usage-notifications]
 
   schedule {


### PR DESCRIPTION
# Summary | Résumé

Need to recreate the daily refresh schedule for sms-usage-notifications in a new resource to avoid the scheduled in the past error.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/835

## Test instructions | Instructions pour tester la modification

tf apply runs

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
