### PR TITLE
redline performance test ECS task

### DIFF
--- a/aws/performance-test/container_definitions/perf_test_failure_scenarios.json.tmpl
+++ b/aws/performance-test/container_definitions/perf_test_failure_scenarios.json.tmpl
@@ -1,0 +1,69 @@
+[
+  {
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${AWS_LOGS_GROUP}",
+        "awslogs-region": "${AWS_LOGS_REGION}",
+        "awslogs-stream-prefix": "${AWS_LOGS_STREAM_PREFIX}"
+      }
+    },
+    "ulimits": [
+      {
+        "name": "nofile",
+        "softLimit": 98304,
+        "hardLimit": 98304
+      }
+    ],
+    "volumesFrom": [],
+    "essential": true,
+    "name": "performance-tests-container",
+    "image": "${ECR_REPOSITORY_URL}",
+    "cpu": 0,
+    "entryPoint": ["tests_nightly_performance/run_failure_scenarios.sh"],
+    "environment": [
+      {
+        "name": "PERF_TEST_AWS_S3_BUCKET",
+        "value": "${PERF_TEST_AWS_S3_BUCKET}"
+      },
+      {
+        "name": "PERF_TEST_CSV_DIRECTORY_PATH",
+        "value": "${PERF_TEST_CSV_DIRECTORY_PATH}"
+      },
+      {
+        "name": "PERF_TEST_SMS_TEMPLATE_ID_ONE_VAR",
+        "value": "${PERF_TEST_SMS_TEMPLATE_ID_ONE_VAR}"
+      },
+      {
+        "name": "PERF_TEST_EMAIL_TEMPLATE_ID_ONE_VAR",
+        "value": "${PERF_TEST_EMAIL_TEMPLATE_ID_ONE_VAR}"
+      }
+    ],
+    "secrets": [
+      {
+        "name": "PERF_TEST_PHONE_NUMBER",
+        "valueFrom": "${PERF_TEST_PHONE_NUMBER_ARN}"
+      },
+      {
+        "name": "PERF_TEST_EMAIL_ADDRESS",
+        "valueFrom": "${PERF_TEST_EMAIL_ARN}"
+      },
+      {
+        "name": "PERF_TEST_DOMAIN",
+        "valueFrom": "${PERF_TEST_DOMAIN_ARN}"
+      },
+      {
+        "name": "PERF_TEST_API_KEY",
+        "valueFrom": "${PERF_TEST_API_KEY_ARN}"
+      },
+      {
+        "name": "PERF_TEST_SLACK_WEBHOOK",
+        "valueFrom": "${PERF_TEST_SLACK_WEBHOOK_ARN}"
+      },
+      {
+        "name": "DATABASE_READER_URI",
+        "valueFrom": "${DATABASE_READER_URI_ARN}"
+      }
+    ]
+  }
+]

