### PR TITLE
Update waf.tf to include v3 endpoints

### DIFF
--- a/aws/common/waf.tf
+++ b/aws/common/waf.tf
@@ -22,7 +22,7 @@ resource "aws_wafv2_regex_pattern_set" "re_api" {
   }
 
   regular_expression {
-    regex_string = "/notifications.*|/organisation.*|/organisations.*|/platform-stats.*|/provider-details.*|/service.*|/static.*|/user.*|/v2.*|/cache-clear|/support/find-ids|/newsletter.*"
+    regex_string = "/notifications.*|/organisation.*|/organisations.*|/platform-stats.*|/provider-details.*|/service.*|/static.*|/user.*|/v2.*|/cache-clear|/support/find-ids|/newsletter.*/v3.*"
   }
 
   tags = {

--- a/aws/common/waf.tf
+++ b/aws/common/waf.tf
@@ -22,7 +22,7 @@ resource "aws_wafv2_regex_pattern_set" "re_api" {
   }
 
   regular_expression {
-    regex_string = "/notifications.*|/organisation.*|/organisations.*|/platform-stats.*|/provider-details.*|/service.*|/static.*|/user.*|/v2.*|/cache-clear|/support/find-ids|/newsletter.*/v3.*"
+    regex_string = "/notifications.*|/organisation.*|/organisations.*|/platform-stats.*|/provider-details.*|/service.*|/static.*|/user.*|/v2.*|/cache-clear|/support/find-ids|/newsletter.*|/v3.*"
   }
 
   tags = {


### PR DESCRIPTION
# Summary | Résumé

We are adding v3 endpoints to waf as the new template endpoints will be behind the v3 flag (they new enpoints require a manage_template permission for the API key)
