### PR TITLE
Tune OOM limits, fix staging node count, and utility script

### DIFF
--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -226,7 +226,7 @@ resource "aws_launch_template" "notification-canada-ca-eks-node-group" {
   # Review pod resource requests if scheduling issues arise after rollout.
   #
   # Note: evictionMaxPodGracePeriod caps per-pod terminationGracePeriodSeconds
-  # at 60s during eviction — adjust if workloads require longer shutdown windows.
+  # at 180s during eviction — adjust if workloads require longer shutdown windows.
   user_data = base64encode(<<-USERDATA
     ---
     apiVersion: node.eks.aws/v1alpha1

--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -217,6 +217,43 @@ resource "aws_launch_template" "notification-canada-ca-eks-node-group" {
     http_tokens                 = "required"
   }
 
+  # Aggressive memory eviction configuration (AL2023 nodeadm format).
+  # Defaults: evictionHard.memory.available=100Mi, no soft eviction.
+  # Raises thresholds so kubelet reclaims memory earlier, before the kernel
+  # OOM killer freezes the node.
+  #
+  # Note: systemReserved.memory reduces node allocatable memory by 512Mi.
+  # Review pod resource requests if scheduling issues arise after rollout.
+  #
+  # Note: evictionMaxPodGracePeriod caps per-pod terminationGracePeriodSeconds
+  # at 60s during eviction — adjust if workloads require longer shutdown windows.
+  user_data = base64encode(<<-USERDATA
+    ---
+    apiVersion: node.eks.aws/v1alpha1
+    kind: NodeConfig
+    spec:
+      kubelet:
+        config:
+          evictionHard:
+            memory.available: "500Mi"
+            nodefs.available: "10%"
+            imagefs.available: "15%"
+          evictionSoft:
+            memory.available: "1Gi"
+            nodefs.available: "15%"
+            imagefs.available: "20%"
+          evictionSoftGracePeriod:
+            memory.available: "1m30s"
+            nodefs.available: "1m30s"
+            imagefs.available: "1m30s"
+          evictionMinimumReclaim:
+            memory.available: "128Mi"
+          evictionMaxPodGracePeriod: 180
+          systemReserved:
+            memory: "512Mi"
+  USERDATA
+  )
+
   tags = {
     Name       = "notification-canada-ca"
     CostCenter = "notification-canada-ca-${var.env}"

--- a/env/staging_config.tfvars
+++ b/env/staging_config.tfvars
@@ -8,13 +8,13 @@ billing_tag_key      = "CostCenter"
 
 
 ## EKS     
-primary_worker_desired_size     = 6
+primary_worker_desired_size     = 9
 primary_worker_instance_types   = ["c7i.xlarge"]
 secondary_worker_instance_types = ["c7i.xlarge"]
 enable_signoz                   = true
 node_upgrade                    = false
 force_upgrade                   = true
-primary_worker_max_size         = 7
+primary_worker_max_size         = 9
 primary_worker_min_size         = 4
 eks_cluster_name                = "notification-canada-ca-staging-eks-cluster"
 eks_cluster_version             = "1.35"

--- a/scripts/find_unregistered_ec2s.sh
+++ b/scripts/find_unregistered_ec2s.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# find_unregistered_ec2s.sh
+#
+# Compares running EC2 instances in the AWS account against nodes registered
+# to an EKS cluster and prints any EC2s that are NOT registered as EKS nodes.
+#
+# Usage:
+#   ./find_unregistered_ec2s.sh <eks-cluster-name> [aws-region]
+#
+# Prerequisites: kubectl (with kubeconfig pointing at the cluster), aws CLI, jq
+
+set -euo pipefail
+
+CLUSTER_NAME="${1:-}"
+AWS_REGION="${2:-${AWS_DEFAULT_REGION:-us-east-1}}"
+
+if [[ -z "$CLUSTER_NAME" ]]; then
+  echo "Usage: $0 <eks-cluster-name> [aws-region]" >&2
+  exit 1
+fi
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+echo "Cluster : $CLUSTER_NAME"
+echo "Region  : $AWS_REGION"
+echo ""
+
+# ── 1. Update kubeconfig for the cluster ─────────────────────────────────────
+echo "Updating kubeconfig..."
+aws eks update-kubeconfig \
+  --name "$CLUSTER_NAME" \
+  --region "$AWS_REGION" \
+  --no-cli-pager \
+  2>/dev/null
+
+# ── 2. Get EC2 instance IDs registered as EKS nodes ─────────────────────────
+echo "Fetching EKS node list..."
+EKS_INSTANCE_IDS=$(kubectl get nodes \
+  -o jsonpath='{.items[*].spec.providerID}' \
+  | tr ' ' '\n' \
+  | sed 's|.*/||')   # strip "aws:///region/az/" prefix, leaving just the instance ID
+
+EKS_COUNT=$(echo "$EKS_INSTANCE_IDS" | grep -c 'i-' || true)
+echo -e "${GREEN}EKS registered nodes: $EKS_COUNT${NC}"
+
+# ── 3. Get all running EC2 instances in the account ──────────────────────────
+echo "Fetching running EC2 instances..."
+EC2_JSON=$(aws ec2 describe-instances \
+  --region "$AWS_REGION" \
+  --filters "Name=instance-state-name,Values=running" \
+  --query 'Reservations[*].Instances[*].{id:InstanceId,name:Tags[?Key==`Name`]|[0].Value,type:InstanceType,launched:LaunchTime,az:Placement.AvailabilityZone}' \
+  --output json \
+  --no-cli-pager)
+
+EC2_COUNT=$(echo "$EC2_JSON" | jq '[.[][] ] | length')
+echo -e "${GREEN}Running EC2 instances : $EC2_COUNT${NC}"
+echo ""
+
+# ── 4. Find EC2s not in EKS ──────────────────────────────────────────────────
+echo "EC2 instances NOT registered to EKS cluster '$CLUSTER_NAME':"
+echo "─────────────────────────────────────────────────────────────────────────"
+printf "%-22s %-40s %-14s %-25s %s\n" "INSTANCE ID" "NAME" "TYPE" "LAUNCHED" "AZ"
+echo "─────────────────────────────────────────────────────────────────────────"
+
+UNREGISTERED=0
+
+while IFS= read -r instance; do
+  id=$(echo "$instance"    | jq -r '.id')
+  name=$(echo "$instance"  | jq -r '.name // "(no name)"')
+  type=$(echo "$instance"  | jq -r '.type')
+  launched=$(echo "$instance" | jq -r '.launched')
+  az=$(echo "$instance"    | jq -r '.az')
+
+  if ! echo "$EKS_INSTANCE_IDS" | grep -qx "$id"; then
+    printf "%-22s %-40s %-14s %-25s %s\n" "$id" "$name" "$type" "$launched" "$az"
+    UNREGISTERED=$((UNREGISTERED + 1))
+  fi
+done < <(echo "$EC2_JSON" | jq -c '.[][]')
+
+echo "─────────────────────────────────────────────────────────────────────────"
+
+if [[ $UNREGISTERED -eq 0 ]]; then
+  echo -e "${GREEN}All running EC2s are registered as EKS nodes.${NC}"
+else
+  echo -e "${YELLOW}Total unregistered EC2s: $UNREGISTERED${NC}"
+fi

--- a/scripts/find_unregistered_ec2s.sh
+++ b/scripts/find_unregistered_ec2s.sh
@@ -35,7 +35,7 @@ aws eks update-kubeconfig \
   --name "$CLUSTER_NAME" \
   --region "$AWS_REGION" \
   --no-cli-pager \
-  2>/dev/null
+  >/dev/null
 
 # ── 2. Get EC2 instance IDs registered as EKS nodes ─────────────────────────
 echo "Fetching EKS node list..."

--- a/scripts/find_unregistered_ec2s.sh
+++ b/scripts/find_unregistered_ec2s.sh
@@ -12,8 +12,7 @@
 set -euo pipefail
 
 CLUSTER_NAME="${1:-}"
-AWS_REGION="${2:-${AWS_DEFAULT_REGION:-us-east-1}}"
-
+AWS_REGION="${2:-${AWS_DEFAULT_REGION:-ca-central-1}}"
 if [[ -z "$CLUSTER_NAME" ]]; then
   echo "Usage: $0 <eks-cluster-name> [aws-region]" >&2
   exit 1


### PR DESCRIPTION
# Summary | Résumé

We're seeing some issues with OOM on nodes in staging. Firstly staging is running 3 fewer dedicated nodes than production, so we should fix that. 

Secondly, I've added a section to the on demand node class that tunes the OOM evictions to be more aggressive - this way we prevent a scenario where we suck up too much ram too fast before the scheduler evicts the other pods. This will hopefully prevent nodes from becoming unresponsive. 

Finally, I had Claude write a shell script that compares the nodes that are registered in EKS against the straight up EC2 nodes we have in AWS. This will list any nodes that are running but not properly registered to EKS (we had this issue in staging which meant we were running 5 nodes instead of 6, which was already super low).

## Related Issues | Cartes liées

- OOM issues in staging

## Test instructions | Instructions pour tester la modification

TF Apply works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