--- a/aws/performance-test/ecs.tf
+++ b/aws/performance-test/ecs.tf
@@ -72,8 +72,8 @@ resource "aws_ecs_task_definition" "perf_test_task" {
 }
 
 data "template_file" "perf_test_failure_scenarios_container_definition" {
+  count    = var.env == "production" ? 0 : 1
   template = file("container_definitions/perf_test_failure_scenarios.json.tmpl")
-
   vars = {
     AWS_LOGS_GROUP         = var.cloudwatch_enabled ? aws_cloudwatch_log_group.perf_test_ecs_logs[0].name : "none"
     AWS_LOGS_REGION        = var.region

--- a/aws/performance-test/ecs.tf
+++ b/aws/performance-test/ecs.tf
@@ -70,3 +70,41 @@ resource "aws_ecs_task_definition" "perf_test_task" {
     (var.billing_tag_key) = var.billing_tag_value
   }
 }
+
+data "template_file" "perf_test_failure_scenarios_container_definition" {
+  template = file("container_definitions/perf_test_failure_scenarios.json.tmpl")
+
+  vars = {
+    AWS_LOGS_GROUP         = var.cloudwatch_enabled ? aws_cloudwatch_log_group.perf_test_ecs_logs[0].name : "none"
+    AWS_LOGS_REGION        = var.region
+    AWS_LOGS_STREAM_PREFIX = "${aws_ecs_cluster.perf_test.name}-task"
+    ECR_REPOSITORY_URL     = var.performance_test_ecr_repository_url
+
+    PERF_TEST_AWS_S3_BUCKET             = var.perf_test_aws_s3_bucket
+    PERF_TEST_CSV_DIRECTORY_PATH        = var.perf_test_csv_directory_path
+    PERF_TEST_EMAIL_TEMPLATE_ID_ONE_VAR = var.perf_test_email_template_id_one_var
+    PERF_TEST_SMS_TEMPLATE_ID_ONE_VAR   = var.perf_test_sms_template_id_one_var
+
+    PERF_TEST_PHONE_NUMBER_ARN  = var.env == "production" ? "" : aws_secretsmanager_secret_version.perf_test_phone_number[0].arn
+    PERF_TEST_EMAIL_ARN         = var.env == "production" ? "" : aws_secretsmanager_secret_version.perf_test_email[0].arn
+    PERF_TEST_DOMAIN_ARN        = var.env == "production" ? "" : aws_secretsmanager_secret_version.perf_test_domain[0].arn
+    PERF_TEST_API_KEY_ARN       = var.env == "production" ? "" : aws_secretsmanager_secret_version.perf_test_api_key[0].arn
+    PERF_TEST_SLACK_WEBHOOK_ARN = var.env == "production" ? "" : aws_secretsmanager_secret_version.perf_test_slack_webhook[0].arn
+    DATABASE_READER_URI_ARN     = var.env == "production" ? "" : aws_secretsmanager_secret_version.perf_test_database_uri[0].arn
+  }
+}
+
+resource "aws_ecs_task_definition" "perf_test_failure_scenarios_task" {
+  family                   = "performance_test_cluster_failure_scenarios"
+  cpu                      = 2048
+  memory                   = 4096
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  execution_role_arn       = aws_iam_role.container_execution_role.arn
+  task_role_arn            = aws_iam_role.perf_test_ecs_task.arn
+  container_definitions    = data.template_file.perf_test_failure_scenarios_container_definition.rendered
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+  }
+}

--- a/aws/performance-test/ecs.tf
+++ b/aws/performance-test/ecs.tf
@@ -77,7 +77,7 @@ data "template_file" "perf_test_failure_scenarios_container_definition" {
   vars = {
     AWS_LOGS_GROUP         = var.cloudwatch_enabled ? aws_cloudwatch_log_group.perf_test_ecs_logs[0].name : "none"
     AWS_LOGS_REGION        = var.region
-    AWS_LOGS_STREAM_PREFIX = "${aws_ecs_cluster.perf_test.name}-task"
+    AWS_LOGS_STREAM_PREFIX = "${aws_ecs_cluster.perf_test.name}-failure-scenarios-task"
     ECR_REPOSITORY_URL     = var.performance_test_ecr_repository_url
 
     PERF_TEST_AWS_S3_BUCKET             = var.perf_test_aws_s3_bucket

--- a/aws/performance-test/ecs.tf
+++ b/aws/performance-test/ecs.tf
@@ -95,6 +95,7 @@ data "template_file" "perf_test_failure_scenarios_container_definition" {
 }
 
 resource "aws_ecs_task_definition" "perf_test_failure_scenarios_task" {
+  count                    = var.env == "production" ? 0 : 1
   family                   = "performance_test_cluster_failure_scenarios"
   cpu                      = 2048
   memory                   = 4096
@@ -102,7 +103,7 @@ resource "aws_ecs_task_definition" "perf_test_failure_scenarios_task" {
   requires_compatibilities = ["FARGATE"]
   execution_role_arn       = aws_iam_role.container_execution_role.arn
   task_role_arn            = aws_iam_role.perf_test_ecs_task.arn
-  container_definitions    = data.template_file.perf_test_failure_scenarios_container_definition.rendered
+  container_definitions    = data.template_file.perf_test_failure_scenarios_container_definition[0].rendered
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value


### PR DESCRIPTION
# Summary | Résumé

ECS task for redline performance test

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/761

## Test instructions | Instructions pour tester la modification

TF Apply works
Try invoking this on api

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
