### PR TITLE
updating helm s3 reference (master is broken)

### DIFF
--- a/.github/actions/setup-helmfile-wrapper/action.yml
+++ b/.github/actions/setup-helmfile-wrapper/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: helm-diff plugin version
     required: false
     default: "v3.9.8"
+  helm-s3-plugin-version:
+    description: helm-s3 plugin version
+    required: false
+    default: "v0.17.2"
   kubectl-version:
     description: AWS EKS kubectl version (must align with cluster minor)
     required: false
@@ -42,5 +46,6 @@ runs:
         helmfile-version: ${{ inputs.helmfile-version }}
         helm-version: ${{ inputs.helm-version }}
         helm-diff-plugin-version: ${{ inputs.helm-diff-plugin-version }}
+        helm-s3-plugin-version: ${{ inputs.helm-s3-plugin-version }}
         kubectl-version: ${{ inputs.kubectl-version }}
         kubectl-release-date: ${{ inputs.kubectl-release-date }}


### PR DESCRIPTION
# Summary | Résumé

This pull request updates the `.github/actions/setup-helmfile-wrapper/action.yml` file to add support for specifying the version of the `helm-s3` plugin as an input parameter. This allows users of the action to configure which version of the `helm-s3` plugin is installed.

Enhancements to Helm plugin configuration:

* Added a new input `helm-s3-plugin-version` with a default value of `v0.17.2` to allow specifying the desired version of the `helm-s3` plugin.
* Updated the action's runtime environment to pass the new `helm-s3-plugin-version` input to the underlying scripts.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1
* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/1

## Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
