### PR TITLE
fix existing directory and db versions for blazer

### DIFF
--- a/aws/database-tools/images.tf
+++ b/aws/database-tools/images.tf
@@ -6,7 +6,7 @@ resource "null_resource" "lambda_repo_clone" {
   }
 
   provisioner "local-exec" {
-    command = "git clone 'https://github.com/cds-snc/notification-lambdas.git' /var/tmp/notification-lambdas"
+    command = "rm -rf /var/tmp/notification-lambdas && git clone 'https://github.com/cds-snc/notification-lambdas.git' /var/tmp/notification-lambdas"
   }
 }
 

--- a/env/dev_config.tfvars
+++ b/env/dev_config.tfvars
@@ -178,7 +178,7 @@ pinpoint_to_sqs_sms_callbacks_docker_tag = "bootstrap"
 
 ## BLAZER
 blazer_image_tag   = "latest"
-blazer_rds_version = "15.10"
+blazer_rds_version = "15.18"
 
 ## DATA LAKE
 datalake_bucket_name = "cds-data-lake-raw-production"

--- a/env/production_config.tfvars
+++ b/env/production_config.tfvars
@@ -188,7 +188,7 @@ pinpoint_to_sqs_sms_callbacks_docker_tag = "bootstrap"
 
 ## BLAZER
 blazer_image_tag   = "latest"
-blazer_rds_version = "15.5"
+blazer_rds_version = "15.18"
 
 ## DATA LAKE
 datalake_bucket_name = "cds-data-lake-raw-production"

--- a/env/staging_config.tfvars
+++ b/env/staging_config.tfvars
@@ -178,7 +178,7 @@ pinpoint_to_sqs_sms_callbacks_docker_tag = "bootstrap"
 
 ## BLAZER
 blazer_image_tag   = "latest"
-blazer_rds_version = "15.5"
+blazer_rds_version = "15.18"
 
 ## DATA LAKE
 datalake_bucket_name = "cds-data-lake-raw-production"


### PR DESCRIPTION
# Summary | Résumé

The initial issue here is that postgres 15.10 is no longer offered by AWS, so the blazer RDS would not get created. I've updated the version in all environments to latest 15.x version supported by AWS. 

Secondly, on a rerun of a failed job here, the github runner has the lambda repo cloned already, and so that step fails. Adding a delete of the directory before cloning to be safe.

## Related Issues | Cartes liées

Ad-hoc monday morning dev environment fix.

## Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
