### PR TITLE
Cbrid Tags Pass 1 -- Cloudwatch/22DH

### DIFF
--- a/.github/workflows/terragrunt_plan_production.yml
+++ b/.github/workflows/terragrunt_plan_production.yml
@@ -60,8 +60,16 @@ jobs:
 
             cat /var/tmp/output.txt
 
+            PLAN_SIZE=$(wc -m < /var/tmp/output.txt)
+            if (( $PLAN_SIZE < 60000 )); then
+              PLAN_OUTPUT=$(cat /var/tmp/output.txt)
+            else
+              PLAN_OUTPUT="Plan output too large to display in PR comment. See GitHub Actions logs for full plan details."
+              cat /var/tmp/output.txt
+            fi
+
             echo 'plan<<EOF' >> $GITHUB_OUTPUT
-            cat /var/tmp/output.txt >> $GITHUB_OUTPUT
+            echo "$PLAN_OUTPUT" >> $GITHUB_OUTPUT
             echo 'EOF' >> $GITHUB_OUTPUT
 
         - name: Comment on PR with plan output
@@ -119,8 +127,16 @@ jobs:
 
           cat /var/tmp/output.txt
 
+          PLAN_SIZE=$(wc -m < /var/tmp/output.txt)
+          if (( $PLAN_SIZE < 60000 )); then
+            PLAN_OUTPUT=$(cat /var/tmp/output.txt)
+          else
+            PLAN_OUTPUT="Plan output too large to display in PR comment. See GitHub Actions logs for full plan details."
+            cat /var/tmp/output.txt
+          fi
+
           echo 'plan<<EOF' >> $GITHUB_OUTPUT
-          cat /var/tmp/output.txt >> $GITHUB_OUTPUT
+          echo "$PLAN_OUTPUT" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Comment on PR with plan output
@@ -173,8 +189,16 @@ jobs:
 
           cat /var/tmp/output.txt
 
+          PLAN_SIZE=$(wc -m < /var/tmp/output.txt)
+          if (( $PLAN_SIZE < 60000 )); then
+            PLAN_OUTPUT=$(cat /var/tmp/output.txt)
+          else
+            PLAN_OUTPUT="Plan output too large to display in PR comment. See GitHub Actions logs for full plan details."
+            cat /var/tmp/output.txt
+          fi
+
           echo 'plan<<EOF' >> $GITHUB_OUTPUT
-          cat /var/tmp/output.txt >> $GITHUB_OUTPUT
+          echo "$PLAN_OUTPUT" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Comment on PR with plan output
@@ -229,8 +253,16 @@ jobs:
 
           cat /var/tmp/output.txt
 
+          PLAN_SIZE=$(wc -m < /var/tmp/output.txt)
+          if (( $PLAN_SIZE < 60000 )); then
+            PLAN_OUTPUT=$(cat /var/tmp/output.txt)
+          else
+            PLAN_OUTPUT="Plan output too large to display in PR comment. See GitHub Actions logs for full plan details."
+            cat /var/tmp/output.txt
+          fi
+
           echo 'plan<<EOF' >> $GITHUB_OUTPUT
-          cat /var/tmp/output.txt >> $GITHUB_OUTPUT
+          echo "$PLAN_OUTPUT" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Comment on PR with plan output
@@ -314,8 +346,16 @@ jobs:
 
           cat /var/tmp/output.txt
 
+          PLAN_SIZE=$(wc -m < /var/tmp/output.txt)
+          if (( $PLAN_SIZE < 60000 )); then
+            PLAN_OUTPUT=$(cat /var/tmp/output.txt)
+          else
+            PLAN_OUTPUT="Plan output too large to display in PR comment. See GitHub Actions logs for full plan details."
+            cat /var/tmp/output.txt
+          fi
+
           echo 'plan<<EOF' >> $GITHUB_OUTPUT
-          cat /var/tmp/output.txt >> $GITHUB_OUTPUT
+          echo "$PLAN_OUTPUT" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Comment on PR with plan output
@@ -370,8 +410,16 @@ jobs:
 
           cat /var/tmp/output.txt
 
+          PLAN_SIZE=$(wc -m < /var/tmp/output.txt)
+          if (( $PLAN_SIZE < 60000 )); then
+            PLAN_OUTPUT=$(cat /var/tmp/output.txt)
+          else
+            PLAN_OUTPUT="Plan output too large to display in PR comment. See GitHub Actions logs for full plan details."
+            cat /var/tmp/output.txt
+          fi
+
           echo 'plan<<EOF' >> $GITHUB_OUTPUT
-          cat /var/tmp/output.txt >> $GITHUB_OUTPUT
+          echo "$PLAN_OUTPUT" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Comment on PR with plan output
@@ -428,8 +476,16 @@ jobs:
 
           cat /var/tmp/output.txt
 
+          PLAN_SIZE=$(wc -m < /var/tmp/output.txt)
+          if (( $PLAN_SIZE < 60000 )); then
+            PLAN_OUTPUT=$(cat /var/tmp/output.txt)
+          else
+            PLAN_OUTPUT="Plan output too large to display in PR comment. See GitHub Actions logs for full plan details."
+            cat /var/tmp/output.txt
+          fi
+
           echo 'plan<<EOF' >> $GITHUB_OUTPUT
-          cat /var/tmp/output.txt >> $GITHUB_OUTPUT
+          echo "$PLAN_OUTPUT" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Comment on PR with plan output
@@ -481,8 +537,16 @@ jobs:
 
           cat /var/tmp/output.txt
 
+          PLAN_SIZE=$(wc -m < /var/tmp/output.txt)
+          if (( $PLAN_SIZE < 60000 )); then
+            PLAN_OUTPUT=$(cat /var/tmp/output.txt)
+          else
+            PLAN_OUTPUT="Plan output too large to display in PR comment. See GitHub Actions logs for full plan details."
+            cat /var/tmp/output.txt
+          fi
+
           echo 'plan<<EOF' >> $GITHUB_OUTPUT
-          cat /var/tmp/output.txt >> $GITHUB_OUTPUT
+          echo "$PLAN_OUTPUT" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Comment on PR with plan output

--- a/.github/workflows/terragrunt_plan_staging.yml
+++ b/.github/workflows/terragrunt_plan_staging.yml
@@ -212,8 +212,16 @@ jobs:
 
           cat /var/tmp/output.txt
 
+          PLAN_SIZE=$(wc -m < /var/tmp/output.txt)
+          if (( $PLAN_SIZE < 60000 )); then
+            PLAN_OUTPUT=$(cat /var/tmp/output.txt)
+          else
+            PLAN_OUTPUT="Plan output too large to display in PR comment. See GitHub Actions logs for full plan details."
+            cat /var/tmp/output.txt
+          fi
+
           echo 'plan<<EOF' >> $GITHUB_OUTPUT
-          cat /var/tmp/output.txt >> $GITHUB_OUTPUT
+          echo "$PLAN_OUTPUT" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Comment on PR with plan output
@@ -274,8 +282,16 @@ jobs:
 
           cat /var/tmp/output.txt
 
+          PLAN_SIZE=$(wc -m < /var/tmp/output.txt)
+          if (( $PLAN_SIZE < 60000 )); then
+            PLAN_OUTPUT=$(cat /var/tmp/output.txt)
+          else
+            PLAN_OUTPUT="Plan output too large to display in PR comment. See GitHub Actions logs for full plan details."
+            cat /var/tmp/output.txt
+          fi
+
           echo 'plan<<EOF' >> $GITHUB_OUTPUT
-          cat /var/tmp/output.txt >> $GITHUB_OUTPUT
+          echo "$PLAN_OUTPUT" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Comment on PR with plan output
@@ -331,8 +347,16 @@ jobs:
 
           cat /var/tmp/output.txt
 
+          PLAN_SIZE=$(wc -m < /var/tmp/output.txt)
+          if (( $PLAN_SIZE < 60000 )); then
+            PLAN_OUTPUT=$(cat /var/tmp/output.txt)
+          else
+            PLAN_OUTPUT="Plan output too large to display in PR comment. See GitHub Actions logs for full plan details."
+            cat /var/tmp/output.txt
+          fi
+
           echo 'plan<<EOF' >> $GITHUB_OUTPUT
-          cat /var/tmp/output.txt >> $GITHUB_OUTPUT
+          echo "$PLAN_OUTPUT" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Comment on PR with plan output
@@ -390,8 +414,16 @@ jobs:
 
           cat /var/tmp/output.txt
 
+          PLAN_SIZE=$(wc -m < /var/tmp/output.txt)
+          if (( $PLAN_SIZE < 60000 )); then
+            PLAN_OUTPUT=$(cat /var/tmp/output.txt)
+          else
+            PLAN_OUTPUT="Plan output too large to display in PR comment. See GitHub Actions logs for full plan details."
+            cat /var/tmp/output.txt
+          fi
+
           echo 'plan<<EOF' >> $GITHUB_OUTPUT
-          cat /var/tmp/output.txt >> $GITHUB_OUTPUT
+          echo "$PLAN_OUTPUT" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Comment on PR with plan output
@@ -479,8 +511,16 @@ jobs:
 
           cat /var/tmp/output.txt
 
+          PLAN_SIZE=$(wc -m < /var/tmp/output.txt)
+          if (( $PLAN_SIZE < 60000 )); then
+            PLAN_OUTPUT=$(cat /var/tmp/output.txt)
+          else
+            PLAN_OUTPUT="Plan output too large to display in PR comment. See GitHub Actions logs for full plan details."
+            cat /var/tmp/output.txt
+          fi
+
           echo 'plan<<EOF' >> $GITHUB_OUTPUT
-          cat /var/tmp/output.txt >> $GITHUB_OUTPUT
+          echo "$PLAN_OUTPUT" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Comment on PR with plan output
@@ -537,8 +577,16 @@ jobs:
 
           cat /var/tmp/output.txt
 
+          PLAN_SIZE=$(wc -m < /var/tmp/output.txt)
+          if (( $PLAN_SIZE < 60000 )); then
+            PLAN_OUTPUT=$(cat /var/tmp/output.txt)
+          else
+            PLAN_OUTPUT="Plan output too large to display in PR comment. See GitHub Actions logs for full plan details."
+            cat /var/tmp/output.txt
+          fi
+
           echo 'plan<<EOF' >> $GITHUB_OUTPUT
-          cat /var/tmp/output.txt >> $GITHUB_OUTPUT
+          echo "$PLAN_OUTPUT" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Comment on PR with plan output
@@ -599,8 +647,16 @@ jobs:
 
           cat /var/tmp/output.txt
 
+          PLAN_SIZE=$(wc -m < /var/tmp/output.txt)
+          if (( $PLAN_SIZE < 60000 )); then
+            PLAN_OUTPUT=$(cat /var/tmp/output.txt)
+          else
+            PLAN_OUTPUT="Plan output too large to display in PR comment. See GitHub Actions logs for full plan details."
+            cat /var/tmp/output.txt
+          fi
+
           echo 'plan<<EOF' >> $GITHUB_OUTPUT
-          cat /var/tmp/output.txt >> $GITHUB_OUTPUT
+          echo "$PLAN_OUTPUT" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Comment on PR with plan output
@@ -656,8 +712,16 @@ jobs:
 
           cat /var/tmp/output.txt
 
+          PLAN_SIZE=$(wc -m < /var/tmp/output.txt)
+          if (( $PLAN_SIZE < 60000 )); then
+            PLAN_OUTPUT=$(cat /var/tmp/output.txt)
+          else
+            PLAN_OUTPUT="Plan output too large to display in PR comment. See GitHub Actions logs for full plan details."
+            cat /var/tmp/output.txt
+          fi
+
           echo 'plan<<EOF' >> $GITHUB_OUTPUT
-          cat /var/tmp/output.txt >> $GITHUB_OUTPUT
+          echo "$PLAN_OUTPUT" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Comment on PR with plan output

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -5,7 +5,7 @@
 # There are also alarms defined in aws/eks/cloudwatch_alarms.tf
 
 resource "aws_cloudwatch_metric_alarm" "sqs-priority-queue-delay-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-priority-queue-delay-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in high priority queue >= 20 seconds for 3 minutes"
@@ -24,7 +24,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-priority-queue-delay-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-priority-queue-delay-critical" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-priority-queue-delay-critical"
   alarm_description         = "ApproximateAgeOfOldestMessage in high priority queue >= 60 seconds for 5 minutes"
@@ -46,7 +46,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-priority-queue-delay-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-bulk-queue-delay-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-bulk-queue-delay-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in bulk queue reached 60 minutes"
@@ -65,7 +65,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-bulk-queue-delay-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-bulk-queue-delay-critical" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-bulk-queue-delay-critical"
   alarm_description         = "ApproximateAgeOfOldestMessage in bulk queue reached 3 hours"
@@ -86,7 +86,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-bulk-queue-delay-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-priority-db-tasks-stuck-in-queue-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-priority-db-tasks-stuck-in-queue-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in priority DB tasks queue is older than 5 minutes in a 1-minute period"
@@ -105,7 +105,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-priority-db-tasks-stuck-in-queue-war
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-priority-db-tasks-stuck-in-queue-critical" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-priority-db-tasks-stuck-in-queue-critical"
   alarm_description         = "ApproximateAgeOfOldestMessage in priority DB tasks queue is older than 15 minute for 1 minute"
@@ -126,7 +126,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-priority-db-tasks-stuck-in-queue-cri
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-normal-db-tasks-stuck-in-queue-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-normal-db-tasks-stuck-in-queue-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in normal DB tasks queue is older than 5 minutes in a 1-minute period"
@@ -145,7 +145,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-normal-db-tasks-stuck-in-queue-warni
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-normal-db-tasks-stuck-in-queue-critical" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-normal-db-tasks-stuck-in-queue-critical"
   alarm_description         = "ApproximateAgeOfOldestMessage in normal DB tasks queue is older than 15 minute for 1 minute"
@@ -166,7 +166,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-normal-db-tasks-stuck-in-queue-criti
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-bulk-db-tasks-stuck-in-queue-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-bulk-db-tasks-stuck-in-queue-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in bulk DB tasks queue is older than 5 minutes in a 1-minute period"
@@ -185,7 +185,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-bulk-db-tasks-stuck-in-queue-warning
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-bulk-db-tasks-stuck-in-queue-critical" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-bulk-db-tasks-stuck-in-queue-critical"
   alarm_description         = "ApproximateAgeOfOldestMessage in bulk DB tasks queue is older than 15 minute for 1 minute"
@@ -207,7 +207,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-bulk-db-tasks-stuck-in-queue-critica
 
 
 resource "aws_cloudwatch_metric_alarm" "healtheck-page-slow-response-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "healtheck-page-slow-response-warning"
   alarm_description   = "Healthcheck page response time is above 100ms for 10 minutes"
@@ -226,7 +226,7 @@ resource "aws_cloudwatch_metric_alarm" "healtheck-page-slow-response-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "healtheck-page-slow-response-critical" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "healtheck-page-slow-response-critical"
   alarm_description         = "Healthcheck page response time is above 200ms for 10 minutes"
@@ -247,7 +247,7 @@ resource "aws_cloudwatch_metric_alarm" "healtheck-page-slow-response-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "sign-in-3-500-error-15-minutes-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sign-in-3-500-error-15-minutes-critical"
   alarm_description   = "Three 500 errors in 15 minutes for sign-in"
@@ -264,7 +264,7 @@ resource "aws_cloudwatch_metric_alarm" "sign-in-3-500-error-15-minutes-critical"
 }
 
 resource "aws_cloudwatch_metric_alarm" "contact-3-500-error-15-minutes-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "contact-3-500-error-15-minutes-critical"
   alarm_description   = "Three 500 errors in 15 minutes for contact us"
@@ -281,7 +281,7 @@ resource "aws_cloudwatch_metric_alarm" "contact-3-500-error-15-minutes-critical"
 }
 
 resource "aws_cloudwatch_metric_alarm" "document-download-bucket-size-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "document-download-bucket-size-warning"
   alarm_description   = "Document download S3 bucket size is larger than ${var.alarm_warning_document_download_bucket_size_gb} GB"
@@ -300,7 +300,7 @@ resource "aws_cloudwatch_metric_alarm" "document-download-bucket-size-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "scan-files-document-download-bucket-size-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "scan-files-document-download-bucket-size-warning"
   alarm_description   = "Scan files document download S3 bucket size is larger than ${var.alarm_warning_document_download_bucket_size_gb} GB"
@@ -319,7 +319,7 @@ resource "aws_cloudwatch_metric_alarm" "scan-files-document-download-bucket-size
 }
 
 resource "aws_cloudwatch_metric_alarm" "live-service-over-daily-rate-limit-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "live-service-over-daily-rate-limit-warning"
   alarm_description   = "A live service reached its daily rate limit and has been blocked from sending more notifications"
@@ -338,7 +338,7 @@ resource "aws_cloudwatch_metric_alarm" "live-service-over-daily-rate-limit-warni
 }
 
 resource "aws_cloudwatch_metric_alarm" "inflights-not-being-processed-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "inflights-not-being-processed-warning"
   alarm_description   = "Batch saving inflights are being created but are not being processed fast enough. Difference > ${var.alarm_warning_inflight_processed_created_delta_threshold} for 5 minutes"
@@ -391,7 +391,7 @@ resource "aws_cloudwatch_metric_alarm" "inflights-not-being-processed-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "inflights-not-being-processed-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "inflights-not-being-processed-critical"
   alarm_description   = "Batch saving inflights are being created but are not being processed fast enough. Difference > ${var.alarm_critical_inflight_processed_created_delta_threshold} for 5 minutes"
@@ -444,7 +444,7 @@ resource "aws_cloudwatch_metric_alarm" "inflights-not-being-processed-critical" 
 }
 
 resource "aws_cloudwatch_metric_alarm" "bulk-not-being-processed-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "bulk-buffer-not-being-processed-warning"
   alarm_description   = "Bulk saving are being created but are not being processed fast enough. Difference > ${var.alarm_warning_bulk_processed_created_delta_threshold} for 5 minutes"
@@ -498,7 +498,7 @@ resource "aws_cloudwatch_metric_alarm" "bulk-not-being-processed-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "bulk-not-being-processed-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "bulk-buffer-not-being-processed-critical"
   alarm_description   = "Bulk saving are being created but are not being processed fast enough. Difference > ${var.alarm_critical_bulk_processed_created_delta_threshold} for 5 minutes"
@@ -551,7 +551,7 @@ resource "aws_cloudwatch_metric_alarm" "bulk-not-being-processed-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "priority-bulk-not-being-processed-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "priority-bulk-buffer-not-being-processed-warning"
   alarm_description   = "Priority bulk saving are being created but are not being processed fast enough. Difference > ${var.alarm_warning_bulk_processed_created_delta_threshold} for 5 minutes"
@@ -606,7 +606,7 @@ resource "aws_cloudwatch_metric_alarm" "priority-bulk-not-being-processed-warnin
 }
 
 resource "aws_cloudwatch_metric_alarm" "priority-bulk-not-being-processed-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "priority_bulk-buffer-not-being-processed-critical"
   alarm_description   = "Priority bulk saving are being created but are not being processed fast enough. Difference > ${var.alarm_critical_bulk_processed_created_delta_threshold} for 5 minutes"
@@ -662,7 +662,7 @@ resource "aws_cloudwatch_metric_alarm" "priority-bulk-not-being-processed-critic
 }
 
 resource "aws_cloudwatch_metric_alarm" "normal-bulk-not-being-processed-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "normal-bulk-buffer-not-being-processed-warning"
   alarm_description   = "Normal bulk saving are being created but are not being processed fast enough. Difference > ${var.alarm_warning_bulk_processed_created_delta_threshold} for 5 minutes"
@@ -717,7 +717,7 @@ resource "aws_cloudwatch_metric_alarm" "normal-bulk-not-being-processed-warning"
 }
 
 resource "aws_cloudwatch_metric_alarm" "normal-bulk-not-being-processed-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "normal_bulk-buffer-not-being-processed-critical"
   alarm_description   = "Normal bulk saving are being created but are not being processed fast enough. Difference > ${var.alarm_critical_bulk_processed_created_delta_threshold} for 5 minutes"
@@ -773,7 +773,7 @@ resource "aws_cloudwatch_metric_alarm" "normal-bulk-not-being-processed-critical
 }
 
 resource "aws_cloudwatch_metric_alarm" "bulk-bulk-not-being-processed-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "bulk-bulk-buffer-not-being-processed-warning"
   alarm_description   = "Bulk bulk saving are being created but are not being processed fast enough. Difference > ${var.alarm_warning_bulk_processed_created_delta_threshold} for 5 minutes"
@@ -828,7 +828,7 @@ resource "aws_cloudwatch_metric_alarm" "bulk-bulk-not-being-processed-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "bulk-bulk-not-being-processed-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "bulk_bulk-buffer-not-being-processed-critical"
   alarm_description   = "Bulk bulk saving are being created but are not being processed fast enough. Difference > ${var.alarm_critical_bulk_processed_created_delta_threshold} for 5 minutes"
@@ -884,7 +884,7 @@ resource "aws_cloudwatch_metric_alarm" "bulk-bulk-not-being-processed-critical" 
 }
 
 resource "aws_cloudwatch_metric_alarm" "expired-inflight-poisoned-message-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "expired-inflight-any"
   alarm_description   = "Possible poisoned message - inflights are expiring. Investigate if this is repeated. Check the Redis-batch-saving dashboard"
@@ -908,7 +908,7 @@ resource "aws_cloudwatch_metric_alarm" "expired-inflight-poisoned-message-warnin
 }
 
 resource "aws_cloudwatch_metric_alarm" "expired-inflight-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "expired-inflight-warning"
   alarm_description   = "Inflights are expiring faster than they are being acknowledged in two consecutive 5-minute periods - queue is deteriorating. Check the Redis-batch-saving dashboard"
@@ -965,7 +965,7 @@ resource "aws_cloudwatch_metric_alarm" "expired-inflight-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "expired-inflight-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "expired-inflight-critical"
   alarm_description   = "More than ${var.alarm_critical_expired_inflights_threshold} inflights expired in 5 minutes AND celery acknowledgment throughput is zero - system is stuck, check the Redis-batch-saving dashboard"

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -5,6 +5,7 @@
 # There are also alarms defined in aws/eks/cloudwatch_alarms.tf
 
 resource "aws_cloudwatch_metric_alarm" "sqs-priority-queue-delay-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-priority-queue-delay-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in high priority queue >= 20 seconds for 3 minutes"
@@ -23,6 +24,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-priority-queue-delay-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-priority-queue-delay-critical" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-priority-queue-delay-critical"
   alarm_description         = "ApproximateAgeOfOldestMessage in high priority queue >= 60 seconds for 5 minutes"
@@ -44,6 +46,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-priority-queue-delay-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-bulk-queue-delay-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-bulk-queue-delay-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in bulk queue reached 60 minutes"
@@ -62,6 +65,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-bulk-queue-delay-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-bulk-queue-delay-critical" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-bulk-queue-delay-critical"
   alarm_description         = "ApproximateAgeOfOldestMessage in bulk queue reached 3 hours"
@@ -82,6 +86,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-bulk-queue-delay-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-priority-db-tasks-stuck-in-queue-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-priority-db-tasks-stuck-in-queue-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in priority DB tasks queue is older than 5 minutes in a 1-minute period"
@@ -100,6 +105,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-priority-db-tasks-stuck-in-queue-war
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-priority-db-tasks-stuck-in-queue-critical" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-priority-db-tasks-stuck-in-queue-critical"
   alarm_description         = "ApproximateAgeOfOldestMessage in priority DB tasks queue is older than 15 minute for 1 minute"
@@ -120,6 +126,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-priority-db-tasks-stuck-in-queue-cri
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-normal-db-tasks-stuck-in-queue-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-normal-db-tasks-stuck-in-queue-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in normal DB tasks queue is older than 5 minutes in a 1-minute period"
@@ -138,6 +145,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-normal-db-tasks-stuck-in-queue-warni
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-normal-db-tasks-stuck-in-queue-critical" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-normal-db-tasks-stuck-in-queue-critical"
   alarm_description         = "ApproximateAgeOfOldestMessage in normal DB tasks queue is older than 15 minute for 1 minute"
@@ -158,6 +166,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-normal-db-tasks-stuck-in-queue-criti
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-bulk-db-tasks-stuck-in-queue-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-bulk-db-tasks-stuck-in-queue-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in bulk DB tasks queue is older than 5 minutes in a 1-minute period"
@@ -176,6 +185,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-bulk-db-tasks-stuck-in-queue-warning
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-bulk-db-tasks-stuck-in-queue-critical" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-bulk-db-tasks-stuck-in-queue-critical"
   alarm_description         = "ApproximateAgeOfOldestMessage in bulk DB tasks queue is older than 15 minute for 1 minute"
@@ -197,6 +207,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-bulk-db-tasks-stuck-in-queue-critica
 
 
 resource "aws_cloudwatch_metric_alarm" "healtheck-page-slow-response-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "healtheck-page-slow-response-warning"
   alarm_description   = "Healthcheck page response time is above 100ms for 10 minutes"
@@ -215,6 +226,7 @@ resource "aws_cloudwatch_metric_alarm" "healtheck-page-slow-response-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "healtheck-page-slow-response-critical" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "healtheck-page-slow-response-critical"
   alarm_description         = "Healthcheck page response time is above 200ms for 10 minutes"
@@ -235,6 +247,7 @@ resource "aws_cloudwatch_metric_alarm" "healtheck-page-slow-response-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "sign-in-3-500-error-15-minutes-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sign-in-3-500-error-15-minutes-critical"
   alarm_description   = "Three 500 errors in 15 minutes for sign-in"
@@ -251,6 +264,7 @@ resource "aws_cloudwatch_metric_alarm" "sign-in-3-500-error-15-minutes-critical"
 }
 
 resource "aws_cloudwatch_metric_alarm" "contact-3-500-error-15-minutes-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "contact-3-500-error-15-minutes-critical"
   alarm_description   = "Three 500 errors in 15 minutes for contact us"
@@ -267,6 +281,7 @@ resource "aws_cloudwatch_metric_alarm" "contact-3-500-error-15-minutes-critical"
 }
 
 resource "aws_cloudwatch_metric_alarm" "document-download-bucket-size-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "document-download-bucket-size-warning"
   alarm_description   = "Document download S3 bucket size is larger than ${var.alarm_warning_document_download_bucket_size_gb} GB"
@@ -285,6 +300,7 @@ resource "aws_cloudwatch_metric_alarm" "document-download-bucket-size-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "scan-files-document-download-bucket-size-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "scan-files-document-download-bucket-size-warning"
   alarm_description   = "Scan files document download S3 bucket size is larger than ${var.alarm_warning_document_download_bucket_size_gb} GB"
@@ -303,6 +319,7 @@ resource "aws_cloudwatch_metric_alarm" "scan-files-document-download-bucket-size
 }
 
 resource "aws_cloudwatch_metric_alarm" "live-service-over-daily-rate-limit-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "live-service-over-daily-rate-limit-warning"
   alarm_description   = "A live service reached its daily rate limit and has been blocked from sending more notifications"
@@ -321,6 +338,7 @@ resource "aws_cloudwatch_metric_alarm" "live-service-over-daily-rate-limit-warni
 }
 
 resource "aws_cloudwatch_metric_alarm" "inflights-not-being-processed-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "inflights-not-being-processed-warning"
   alarm_description   = "Batch saving inflights are being created but are not being processed fast enough. Difference > ${var.alarm_warning_inflight_processed_created_delta_threshold} for 5 minutes"
@@ -373,6 +391,7 @@ resource "aws_cloudwatch_metric_alarm" "inflights-not-being-processed-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "inflights-not-being-processed-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "inflights-not-being-processed-critical"
   alarm_description   = "Batch saving inflights are being created but are not being processed fast enough. Difference > ${var.alarm_critical_inflight_processed_created_delta_threshold} for 5 minutes"
@@ -425,6 +444,7 @@ resource "aws_cloudwatch_metric_alarm" "inflights-not-being-processed-critical" 
 }
 
 resource "aws_cloudwatch_metric_alarm" "bulk-not-being-processed-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "bulk-buffer-not-being-processed-warning"
   alarm_description   = "Bulk saving are being created but are not being processed fast enough. Difference > ${var.alarm_warning_bulk_processed_created_delta_threshold} for 5 minutes"
@@ -478,6 +498,7 @@ resource "aws_cloudwatch_metric_alarm" "bulk-not-being-processed-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "bulk-not-being-processed-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "bulk-buffer-not-being-processed-critical"
   alarm_description   = "Bulk saving are being created but are not being processed fast enough. Difference > ${var.alarm_critical_bulk_processed_created_delta_threshold} for 5 minutes"
@@ -530,6 +551,7 @@ resource "aws_cloudwatch_metric_alarm" "bulk-not-being-processed-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "priority-bulk-not-being-processed-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "priority-bulk-buffer-not-being-processed-warning"
   alarm_description   = "Priority bulk saving are being created but are not being processed fast enough. Difference > ${var.alarm_warning_bulk_processed_created_delta_threshold} for 5 minutes"
@@ -584,6 +606,7 @@ resource "aws_cloudwatch_metric_alarm" "priority-bulk-not-being-processed-warnin
 }
 
 resource "aws_cloudwatch_metric_alarm" "priority-bulk-not-being-processed-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "priority_bulk-buffer-not-being-processed-critical"
   alarm_description   = "Priority bulk saving are being created but are not being processed fast enough. Difference > ${var.alarm_critical_bulk_processed_created_delta_threshold} for 5 minutes"
@@ -639,6 +662,7 @@ resource "aws_cloudwatch_metric_alarm" "priority-bulk-not-being-processed-critic
 }
 
 resource "aws_cloudwatch_metric_alarm" "normal-bulk-not-being-processed-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "normal-bulk-buffer-not-being-processed-warning"
   alarm_description   = "Normal bulk saving are being created but are not being processed fast enough. Difference > ${var.alarm_warning_bulk_processed_created_delta_threshold} for 5 minutes"
@@ -693,6 +717,7 @@ resource "aws_cloudwatch_metric_alarm" "normal-bulk-not-being-processed-warning"
 }
 
 resource "aws_cloudwatch_metric_alarm" "normal-bulk-not-being-processed-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "normal_bulk-buffer-not-being-processed-critical"
   alarm_description   = "Normal bulk saving are being created but are not being processed fast enough. Difference > ${var.alarm_critical_bulk_processed_created_delta_threshold} for 5 minutes"
@@ -748,6 +773,7 @@ resource "aws_cloudwatch_metric_alarm" "normal-bulk-not-being-processed-critical
 }
 
 resource "aws_cloudwatch_metric_alarm" "bulk-bulk-not-being-processed-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "bulk-bulk-buffer-not-being-processed-warning"
   alarm_description   = "Bulk bulk saving are being created but are not being processed fast enough. Difference > ${var.alarm_warning_bulk_processed_created_delta_threshold} for 5 minutes"
@@ -802,6 +828,7 @@ resource "aws_cloudwatch_metric_alarm" "bulk-bulk-not-being-processed-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "bulk-bulk-not-being-processed-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "bulk_bulk-buffer-not-being-processed-critical"
   alarm_description   = "Bulk bulk saving are being created but are not being processed fast enough. Difference > ${var.alarm_critical_bulk_processed_created_delta_threshold} for 5 minutes"
@@ -857,6 +884,7 @@ resource "aws_cloudwatch_metric_alarm" "bulk-bulk-not-being-processed-critical" 
 }
 
 resource "aws_cloudwatch_metric_alarm" "expired-inflight-poisoned-message-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "expired-inflight-any"
   alarm_description   = "Possible poisoned message - inflights are expiring. Investigate if this is repeated. Check the Redis-batch-saving dashboard"
@@ -880,6 +908,7 @@ resource "aws_cloudwatch_metric_alarm" "expired-inflight-poisoned-message-warnin
 }
 
 resource "aws_cloudwatch_metric_alarm" "expired-inflight-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "expired-inflight-warning"
   alarm_description   = "Inflights are expiring faster than they are being acknowledged in two consecutive 5-minute periods - queue is deteriorating. Check the Redis-batch-saving dashboard"
@@ -936,6 +965,7 @@ resource "aws_cloudwatch_metric_alarm" "expired-inflight-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "expired-inflight-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "expired-inflight-critical"
   alarm_description   = "More than ${var.alarm_critical_expired_inflights_threshold} inflights expired in 5 minutes AND celery acknowledgment throughput is zero - system is stuck, check the Redis-batch-saving dashboard"

--- a/aws/common/cloudwatch_alarms_email.tf
+++ b/aws/common/cloudwatch_alarms_email.tf
@@ -6,7 +6,7 @@
 
 
 resource "aws_cloudwatch_metric_alarm" "ses-bounce-rate-warning" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "ses-bounce-rate-warning"
   alarm_description         = "Bounce rate >=5% over the last 12 hours"
@@ -23,7 +23,7 @@ resource "aws_cloudwatch_metric_alarm" "ses-bounce-rate-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ses-bounce-rate-critical" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "ses-bounce-rate-critical"
   alarm_description         = "Bounce rate >=7% over the last 12 hours"
@@ -41,7 +41,7 @@ resource "aws_cloudwatch_metric_alarm" "ses-bounce-rate-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ses-complaint-rate-warning" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "ses-complaint-rate-warning"
   alarm_description         = "Complaint rate >=0.3% over the last 12 hours"
@@ -58,7 +58,7 @@ resource "aws_cloudwatch_metric_alarm" "ses-complaint-rate-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ses-complaint-rate-critical" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "ses-complaint-rate-critical"
   alarm_description         = "Complaint rate >=0.4% over the last 12 hours"
@@ -76,7 +76,7 @@ resource "aws_cloudwatch_metric_alarm" "ses-complaint-rate-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ses-daily-email-quota-warning" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "ses-daily-email-quota-warning"
   alarm_description         = "SES sends over the last 24 hours have reached 70% of the daily email quota"
@@ -93,7 +93,7 @@ resource "aws_cloudwatch_metric_alarm" "ses-daily-email-quota-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ses-daily-email-quota-critical" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "ses-daily-email-quota-critical"
   alarm_description         = "SES sends over the last 24 hours have reached 90% of the daily email quota"
@@ -111,7 +111,7 @@ resource "aws_cloudwatch_metric_alarm" "ses-daily-email-quota-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-email-high-queue-delay-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-send-email-high-queue-delay-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in send email high priority queue >= 20 seconds for 3 minutes"
@@ -130,7 +130,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-email-high-queue-delay-warning"
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-email-high-queue-delay-critical" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-send-email-high-queue-delay-critical"
   alarm_description         = "ApproximateAgeOfOldestMessage in send-email-high queue >= 60 seconds for 5 minutes"
@@ -152,7 +152,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-email-high-queue-delay-critical
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-email-medium-queue-delay-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-send-email-medium-queue-delay-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in send-email-medium queue is >= 30 minutes for 5 minutes"
@@ -171,7 +171,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-email-medium-queue-delay-warnin
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-email-medium-queue-delay-critical" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-send-email-medium-queue-delay-critical"
   alarm_description         = "ApproximateAgeOfOldestMessage in send-email-medium queue is >= 45 minutes for 5 minutes"
@@ -192,7 +192,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-email-medium-queue-delay-critic
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-email-low-queue-delay-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-send-email-low-queue-delay-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in send-email-low queue is >= 1 hour for 5 minutes"
@@ -211,7 +211,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-email-low-queue-delay-warning" 
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-email-low-queue-delay-critical" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-send-email-low-queue-delay-critical"
   alarm_description         = "ApproximateAgeOfOldestMessage in send-email-low queue is >= 3 hours"
@@ -232,7 +232,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-email-low-queue-delay-critical"
 }
 
 resource "aws_cloudwatch_metric_alarm" "no-emails-sent-5-minutes-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "no-emails-sent-1-minute-warning"
   alarm_description   = "SES sending rate is less than 1 per minute"
@@ -248,7 +248,7 @@ resource "aws_cloudwatch_metric_alarm" "no-emails-sent-5-minutes-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "no-emails-sent-5-minutes-critical" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "no-emails-sent-5-minutes-critical"
   alarm_description         = "No emails delivered with SES in 5 minutes"

--- a/aws/common/cloudwatch_alarms_email.tf
+++ b/aws/common/cloudwatch_alarms_email.tf
@@ -6,6 +6,7 @@
 
 
 resource "aws_cloudwatch_metric_alarm" "ses-bounce-rate-warning" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "ses-bounce-rate-warning"
   alarm_description         = "Bounce rate >=5% over the last 12 hours"
@@ -22,6 +23,7 @@ resource "aws_cloudwatch_metric_alarm" "ses-bounce-rate-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ses-bounce-rate-critical" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "ses-bounce-rate-critical"
   alarm_description         = "Bounce rate >=7% over the last 12 hours"
@@ -39,6 +41,7 @@ resource "aws_cloudwatch_metric_alarm" "ses-bounce-rate-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ses-complaint-rate-warning" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "ses-complaint-rate-warning"
   alarm_description         = "Complaint rate >=0.3% over the last 12 hours"
@@ -55,6 +58,7 @@ resource "aws_cloudwatch_metric_alarm" "ses-complaint-rate-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ses-complaint-rate-critical" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "ses-complaint-rate-critical"
   alarm_description         = "Complaint rate >=0.4% over the last 12 hours"
@@ -72,6 +76,7 @@ resource "aws_cloudwatch_metric_alarm" "ses-complaint-rate-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ses-daily-email-quota-warning" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "ses-daily-email-quota-warning"
   alarm_description         = "SES sends over the last 24 hours have reached 70% of the daily email quota"
@@ -88,6 +93,7 @@ resource "aws_cloudwatch_metric_alarm" "ses-daily-email-quota-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ses-daily-email-quota-critical" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "ses-daily-email-quota-critical"
   alarm_description         = "SES sends over the last 24 hours have reached 90% of the daily email quota"
@@ -105,6 +111,7 @@ resource "aws_cloudwatch_metric_alarm" "ses-daily-email-quota-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-email-high-queue-delay-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-send-email-high-queue-delay-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in send email high priority queue >= 20 seconds for 3 minutes"
@@ -123,6 +130,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-email-high-queue-delay-warning"
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-email-high-queue-delay-critical" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-send-email-high-queue-delay-critical"
   alarm_description         = "ApproximateAgeOfOldestMessage in send-email-high queue >= 60 seconds for 5 minutes"
@@ -144,6 +152,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-email-high-queue-delay-critical
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-email-medium-queue-delay-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-send-email-medium-queue-delay-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in send-email-medium queue is >= 30 minutes for 5 minutes"
@@ -162,6 +171,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-email-medium-queue-delay-warnin
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-email-medium-queue-delay-critical" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-send-email-medium-queue-delay-critical"
   alarm_description         = "ApproximateAgeOfOldestMessage in send-email-medium queue is >= 45 minutes for 5 minutes"
@@ -182,6 +192,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-email-medium-queue-delay-critic
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-email-low-queue-delay-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-send-email-low-queue-delay-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in send-email-low queue is >= 1 hour for 5 minutes"
@@ -200,6 +211,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-email-low-queue-delay-warning" 
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-email-low-queue-delay-critical" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-send-email-low-queue-delay-critical"
   alarm_description         = "ApproximateAgeOfOldestMessage in send-email-low queue is >= 3 hours"
@@ -220,6 +232,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-email-low-queue-delay-critical"
 }
 
 resource "aws_cloudwatch_metric_alarm" "no-emails-sent-5-minutes-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "no-emails-sent-1-minute-warning"
   alarm_description   = "SES sending rate is less than 1 per minute"
@@ -235,6 +248,7 @@ resource "aws_cloudwatch_metric_alarm" "no-emails-sent-5-minutes-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "no-emails-sent-5-minutes-critical" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "no-emails-sent-5-minutes-critical"
   alarm_description         = "No emails delivered with SES in 5 minutes"

--- a/aws/common/cloudwatch_alarms_redis_queue.tf
+++ b/aws/common/cloudwatch_alarms_redis_queue.tf
@@ -5,6 +5,7 @@
 # There are also alarms defined in aws/eks/cloudwatch_alarms.tf
 
 resource "aws_cloudwatch_metric_alarm" "priority-inflights-not-being-processed-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "priority-inflights-not-being-processed-warning"
   alarm_description   = "Batch saving priority inflights are being created but are not being processed fast enough. Difference > ${var.alarm_warning_priority_inflight_processed_created_delta_threshold} for 5 minutes"
@@ -59,6 +60,7 @@ resource "aws_cloudwatch_metric_alarm" "priority-inflights-not-being-processed-w
 
 
 resource "aws_cloudwatch_metric_alarm" "priority_inflights-not-being-processed-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "priority-inflights-not-being-processed-critical"
   alarm_description   = "Batch saving priority inflights are being created but are not being processed fast enough. Difference > ${var.alarm_critical_priority_inflight_processed_created_delta_threshold} for 5 minutes"
@@ -113,6 +115,7 @@ resource "aws_cloudwatch_metric_alarm" "priority_inflights-not-being-processed-c
 }
 
 resource "aws_cloudwatch_metric_alarm" "normal-inflights-not-being-processed-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "normal-inflights-not-being-processed-warning"
   alarm_description   = "Batch saving normal inflights are being created but are not being processed fast enough. Difference > ${var.alarm_warning_normal_inflight_processed_created_delta_threshold} for 5 minutes"
@@ -166,6 +169,7 @@ resource "aws_cloudwatch_metric_alarm" "normal-inflights-not-being-processed-war
 }
 
 resource "aws_cloudwatch_metric_alarm" "normal-inflights-not-being-processed-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "normal-inflights-not-being-processed-critical"
   alarm_description   = "Batch saving normal inflights are being created but are not being processed fast enough. Difference > ${var.alarm_critical_normal_inflight_processed_created_delta_threshold} for 5 minutes"
@@ -220,6 +224,7 @@ resource "aws_cloudwatch_metric_alarm" "normal-inflights-not-being-processed-cri
 }
 
 resource "aws_cloudwatch_metric_alarm" "bulk-inflights-not-being-processed-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "bulk-inflights-not-being-processed-warning"
   alarm_description   = "Batch saving bulk inflights are being created but are not being processed fast enough. Difference > ${var.alarm_warning_bulk_inflight_processed_created_delta_threshold} for 5 minutes"
@@ -273,6 +278,7 @@ resource "aws_cloudwatch_metric_alarm" "bulk-inflights-not-being-processed-warni
 }
 
 resource "aws_cloudwatch_metric_alarm" "bulk-inflights-not-being-processed-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "bulk-inflights-not-being-processed-critical"
   alarm_description   = "Batch saving bulk inflights are being created but are not being processed fast enough. Difference > ${var.alarm_critical_bulk_inflight_processed_created_delta_threshold} for 5 minutes"

--- a/aws/common/cloudwatch_alarms_redis_queue.tf
+++ b/aws/common/cloudwatch_alarms_redis_queue.tf
@@ -5,7 +5,7 @@
 # There are also alarms defined in aws/eks/cloudwatch_alarms.tf
 
 resource "aws_cloudwatch_metric_alarm" "priority-inflights-not-being-processed-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "priority-inflights-not-being-processed-warning"
   alarm_description   = "Batch saving priority inflights are being created but are not being processed fast enough. Difference > ${var.alarm_warning_priority_inflight_processed_created_delta_threshold} for 5 minutes"
@@ -60,7 +60,7 @@ resource "aws_cloudwatch_metric_alarm" "priority-inflights-not-being-processed-w
 
 
 resource "aws_cloudwatch_metric_alarm" "priority_inflights-not-being-processed-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "priority-inflights-not-being-processed-critical"
   alarm_description   = "Batch saving priority inflights are being created but are not being processed fast enough. Difference > ${var.alarm_critical_priority_inflight_processed_created_delta_threshold} for 5 minutes"
@@ -115,7 +115,7 @@ resource "aws_cloudwatch_metric_alarm" "priority_inflights-not-being-processed-c
 }
 
 resource "aws_cloudwatch_metric_alarm" "normal-inflights-not-being-processed-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "normal-inflights-not-being-processed-warning"
   alarm_description   = "Batch saving normal inflights are being created but are not being processed fast enough. Difference > ${var.alarm_warning_normal_inflight_processed_created_delta_threshold} for 5 minutes"
@@ -169,7 +169,7 @@ resource "aws_cloudwatch_metric_alarm" "normal-inflights-not-being-processed-war
 }
 
 resource "aws_cloudwatch_metric_alarm" "normal-inflights-not-being-processed-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "normal-inflights-not-being-processed-critical"
   alarm_description   = "Batch saving normal inflights are being created but are not being processed fast enough. Difference > ${var.alarm_critical_normal_inflight_processed_created_delta_threshold} for 5 minutes"
@@ -224,7 +224,7 @@ resource "aws_cloudwatch_metric_alarm" "normal-inflights-not-being-processed-cri
 }
 
 resource "aws_cloudwatch_metric_alarm" "bulk-inflights-not-being-processed-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "bulk-inflights-not-being-processed-warning"
   alarm_description   = "Batch saving bulk inflights are being created but are not being processed fast enough. Difference > ${var.alarm_warning_bulk_inflight_processed_created_delta_threshold} for 5 minutes"
@@ -278,7 +278,7 @@ resource "aws_cloudwatch_metric_alarm" "bulk-inflights-not-being-processed-warni
 }
 
 resource "aws_cloudwatch_metric_alarm" "bulk-inflights-not-being-processed-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "bulk-inflights-not-being-processed-critical"
   alarm_description   = "Batch saving bulk inflights are being created but are not being processed fast enough. Difference > ${var.alarm_critical_bulk_inflight_processed_created_delta_threshold} for 5 minutes"

--- a/aws/common/cloudwatch_alarms_sms.tf
+++ b/aws/common/cloudwatch_alarms_sms.tf
@@ -6,6 +6,7 @@
 
 
 resource "aws_cloudwatch_metric_alarm" "sns-spending-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sns-spending-warning"
   alarm_description   = "SNS spending reached 80% of limit this month"
@@ -38,6 +39,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-spending-us-west-2-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "sns-spending-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sns-spending-critical"
   alarm_description   = "SNS spending reached 90% of limit this month"
@@ -72,6 +74,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-spending-us-west-2-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sns-sms-success-rate-canadian-numbers-warning"
   alarm_description   = "SMS success rate to Canadian numbers is below 60% over 2 consecutive periods of 12 hours"
@@ -145,6 +148,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-us
 }
 
 resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sns-sms-success-rate-canadian-numbers-critical"
   alarm_description   = "SMS success rate to Canadian numbers is below 25% with at least 25 messages over 2 consecutive periods of 12 hours"
@@ -220,6 +224,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-us
 }
 
 resource "aws_cloudwatch_metric_alarm" "sns-sms-blocked-as-spam-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sns-sms-blocked-as-spam-warning"
   alarm_description   = "More than 10 SMS have been blocked as spam over 12 hours"
@@ -252,6 +257,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-blocked-as-spam-us-west-2-warnin
 }
 
 resource "aws_cloudwatch_metric_alarm" "sns-sms-phone-carrier-unavailable-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sns-sms-phone-carrier-unavailable-warning"
   alarm_description   = "More than 100 SMS failed because a phone carrier is unavailable over 3 hours"
@@ -284,6 +290,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-phone-carrier-unavailable-us-wes
 }
 
 resource "aws_cloudwatch_metric_alarm" "sns-sms-rate-exceeded-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sns-sms-rate-exceeded-warning"
   alarm_description   = "At least 1 SNS SMS rate exceeded error in 5 minutes"
@@ -316,6 +323,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-rate-exceeded-us-west-2-warning"
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-high-queue-delay-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-send-sms-high-queue-delay-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in send sms high priority queue >= 10 seconds for 3 minutes"
@@ -334,6 +342,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-high-queue-delay-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-high-queue-delay-critical" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-send-sms-high-queue-delay-critical"
   alarm_description         = "ApproximateAgeOfOldestMessage in send-sms-high queue >= 60 seconds for 5 minutes"
@@ -355,6 +364,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-high-queue-delay-critical" 
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-medium-queue-delay-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-send-sms-medium-queue-delay-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in send-sms-medium queue is >= 10 minutes for 5 minutes"
@@ -373,6 +383,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-medium-queue-delay-warning"
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-medium-queue-delay-critical" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-send-sms-medium-queue-delay-critical"
   alarm_description         = "ApproximateAgeOfOldestMessage in send-sms-medium queue is >= 15 minutes for 5 minutes"
@@ -393,6 +404,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-medium-queue-delay-critical
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-low-queue-delay-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-send-sms-low-queue-delay-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in send-sms-low queue is >= 10 minutes for 5 minutes"
@@ -411,6 +423,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-low-queue-delay-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-low-queue-delay-critical" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-send-sms-low-queue-delay-critical"
   alarm_description         = "ApproximateAgeOfOldestMessage in send-sms-low queue is >= 3 hours"
@@ -431,6 +444,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-low-queue-delay-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-dedicated-number-throttled-sms-stuck-in-queue-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-dedicated-number-throttled-sms-stuck-in-queue-warning"
   alarm_description   = "Delay in throttled SMS queue for dedicated numbers >= 1 hour"
@@ -449,6 +463,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-dedicated-number-throttled-sms-stuck
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-dedicated-number-throttled-sms-stuck-in-queue-critical" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-dedicated-number-throttled-sms-stuck-in-queue-critical"
   alarm_description         = "Delay in throttled SMS queue for dedicated numbers >= 4 hours"
@@ -470,6 +485,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-dedicated-number-throttled-sms-stuck
 
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-throttled-sms-tasks-receive-rate-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-send-throttled-sms-tasks-receive-rate-warning"
   alarm_description   = "NumberOfMessagesReceived is more than the expected maximum rate for send-throttled-sms-tasks SQS queue"
@@ -491,6 +507,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-throttled-sms-tasks-receive-rat
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-throttled-sms-tasks-receive-rate-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-send-throttled-sms-tasks-receive-rate-critical"
   alarm_description   = "NumberOfMessagesReceived is more than the expected maximum rate for send-throttled-sms-tasks SQS queue"

--- a/aws/common/cloudwatch_alarms_sms.tf
+++ b/aws/common/cloudwatch_alarms_sms.tf
@@ -6,7 +6,7 @@
 
 
 resource "aws_cloudwatch_metric_alarm" "sns-spending-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sns-spending-warning"
   alarm_description   = "SNS spending reached 80% of limit this month"
@@ -39,7 +39,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-spending-us-west-2-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "sns-spending-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sns-spending-critical"
   alarm_description   = "SNS spending reached 90% of limit this month"
@@ -74,7 +74,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-spending-us-west-2-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sns-sms-success-rate-canadian-numbers-warning"
   alarm_description   = "SMS success rate to Canadian numbers is below 60% over 2 consecutive periods of 12 hours"
@@ -148,7 +148,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-us
 }
 
 resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sns-sms-success-rate-canadian-numbers-critical"
   alarm_description   = "SMS success rate to Canadian numbers is below 25% with at least 25 messages over 2 consecutive periods of 12 hours"
@@ -224,7 +224,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-success-rate-canadian-numbers-us
 }
 
 resource "aws_cloudwatch_metric_alarm" "sns-sms-blocked-as-spam-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sns-sms-blocked-as-spam-warning"
   alarm_description   = "More than 10 SMS have been blocked as spam over 12 hours"
@@ -257,7 +257,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-blocked-as-spam-us-west-2-warnin
 }
 
 resource "aws_cloudwatch_metric_alarm" "sns-sms-phone-carrier-unavailable-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sns-sms-phone-carrier-unavailable-warning"
   alarm_description   = "More than 100 SMS failed because a phone carrier is unavailable over 3 hours"
@@ -290,7 +290,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-phone-carrier-unavailable-us-wes
 }
 
 resource "aws_cloudwatch_metric_alarm" "sns-sms-rate-exceeded-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sns-sms-rate-exceeded-warning"
   alarm_description   = "At least 1 SNS SMS rate exceeded error in 5 minutes"
@@ -323,7 +323,7 @@ resource "aws_cloudwatch_metric_alarm" "sns-sms-rate-exceeded-us-west-2-warning"
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-high-queue-delay-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-send-sms-high-queue-delay-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in send sms high priority queue >= 10 seconds for 3 minutes"
@@ -342,7 +342,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-high-queue-delay-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-high-queue-delay-critical" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-send-sms-high-queue-delay-critical"
   alarm_description         = "ApproximateAgeOfOldestMessage in send-sms-high queue >= 60 seconds for 5 minutes"
@@ -364,7 +364,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-high-queue-delay-critical" 
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-medium-queue-delay-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-send-sms-medium-queue-delay-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in send-sms-medium queue is >= 10 minutes for 5 minutes"
@@ -383,7 +383,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-medium-queue-delay-warning"
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-medium-queue-delay-critical" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-send-sms-medium-queue-delay-critical"
   alarm_description         = "ApproximateAgeOfOldestMessage in send-sms-medium queue is >= 15 minutes for 5 minutes"
@@ -404,7 +404,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-medium-queue-delay-critical
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-low-queue-delay-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-send-sms-low-queue-delay-warning"
   alarm_description   = "ApproximateAgeOfOldestMessage in send-sms-low queue is >= 10 minutes for 5 minutes"
@@ -423,7 +423,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-low-queue-delay-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-low-queue-delay-critical" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-send-sms-low-queue-delay-critical"
   alarm_description         = "ApproximateAgeOfOldestMessage in send-sms-low queue is >= 3 hours"
@@ -444,7 +444,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-sms-low-queue-delay-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-dedicated-number-throttled-sms-stuck-in-queue-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-dedicated-number-throttled-sms-stuck-in-queue-warning"
   alarm_description   = "Delay in throttled SMS queue for dedicated numbers >= 1 hour"
@@ -463,7 +463,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-dedicated-number-throttled-sms-stuck
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-dedicated-number-throttled-sms-stuck-in-queue-critical" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "sqs-dedicated-number-throttled-sms-stuck-in-queue-critical"
   alarm_description         = "Delay in throttled SMS queue for dedicated numbers >= 4 hours"
@@ -485,7 +485,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-dedicated-number-throttled-sms-stuck
 
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-throttled-sms-tasks-receive-rate-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-send-throttled-sms-tasks-receive-rate-warning"
   alarm_description   = "NumberOfMessagesReceived is more than the expected maximum rate for send-throttled-sms-tasks SQS queue"
@@ -507,7 +507,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs-send-throttled-sms-tasks-receive-rat
 }
 
 resource "aws_cloudwatch_metric_alarm" "sqs-send-throttled-sms-tasks-receive-rate-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "sqs-send-throttled-sms-tasks-receive-rate-critical"
   alarm_description   = "NumberOfMessagesReceived is more than the expected maximum rate for send-throttled-sms-tasks SQS queue"

--- a/aws/common/cloudwatch_events.tf
+++ b/aws/common/cloudwatch_events.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_event_rule" "aws_health" {
+  provider = aws.core_services
   count       = var.cloudwatch_enabled ? 1 : 0
   name        = "aws_health"
   description = "Subscribe to AWS health events"
@@ -37,6 +38,7 @@ EOF
 }
 
 resource "aws_cloudwatch_event_target" "aws_health_sns_warning" {
+  provider = aws.core_services
   count     = var.cloudwatch_enabled ? 1 : 0
   rule      = aws_cloudwatch_event_rule.aws_health[0].name
   target_id = "aws_health_sns_warning"

--- a/aws/common/cloudwatch_events.tf
+++ b/aws/common/cloudwatch_events.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_event_rule" "aws_health" {
-  provider = aws.core_services
+  provider    = aws.core_services
   count       = var.cloudwatch_enabled ? 1 : 0
   name        = "aws_health"
   description = "Subscribe to AWS health events"
@@ -38,7 +38,7 @@ EOF
 }
 
 resource "aws_cloudwatch_event_target" "aws_health_sns_warning" {
-  provider = aws.core_services
+  provider  = aws.core_services
   count     = var.cloudwatch_enabled ? 1 : 0
   rule      = aws_cloudwatch_event_rule.aws_health[0].name
   target_id = "aws_health_sns_warning"

--- a/aws/common/cloudwatch_log.tf
+++ b/aws/common/cloudwatch_log.tf
@@ -2,7 +2,7 @@
 # AWS CloudWatch Log Groups
 ###
 resource "aws_cloudwatch_log_group" "sns_deliveries" {
-  provider = aws.core_services
+  provider          = aws.core_services
   count             = var.cloudwatch_enabled ? 1 : 0
   name              = "sns/${var.region}/${var.account_id}/DirectPublishToPhoneNumber"
   retention_in_days = var.sensitive_log_retention_period_days
@@ -12,7 +12,7 @@ resource "aws_cloudwatch_log_group" "sns_deliveries" {
 }
 
 resource "aws_cloudwatch_log_group" "sns_deliveries_failures" {
-  provider = aws.core_services
+  provider          = aws.core_services
   count             = var.cloudwatch_enabled ? 1 : 0
   name              = "sns/${var.region}/${var.account_id}/DirectPublishToPhoneNumber/Failure"
   retention_in_days = var.sensitive_log_retention_period_days
@@ -88,8 +88,8 @@ resource "aws_cloudwatch_log_resource_policy" "route53_resolver_query_logging_po
 ###
 resource "aws_cloudwatch_log_metric_filter" "sns-sms-blocked-as-spam" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "sns-sms-blocked-as-spam"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "sns-sms-blocked-as-spam"
   # See https://docs.amazonaws.cn/en_us/sns/latest/dg/sms_stats_cloudwatch.html#sms_stats_delivery_fail_reasons
   pattern        = "{ $.delivery.providerResponse = \"Blocked as spam by phone carrier\" }"
   log_group_name = aws_cloudwatch_log_group.sns_deliveries_failures[0].name
@@ -121,8 +121,8 @@ resource "aws_cloudwatch_log_metric_filter" "sns-sms-blocked-as-spam-us-west-2" 
 
 resource "aws_cloudwatch_log_metric_filter" "sns-sms-phone-carrier-unavailable" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "sns-sms-phone-carrier-unavailable"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "sns-sms-phone-carrier-unavailable"
   # See https://docs.amazonaws.cn/en_us/sns/latest/dg/sms_stats_cloudwatch.html#sms_stats_delivery_fail_reasons
   pattern        = "{ $.delivery.providerResponse = \"Phone carrier is currently unreachable/unavailable\" }"
   log_group_name = aws_cloudwatch_log_group.sns_deliveries_failures[0].name
@@ -154,8 +154,8 @@ resource "aws_cloudwatch_log_metric_filter" "sns-sms-phone-carrier-unavailable-u
 
 resource "aws_cloudwatch_log_metric_filter" "sns-sms-rate-exceeded" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "sns-sms-rate-exceeded"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "sns-sms-rate-exceeded"
   # See https://docs.amazonaws.cn/en_us/sns/latest/dg/sms_stats_cloudwatch.html#sms_stats_delivery_fail_reasons
   # https://docs.aws.amazon.com/sns/latest/dg/channels-sms-originating-identities-long-codes.html
   # Canadian long code numbers are limited at 1 SMS per second/number

--- a/aws/common/cloudwatch_log.tf
+++ b/aws/common/cloudwatch_log.tf
@@ -2,6 +2,7 @@
 # AWS CloudWatch Log Groups
 ###
 resource "aws_cloudwatch_log_group" "sns_deliveries" {
+  provider = aws.core_services
   count             = var.cloudwatch_enabled ? 1 : 0
   name              = "sns/${var.region}/${var.account_id}/DirectPublishToPhoneNumber"
   retention_in_days = var.sensitive_log_retention_period_days
@@ -11,6 +12,7 @@ resource "aws_cloudwatch_log_group" "sns_deliveries" {
 }
 
 resource "aws_cloudwatch_log_group" "sns_deliveries_failures" {
+  provider = aws.core_services
   count             = var.cloudwatch_enabled ? 1 : 0
   name              = "sns/${var.region}/${var.account_id}/DirectPublishToPhoneNumber/Failure"
   retention_in_days = var.sensitive_log_retention_period_days
@@ -85,6 +87,7 @@ resource "aws_cloudwatch_log_resource_policy" "route53_resolver_query_logging_po
 # AWS CloudWatch Logs Metrics
 ###
 resource "aws_cloudwatch_log_metric_filter" "sns-sms-blocked-as-spam" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "sns-sms-blocked-as-spam"
   # See https://docs.amazonaws.cn/en_us/sns/latest/dg/sms_stats_cloudwatch.html#sms_stats_delivery_fail_reasons
@@ -117,6 +120,7 @@ resource "aws_cloudwatch_log_metric_filter" "sns-sms-blocked-as-spam-us-west-2" 
 }
 
 resource "aws_cloudwatch_log_metric_filter" "sns-sms-phone-carrier-unavailable" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "sns-sms-phone-carrier-unavailable"
   # See https://docs.amazonaws.cn/en_us/sns/latest/dg/sms_stats_cloudwatch.html#sms_stats_delivery_fail_reasons
@@ -149,6 +153,7 @@ resource "aws_cloudwatch_log_metric_filter" "sns-sms-phone-carrier-unavailable-u
 }
 
 resource "aws_cloudwatch_log_metric_filter" "sns-sms-rate-exceeded" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "sns-sms-rate-exceeded"
   # See https://docs.amazonaws.cn/en_us/sns/latest/dg/sms_stats_cloudwatch.html#sms_stats_delivery_fail_reasons

--- a/aws/common/cloudwatch_queries.tf
+++ b/aws/common/cloudwatch_queries.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_query_definition" "sms-sns-blocked-as-spam" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "SMS (SNS) / Block as spam"
 
@@ -16,6 +17,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "sms-sns-carrier-dwell-times" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "SMS (SNS) / Carrier dwell times"
 
@@ -31,6 +33,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "sms-sns-get-failures" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "SMS (SNS) / Get failures"
 
@@ -47,6 +50,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "sms-sns-get-sms-logs-by-phone-number" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "SMS (SNS) / Get SMS logs by phone number"
 
@@ -66,6 +70,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "sms-sns-international-sending-status" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "SMS (SNS) / International sending status"
 
@@ -84,6 +89,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "sms-sns-success-vs-unreachable" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "SMS (SNS) / Success vs Unreachable"
 
@@ -102,6 +108,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "sms-sns-unreachable-phone-numbers" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "SMS (SNS) / Unreachable phone numbers"
 

--- a/aws/common/cloudwatch_queries.tf
+++ b/aws/common/cloudwatch_queries.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_query_definition" "sms-sns-blocked-as-spam" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "SMS (SNS) / Block as spam"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "SMS (SNS) / Block as spam"
 
   log_group_names = [
     aws_cloudwatch_log_group.sns_deliveries_failures[0].name
@@ -18,8 +18,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "sms-sns-carrier-dwell-times" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "SMS (SNS) / Carrier dwell times"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "SMS (SNS) / Carrier dwell times"
 
   log_group_names = [
     aws_cloudwatch_log_group.sns_deliveries[0].name,
@@ -34,8 +34,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "sms-sns-get-failures" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "SMS (SNS) / Get failures"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "SMS (SNS) / Get failures"
 
   log_group_names = [
     aws_cloudwatch_log_group.sns_deliveries_failures[0].name
@@ -51,8 +51,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "sms-sns-get-sms-logs-by-phone-number" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "SMS (SNS) / Get SMS logs by phone number"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "SMS (SNS) / Get SMS logs by phone number"
 
   log_group_names = [
     aws_cloudwatch_log_group.sns_deliveries[0].name,
@@ -71,8 +71,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "sms-sns-international-sending-status" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "SMS (SNS) / International sending status"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "SMS (SNS) / International sending status"
 
   log_group_names = [
     aws_cloudwatch_log_group.sns_deliveries[0].name,
@@ -90,8 +90,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "sms-sns-success-vs-unreachable" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "SMS (SNS) / Success vs Unreachable"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "SMS (SNS) / Success vs Unreachable"
 
   log_group_names = [
     aws_cloudwatch_log_group.sns_deliveries[0].name,
@@ -109,8 +109,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "sms-sns-unreachable-phone-numbers" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "SMS (SNS) / Unreachable phone numbers"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "SMS (SNS) / Unreachable phone numbers"
 
   log_group_names = [
     aws_cloudwatch_log_group.sns_deliveries_failures[0].name

--- a/aws/common/dashboards.tf
+++ b/aws/common/dashboards.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_dashboard" "redis_batch_saving" {
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   dashboard_name = "Redis-batch-saving"
   dashboard_body = <<EOF
@@ -180,6 +181,7 @@ EOF
 }
 
 resource "aws_cloudwatch_dashboard" "queues" {
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   dashboard_name = "Queues"
   dashboard_body = <<EOF
@@ -257,6 +259,7 @@ EOF
 }
 
 resource "aws_cloudwatch_dashboard" "sms" {
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   dashboard_name = "SMS"
   dashboard_body = <<EOF
@@ -816,6 +819,7 @@ EOF
 
 
 resource "aws_cloudwatch_dashboard" "sensitive" {
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   dashboard_name = "Platform-admin-access-of-sensitive-services"
   dashboard_body = <<EOF

--- a/aws/common/dashboards_email.tf
+++ b/aws/common/dashboards_email.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_dashboard" "emails" {
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   dashboard_name = "Emails"
   dashboard_body = <<EOF
@@ -376,6 +377,7 @@ EOF
 }
 
 resource "aws_cloudwatch_dashboard" "email-bounce_rate" {
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   dashboard_name = "Email_Bounce_Rate"
   dashboard_body = <<EOF

--- a/aws/common/kms.tf
+++ b/aws/common/kms.tf
@@ -10,6 +10,7 @@ resource "aws_kms_key" "notification-canada-ca" {
   tags = {
     Name       = "notification-canada-ca"
     CostCenter = "notification-canada-ca-${var.env}"
+    ssc_cbrid  = "22DH"
   }
 }
 
@@ -128,6 +129,7 @@ EOF
   tags = {
     Name       = "notification-canada-ca"
     CostCenter = "notification-canada-ca-${var.env}"
+    ssc_cbrid  = "22DH"
   }
 }
 
@@ -173,5 +175,6 @@ EOF
   tags = {
     Name       = "notification-canada-ca"
     CostCenter = "notification-canada-ca-${var.env}"
+    ssc_cbrid  = "22DH"
   }
 }

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -6,6 +6,7 @@
 
 
 resource "aws_cloudwatch_metric_alarm" "coredns-nxdomain-notification-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "coredns-nxdomain-notification-warning"
   alarm_description   = "More than 30 NXDOMAIN responses containing the basedomain in CoreDNS logs in 5 minutes"
@@ -22,6 +23,7 @@ resource "aws_cloudwatch_metric_alarm" "coredns-nxdomain-notification-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "load-balancer-1-500-error-1-minute-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "load-balancer-1-500-error-1-minute-warning"
   alarm_description   = "One 500 error in 1 minute"
@@ -40,6 +42,7 @@ resource "aws_cloudwatch_metric_alarm" "load-balancer-1-500-error-1-minute-warni
 }
 
 resource "aws_cloudwatch_metric_alarm" "load-balancer-10-500-error-5-minutes-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "load-balancer-10-500-error-5-minutes-critical"
   alarm_description   = "Ten 500 errors in 5 minutes"
@@ -60,6 +63,7 @@ resource "aws_cloudwatch_metric_alarm" "load-balancer-10-500-error-5-minutes-cri
 }
 
 resource "aws_cloudwatch_metric_alarm" "load-balancer-1-502-error-1-minute-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "load-balancer-1-502-error-1-minute-warning"
   alarm_description   = "One 502 error in 1 minute"
@@ -78,6 +82,7 @@ resource "aws_cloudwatch_metric_alarm" "load-balancer-1-502-error-1-minute-warni
 }
 
 resource "aws_cloudwatch_metric_alarm" "load-balancer-10-502-error-5-minutes-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "load-balancer-10-502-error-5-minutes-critical"
   alarm_description   = "Ten 502 errors in 5 minutes"
@@ -97,6 +102,7 @@ resource "aws_cloudwatch_metric_alarm" "load-balancer-10-502-error-5-minutes-cri
 }
 
 resource "aws_cloudwatch_metric_alarm" "document-download-api-high-request-count-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "document-download-api-high-request-count-warning"
   alarm_description   = "More than 300 4XX requests in 10 minutes on ${aws_alb_target_group.notification-canada-ca-document-api.name} target group"
@@ -119,6 +125,7 @@ resource "aws_cloudwatch_metric_alarm" "document-download-api-high-request-count
 
 # UNKNOWN — most sensitive, these are unexpected errors
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-unknown-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-unknown-warning"
   alarm_description   = "One unclassified Celery error in 1 minute"
@@ -135,6 +142,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-unknown-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-unknown-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-unknown-critical"
   alarm_description   = "Ten unclassified Celery errors in 1 minute"
@@ -152,6 +160,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-unknown-critical" {
 
 # DUPLICATE_RECORD
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-duplicate-record-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-duplicate-record-warning"
   alarm_description   = "50 Celery duplicate record errors in 1 minute"
@@ -168,6 +177,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-duplicate-record-warni
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-duplicate-record-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-duplicate-record-critical"
   alarm_description   = "200 Celery duplicate record errors in 1 minute"
@@ -185,6 +195,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-duplicate-record-criti
 
 # JOB_INCOMPLETE
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-job-incomplete-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-job-incomplete-warning"
   alarm_description   = "One Celery job incomplete error in 1 minute"
@@ -201,6 +212,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-job-incomplete-warning
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-job-incomplete-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-job-incomplete-critical"
   alarm_description   = "Ten Celery job incomplete errors in 1 minute"
@@ -218,6 +230,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-job-incomplete-critica
 
 # METRICS
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-metrics-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-metrics-warning"
   alarm_description   = "30 Celery metrics related error in 1 minute"
@@ -234,6 +247,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-metrics-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-metrics-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-metrics-critical"
   alarm_description   = "60 Celery metrics related errors in 1 minute"
@@ -251,6 +265,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-metrics-critical" {
 
 # NOTIFICATION_NOT_FOUND
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-notification-not-found-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-notification-not-found-warning"
   alarm_description   = "50 Celery notifications not found errors in 1 minute"
@@ -267,6 +282,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-notification-not-found
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-notification-not-found-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-notification-not-found-critical"
   alarm_description   = "200 Celery notifications not found errors in 1 minute"
@@ -284,6 +300,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-notification-not-found
 
 # SHUTDOWN
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-shutdown-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-shutdown-warning"
   alarm_description   = "10 Celery shutdown errors in 1 minute"
@@ -300,6 +317,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-shutdown-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-shutdown-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-shutdown-critical"
   alarm_description   = "20 Celery shutdown errors in 1 minute"
@@ -317,6 +335,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-shutdown-critical" {
 
 # THROTTLING
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-throttling-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-throttling-warning"
   alarm_description   = "1000 Celery throttling errors in 1 minute"
@@ -333,6 +352,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-throttling-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-throttling-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-throttling-critical"
   alarm_description   = "3000 Celery throttling errors in 1 minute"
@@ -350,6 +370,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-throttling-critical" {
 
 # NOTIFICATIONS TIMEOUT
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-timeout-notification-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-timeout-warning"
   alarm_description   = "Warning notification timeout error in 1 minute"
@@ -366,6 +387,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-timeout-notification-w
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-timeout-notification-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-timeout-notification-critical"
   alarm_description   = "Critical notification timeout errors in 1 minute"
@@ -383,6 +405,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-timeout-notification-c
 
 # CLIENTS TIMEOUT
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-timeout-client-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-timeout-client-warning"
   alarm_description   = "Warning client timeout error in 1 minute"
@@ -399,6 +422,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-timeout-client-warning
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-timeout-client-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-timeout-client-critical"
   alarm_description   = "Critical for client timeout errors in 1 minute"
@@ -416,6 +440,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-timeout-client-critica
 
 # XRAY
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-xray-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-xray-warning"
   alarm_description   = "Five Celery X-Ray errors in 1 minute"
@@ -432,6 +457,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-xray-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-xray-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-xray-critical"
   alarm_description   = "Twenty-five Celery X-Ray errors in 1 minute"
@@ -449,6 +475,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-xray-critical" {
 ###### END OF CELERY ERROR CLASSIFICATION ALARMS ######
 
 resource "aws_cloudwatch_metric_alarm" "logs-1-500-error-1-minute-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-1-500-error-1-minute-warning"
   alarm_description   = "One 500 error in 1 minute"
@@ -464,6 +491,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-1-500-error-1-minute-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-10-500-error-5-minutes-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-10-500-error-5-minutes-critical"
   alarm_description   = "Ten 500 errors in 5 minutes"
@@ -480,6 +508,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-10-500-error-5-minutes-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "admin-pods-high-cpu-warning" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "admin-pods-high-cpu-warning"
   alarm_description         = "Average CPU of admin pods >=50% during 10 minutes"
@@ -501,6 +530,7 @@ resource "aws_cloudwatch_metric_alarm" "admin-pods-high-cpu-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "api-pods-high-cpu-warning" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "api-pods-high-cpu-warning"
   alarm_description         = "Average CPU of API pods >=50% during 10 minutes"
@@ -522,6 +552,7 @@ resource "aws_cloudwatch_metric_alarm" "api-pods-high-cpu-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-static-pods-high-cpu-warning" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "celery-core-tasks-static-pods-high-cpu-warning"
   alarm_description         = "Average CPU of celery-core-tasks-static pods >=50% during 10 minutes"
@@ -543,6 +574,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-static-pods-high-cpu-w
 }
 
 resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-scalable-pods-high-cpu-warning" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "celery-core-tasks-scalable-pods-high-cpu-warning"
   alarm_description         = "Average CPU of celery-core-tasks-scalable pods >=50% during 10 minutes"
@@ -564,6 +596,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-scalable-pods-high-cpu
 }
 
 resource "aws_cloudwatch_metric_alarm" "celery-sms-dedicated-static-pods-high-cpu-warning" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "celery-sms-dedicated-static-pods-high-cpu-warning"
   alarm_description         = "Average CPU of celery-sms-dedicated-static pods >=50% during 10 minutes"
@@ -586,6 +619,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-sms-dedicated-static-pods-high-cp
 
 
 resource "aws_cloudwatch_metric_alarm" "admin-pods-high-memory-warning" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "admin-pods-high-memory-warning"
   alarm_description         = "Average memory of admin pods >=50% during 10 minutes"
@@ -607,6 +641,7 @@ resource "aws_cloudwatch_metric_alarm" "admin-pods-high-memory-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "api-pods-high-memory-warning" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "api-pods-high-memory-warning"
   alarm_description         = "Average memory of API pods >=50% during 10 minutes"
@@ -628,6 +663,7 @@ resource "aws_cloudwatch_metric_alarm" "api-pods-high-memory-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-static-pods-high-memory-warning" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "celery-core-tasks-static-pods-high-memory-warning"
   alarm_description         = "Average memory of celery-core-tasks-static pods >=50% during 10 minutes"
@@ -649,6 +685,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-static-pods-high-memor
 }
 
 resource "aws_cloudwatch_metric_alarm" "celery-sms-dedicated-static-pods-high-memory-warning" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "celery-sms-dedicated-static-pods-high-memory-warning"
   alarm_description         = "Average memory of celery-sms-dedicated-static >=50% during 10 minutes"
@@ -670,6 +707,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-sms-dedicated-static-pods-high-me
 }
 
 resource "aws_cloudwatch_metric_alarm" "ddos-detected-load-balancer-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "ddos-detected-load-balancer-critical"
   alarm_description   = "DDoS has been detected on the load balancer"
@@ -689,6 +727,7 @@ resource "aws_cloudwatch_metric_alarm" "ddos-detected-load-balancer-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-1-malware-detected-1-minute-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-1-malware-detected-1-minute-warning"
   alarm_description   = "One malware detected error in 1 minute"
@@ -704,6 +743,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-1-malware-detected-1-minute-warning
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-10-malware-detected-1-minute-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-10-malware-detected-1-minute-critical"
   alarm_description   = "Ten malware detected errors in 1 minute"
@@ -720,6 +760,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-10-malware-detected-1-minute-critic
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-1-malware-scan-timeout-1-minute-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-1-malware-scan-timeout-1-minute-warning"
   alarm_description   = "One malware scan timeout detected error in 1 minute"
@@ -740,6 +781,7 @@ moved {
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-1-bounce-rate-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-1-bounce-rate-critical"
   alarm_description   = "Bounce rate exceeding 10% in a 12 hour period"
@@ -756,6 +798,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-1-bounce-rate-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "kubernetes-failed-nodes" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "kubernetes-failed-nodes"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -782,6 +825,7 @@ resource "aws_cloudwatch_metric_alarm" "kubernetes-failed-nodes" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-static-replicas-unavailable" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "celery-core-tasks-static-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -811,6 +855,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-static-replicas-unavai
 
 
 resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-scalable-replicas-unavailable" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "celery-core-tasks-scalable-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -839,6 +884,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-scalable-replicas-unav
 }
 
 resource "aws_cloudwatch_metric_alarm" "celery-beat-replicas-unavailable" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "celery-beat-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -867,6 +913,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-beat-replicas-unavailable" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "celery-sms-dedicated-static-replicas-unavailable" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "celery-sms-dedicated-static-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -895,6 +942,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-sms-dedicated-static-replicas-una
 }
 
 resource "aws_cloudwatch_metric_alarm" "celery-email-send-static-replicas-unavailable" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "celery-email-send-static-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -924,6 +972,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-email-send-static-replicas-unavai
 
 
 resource "aws_cloudwatch_metric_alarm" "celery-email-send-scalable-replicas-unavailable" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "celery-email-send-scalable-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -952,6 +1001,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-email-send-scalable-replicas-unav
 }
 
 resource "aws_cloudwatch_metric_alarm" "celery-sms-send-static-replicas-unavailable" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "celery-sms-send-static-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -981,6 +1031,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-sms-send-static-replicas-unavaila
 
 
 resource "aws_cloudwatch_metric_alarm" "celery-sms-send-scalable-replicas-unavailable" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "celery-sms-send-scalable-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -1009,6 +1060,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-sms-send-scalable-replicas-unavai
 }
 
 resource "aws_cloudwatch_metric_alarm" "admin-replicas-unavailable" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "admin-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -1037,6 +1089,7 @@ resource "aws_cloudwatch_metric_alarm" "admin-replicas-unavailable" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "api-replicas-unavailable" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "api-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -1065,6 +1118,7 @@ resource "aws_cloudwatch_metric_alarm" "api-replicas-unavailable" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "documentation-replicas-unavailable" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "documentation-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -1093,6 +1147,7 @@ resource "aws_cloudwatch_metric_alarm" "documentation-replicas-unavailable" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "document-download-api-replicas-unavailable" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "document-download-api-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -1121,6 +1176,7 @@ resource "aws_cloudwatch_metric_alarm" "document-download-api-replicas-unavailab
 }
 
 resource "aws_cloudwatch_metric_alarm" "api-evicted-pods" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "evicted-api-pods-detected"
   alarm_description         = "One or more Kubernetes API Pods is reporting as Evicted"
@@ -1138,6 +1194,7 @@ resource "aws_cloudwatch_metric_alarm" "api-evicted-pods" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "celery-evicted-pods" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "evicted-celery-pods-detected"
   alarm_description         = "One or more Kubernetes Celery Pods is reporting as Evicted"
@@ -1155,6 +1212,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-evicted-pods" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "admin-evicted-pods" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "evicted-admin-pods-detected"
   alarm_description         = "One or more Kubernetes Admin Pods is reporting as Evicted"
@@ -1172,6 +1230,7 @@ resource "aws_cloudwatch_metric_alarm" "admin-evicted-pods" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "document-download-evicted-pods" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "evicted-document-download-pods-detected"
   alarm_description         = "One or more Kubernetes Document Download Pods is reporting as Evicted"
@@ -1189,6 +1248,7 @@ resource "aws_cloudwatch_metric_alarm" "document-download-evicted-pods" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "documentation-evicted-pods" {
+  provider = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "evicted-documentation-pods-detected"
   alarm_description         = "One or more Kubernetes Documentation Pods is reporting as Evicted"
@@ -1206,6 +1266,7 @@ resource "aws_cloudwatch_metric_alarm" "documentation-evicted-pods" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "karpenter-replicas-unavailable" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "karpenter-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -1234,6 +1295,7 @@ resource "aws_cloudwatch_metric_alarm" "karpenter-replicas-unavailable" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "aggregating-queues-not-active-1-minute-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "aggregating-queues-not-active-1-minute-warning"
   alarm_description   = "Beat inbox tasks have not been active for one minute"
@@ -1249,6 +1311,7 @@ resource "aws_cloudwatch_metric_alarm" "aggregating-queues-not-active-1-minute-w
 }
 
 resource "aws_cloudwatch_metric_alarm" "aggregating-queues-not-active-5-minutes-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "aggregating-queues-not-active-5-minutes-critical"
   alarm_description   = "Beat inbox tasks have not been active for 5 minutes"
@@ -1265,6 +1328,7 @@ resource "aws_cloudwatch_metric_alarm" "aggregating-queues-not-active-5-minutes-
 }
 
 resource "aws_cloudwatch_metric_alarm" "service-callback-too-many-failures-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "service-callback-too-many-failures-warning"
   alarm_description   = "Service reached the max number of callback retries 25 times in 5 minutes"
@@ -1280,6 +1344,7 @@ resource "aws_cloudwatch_metric_alarm" "service-callback-too-many-failures-warni
 }
 
 resource "aws_cloudwatch_metric_alarm" "service-callback-too-many-failures-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "service-callback-too-many-failures-critical"
   alarm_description   = "Service reached the max number of callback retries 100 times in 10 minutes"
@@ -1297,6 +1362,7 @@ resource "aws_cloudwatch_metric_alarm" "service-callback-too-many-failures-criti
 
 
 resource "aws_cloudwatch_metric_alarm" "db-migration-failure-critical" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "db-migration-failure-critical"
   alarm_description   = "The database migration running in the api k8s pods has failed"
@@ -1314,6 +1380,7 @@ resource "aws_cloudwatch_metric_alarm" "db-migration-failure-critical" {
 
 
 resource "aws_cloudwatch_metric_alarm" "logs-1-oom-error-1-minute-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-1-oom-error-1-minute-warning"
   alarm_description   = "One oom error in 1 minute"
@@ -1330,6 +1397,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-1-oom-error-1-minute-warning" {
 
 # both of these are set to warning atm
 resource "aws_cloudwatch_metric_alarm" "logs-10-oom-error-5-minute-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-10-oom-error-5-minute-warning"
   alarm_description   = "Ten oom errors in 5 minute"
@@ -1347,6 +1415,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-10-oom-error-5-minute-warning" {
 ### Velero
 
 resource "aws_cloudwatch_metric_alarm" "logs-1-velero-error-5-minute-warning" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-1-velero-error-5-minute-warning"
   alarm_description   = "Errors In Velero. Verify Backup Status"
@@ -1362,6 +1431,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-1-velero-error-5-minute-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "velero_deployment_unavailable" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "velero-deployment-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -1389,6 +1459,7 @@ resource "aws_cloudwatch_metric_alarm" "velero_deployment_unavailable" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "velero_daemonset_unavailable" {
+  provider = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "velero-daemonset-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -6,7 +6,7 @@
 
 
 resource "aws_cloudwatch_metric_alarm" "coredns-nxdomain-notification-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "coredns-nxdomain-notification-warning"
   alarm_description   = "More than 30 NXDOMAIN responses containing the basedomain in CoreDNS logs in 5 minutes"
@@ -23,7 +23,7 @@ resource "aws_cloudwatch_metric_alarm" "coredns-nxdomain-notification-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "load-balancer-1-500-error-1-minute-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "load-balancer-1-500-error-1-minute-warning"
   alarm_description   = "One 500 error in 1 minute"
@@ -42,7 +42,7 @@ resource "aws_cloudwatch_metric_alarm" "load-balancer-1-500-error-1-minute-warni
 }
 
 resource "aws_cloudwatch_metric_alarm" "load-balancer-10-500-error-5-minutes-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "load-balancer-10-500-error-5-minutes-critical"
   alarm_description   = "Ten 500 errors in 5 minutes"
@@ -63,7 +63,7 @@ resource "aws_cloudwatch_metric_alarm" "load-balancer-10-500-error-5-minutes-cri
 }
 
 resource "aws_cloudwatch_metric_alarm" "load-balancer-1-502-error-1-minute-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "load-balancer-1-502-error-1-minute-warning"
   alarm_description   = "One 502 error in 1 minute"
@@ -82,7 +82,7 @@ resource "aws_cloudwatch_metric_alarm" "load-balancer-1-502-error-1-minute-warni
 }
 
 resource "aws_cloudwatch_metric_alarm" "load-balancer-10-502-error-5-minutes-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "load-balancer-10-502-error-5-minutes-critical"
   alarm_description   = "Ten 502 errors in 5 minutes"
@@ -102,7 +102,7 @@ resource "aws_cloudwatch_metric_alarm" "load-balancer-10-502-error-5-minutes-cri
 }
 
 resource "aws_cloudwatch_metric_alarm" "document-download-api-high-request-count-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "document-download-api-high-request-count-warning"
   alarm_description   = "More than 300 4XX requests in 10 minutes on ${aws_alb_target_group.notification-canada-ca-document-api.name} target group"
@@ -125,7 +125,7 @@ resource "aws_cloudwatch_metric_alarm" "document-download-api-high-request-count
 
 # UNKNOWN — most sensitive, these are unexpected errors
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-unknown-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-unknown-warning"
   alarm_description   = "One unclassified Celery error in 1 minute"
@@ -142,7 +142,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-unknown-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-unknown-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-unknown-critical"
   alarm_description   = "Ten unclassified Celery errors in 1 minute"
@@ -160,7 +160,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-unknown-critical" {
 
 # DUPLICATE_RECORD
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-duplicate-record-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-duplicate-record-warning"
   alarm_description   = "50 Celery duplicate record errors in 1 minute"
@@ -177,7 +177,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-duplicate-record-warni
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-duplicate-record-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-duplicate-record-critical"
   alarm_description   = "200 Celery duplicate record errors in 1 minute"
@@ -195,7 +195,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-duplicate-record-criti
 
 # JOB_INCOMPLETE
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-job-incomplete-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-job-incomplete-warning"
   alarm_description   = "One Celery job incomplete error in 1 minute"
@@ -212,7 +212,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-job-incomplete-warning
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-job-incomplete-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-job-incomplete-critical"
   alarm_description   = "Ten Celery job incomplete errors in 1 minute"
@@ -230,7 +230,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-job-incomplete-critica
 
 # METRICS
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-metrics-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-metrics-warning"
   alarm_description   = "30 Celery metrics related error in 1 minute"
@@ -247,7 +247,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-metrics-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-metrics-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-metrics-critical"
   alarm_description   = "60 Celery metrics related errors in 1 minute"
@@ -265,7 +265,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-metrics-critical" {
 
 # NOTIFICATION_NOT_FOUND
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-notification-not-found-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-notification-not-found-warning"
   alarm_description   = "50 Celery notifications not found errors in 1 minute"
@@ -282,7 +282,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-notification-not-found
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-notification-not-found-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-notification-not-found-critical"
   alarm_description   = "200 Celery notifications not found errors in 1 minute"
@@ -300,7 +300,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-notification-not-found
 
 # SHUTDOWN
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-shutdown-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-shutdown-warning"
   alarm_description   = "10 Celery shutdown errors in 1 minute"
@@ -317,7 +317,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-shutdown-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-shutdown-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-shutdown-critical"
   alarm_description   = "20 Celery shutdown errors in 1 minute"
@@ -335,7 +335,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-shutdown-critical" {
 
 # THROTTLING
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-throttling-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-throttling-warning"
   alarm_description   = "1000 Celery throttling errors in 1 minute"
@@ -352,7 +352,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-throttling-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-throttling-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-throttling-critical"
   alarm_description   = "3000 Celery throttling errors in 1 minute"
@@ -370,7 +370,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-throttling-critical" {
 
 # NOTIFICATIONS TIMEOUT
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-timeout-notification-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-timeout-warning"
   alarm_description   = "Warning notification timeout error in 1 minute"
@@ -387,7 +387,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-timeout-notification-w
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-timeout-notification-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-timeout-notification-critical"
   alarm_description   = "Critical notification timeout errors in 1 minute"
@@ -405,7 +405,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-timeout-notification-c
 
 # CLIENTS TIMEOUT
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-timeout-client-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-timeout-client-warning"
   alarm_description   = "Warning client timeout error in 1 minute"
@@ -422,7 +422,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-timeout-client-warning
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-timeout-client-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-timeout-client-critical"
   alarm_description   = "Critical for client timeout errors in 1 minute"
@@ -440,7 +440,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-timeout-client-critica
 
 # XRAY
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-xray-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-xray-warning"
   alarm_description   = "Five Celery X-Ray errors in 1 minute"
@@ -457,7 +457,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-xray-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-xray-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-celery-error-xray-critical"
   alarm_description   = "Twenty-five Celery X-Ray errors in 1 minute"
@@ -475,7 +475,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-xray-critical" {
 ###### END OF CELERY ERROR CLASSIFICATION ALARMS ######
 
 resource "aws_cloudwatch_metric_alarm" "logs-1-500-error-1-minute-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-1-500-error-1-minute-warning"
   alarm_description   = "One 500 error in 1 minute"
@@ -491,7 +491,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-1-500-error-1-minute-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-10-500-error-5-minutes-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-10-500-error-5-minutes-critical"
   alarm_description   = "Ten 500 errors in 5 minutes"
@@ -508,7 +508,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-10-500-error-5-minutes-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "admin-pods-high-cpu-warning" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "admin-pods-high-cpu-warning"
   alarm_description         = "Average CPU of admin pods >=50% during 10 minutes"
@@ -530,7 +530,7 @@ resource "aws_cloudwatch_metric_alarm" "admin-pods-high-cpu-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "api-pods-high-cpu-warning" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "api-pods-high-cpu-warning"
   alarm_description         = "Average CPU of API pods >=50% during 10 minutes"
@@ -552,7 +552,7 @@ resource "aws_cloudwatch_metric_alarm" "api-pods-high-cpu-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-static-pods-high-cpu-warning" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "celery-core-tasks-static-pods-high-cpu-warning"
   alarm_description         = "Average CPU of celery-core-tasks-static pods >=50% during 10 minutes"
@@ -574,7 +574,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-static-pods-high-cpu-w
 }
 
 resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-scalable-pods-high-cpu-warning" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "celery-core-tasks-scalable-pods-high-cpu-warning"
   alarm_description         = "Average CPU of celery-core-tasks-scalable pods >=50% during 10 minutes"
@@ -596,7 +596,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-scalable-pods-high-cpu
 }
 
 resource "aws_cloudwatch_metric_alarm" "celery-sms-dedicated-static-pods-high-cpu-warning" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "celery-sms-dedicated-static-pods-high-cpu-warning"
   alarm_description         = "Average CPU of celery-sms-dedicated-static pods >=50% during 10 minutes"
@@ -619,7 +619,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-sms-dedicated-static-pods-high-cp
 
 
 resource "aws_cloudwatch_metric_alarm" "admin-pods-high-memory-warning" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "admin-pods-high-memory-warning"
   alarm_description         = "Average memory of admin pods >=50% during 10 minutes"
@@ -641,7 +641,7 @@ resource "aws_cloudwatch_metric_alarm" "admin-pods-high-memory-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "api-pods-high-memory-warning" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "api-pods-high-memory-warning"
   alarm_description         = "Average memory of API pods >=50% during 10 minutes"
@@ -663,7 +663,7 @@ resource "aws_cloudwatch_metric_alarm" "api-pods-high-memory-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-static-pods-high-memory-warning" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "celery-core-tasks-static-pods-high-memory-warning"
   alarm_description         = "Average memory of celery-core-tasks-static pods >=50% during 10 minutes"
@@ -685,7 +685,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-static-pods-high-memor
 }
 
 resource "aws_cloudwatch_metric_alarm" "celery-sms-dedicated-static-pods-high-memory-warning" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "celery-sms-dedicated-static-pods-high-memory-warning"
   alarm_description         = "Average memory of celery-sms-dedicated-static >=50% during 10 minutes"
@@ -707,7 +707,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-sms-dedicated-static-pods-high-me
 }
 
 resource "aws_cloudwatch_metric_alarm" "ddos-detected-load-balancer-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "ddos-detected-load-balancer-critical"
   alarm_description   = "DDoS has been detected on the load balancer"
@@ -727,7 +727,7 @@ resource "aws_cloudwatch_metric_alarm" "ddos-detected-load-balancer-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-1-malware-detected-1-minute-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-1-malware-detected-1-minute-warning"
   alarm_description   = "One malware detected error in 1 minute"
@@ -743,7 +743,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-1-malware-detected-1-minute-warning
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-10-malware-detected-1-minute-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-10-malware-detected-1-minute-critical"
   alarm_description   = "Ten malware detected errors in 1 minute"
@@ -760,7 +760,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-10-malware-detected-1-minute-critic
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-1-malware-scan-timeout-1-minute-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-1-malware-scan-timeout-1-minute-warning"
   alarm_description   = "One malware scan timeout detected error in 1 minute"
@@ -781,7 +781,7 @@ moved {
 }
 
 resource "aws_cloudwatch_metric_alarm" "logs-1-bounce-rate-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-1-bounce-rate-critical"
   alarm_description   = "Bounce rate exceeding 10% in a 12 hour period"
@@ -798,7 +798,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-1-bounce-rate-critical" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "kubernetes-failed-nodes" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "kubernetes-failed-nodes"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -825,7 +825,7 @@ resource "aws_cloudwatch_metric_alarm" "kubernetes-failed-nodes" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-static-replicas-unavailable" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "celery-core-tasks-static-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -855,7 +855,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-static-replicas-unavai
 
 
 resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-scalable-replicas-unavailable" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "celery-core-tasks-scalable-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -884,7 +884,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-scalable-replicas-unav
 }
 
 resource "aws_cloudwatch_metric_alarm" "celery-beat-replicas-unavailable" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "celery-beat-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -913,7 +913,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-beat-replicas-unavailable" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "celery-sms-dedicated-static-replicas-unavailable" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "celery-sms-dedicated-static-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -942,7 +942,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-sms-dedicated-static-replicas-una
 }
 
 resource "aws_cloudwatch_metric_alarm" "celery-email-send-static-replicas-unavailable" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "celery-email-send-static-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -972,7 +972,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-email-send-static-replicas-unavai
 
 
 resource "aws_cloudwatch_metric_alarm" "celery-email-send-scalable-replicas-unavailable" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "celery-email-send-scalable-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -1001,7 +1001,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-email-send-scalable-replicas-unav
 }
 
 resource "aws_cloudwatch_metric_alarm" "celery-sms-send-static-replicas-unavailable" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "celery-sms-send-static-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -1031,7 +1031,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-sms-send-static-replicas-unavaila
 
 
 resource "aws_cloudwatch_metric_alarm" "celery-sms-send-scalable-replicas-unavailable" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "celery-sms-send-scalable-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -1060,7 +1060,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-sms-send-scalable-replicas-unavai
 }
 
 resource "aws_cloudwatch_metric_alarm" "admin-replicas-unavailable" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "admin-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -1089,7 +1089,7 @@ resource "aws_cloudwatch_metric_alarm" "admin-replicas-unavailable" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "api-replicas-unavailable" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "api-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -1118,7 +1118,7 @@ resource "aws_cloudwatch_metric_alarm" "api-replicas-unavailable" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "documentation-replicas-unavailable" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "documentation-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -1147,7 +1147,7 @@ resource "aws_cloudwatch_metric_alarm" "documentation-replicas-unavailable" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "document-download-api-replicas-unavailable" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "document-download-api-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -1176,7 +1176,7 @@ resource "aws_cloudwatch_metric_alarm" "document-download-api-replicas-unavailab
 }
 
 resource "aws_cloudwatch_metric_alarm" "api-evicted-pods" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "evicted-api-pods-detected"
   alarm_description         = "One or more Kubernetes API Pods is reporting as Evicted"
@@ -1194,7 +1194,7 @@ resource "aws_cloudwatch_metric_alarm" "api-evicted-pods" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "celery-evicted-pods" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "evicted-celery-pods-detected"
   alarm_description         = "One or more Kubernetes Celery Pods is reporting as Evicted"
@@ -1212,7 +1212,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-evicted-pods" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "admin-evicted-pods" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "evicted-admin-pods-detected"
   alarm_description         = "One or more Kubernetes Admin Pods is reporting as Evicted"
@@ -1230,7 +1230,7 @@ resource "aws_cloudwatch_metric_alarm" "admin-evicted-pods" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "document-download-evicted-pods" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "evicted-document-download-pods-detected"
   alarm_description         = "One or more Kubernetes Document Download Pods is reporting as Evicted"
@@ -1248,7 +1248,7 @@ resource "aws_cloudwatch_metric_alarm" "document-download-evicted-pods" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "documentation-evicted-pods" {
-  provider = aws.core_services
+  provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
   alarm_name                = "evicted-documentation-pods-detected"
   alarm_description         = "One or more Kubernetes Documentation Pods is reporting as Evicted"
@@ -1266,7 +1266,7 @@ resource "aws_cloudwatch_metric_alarm" "documentation-evicted-pods" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "karpenter-replicas-unavailable" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "karpenter-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -1295,7 +1295,7 @@ resource "aws_cloudwatch_metric_alarm" "karpenter-replicas-unavailable" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "aggregating-queues-not-active-1-minute-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "aggregating-queues-not-active-1-minute-warning"
   alarm_description   = "Beat inbox tasks have not been active for one minute"
@@ -1311,7 +1311,7 @@ resource "aws_cloudwatch_metric_alarm" "aggregating-queues-not-active-1-minute-w
 }
 
 resource "aws_cloudwatch_metric_alarm" "aggregating-queues-not-active-5-minutes-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "aggregating-queues-not-active-5-minutes-critical"
   alarm_description   = "Beat inbox tasks have not been active for 5 minutes"
@@ -1328,7 +1328,7 @@ resource "aws_cloudwatch_metric_alarm" "aggregating-queues-not-active-5-minutes-
 }
 
 resource "aws_cloudwatch_metric_alarm" "service-callback-too-many-failures-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "service-callback-too-many-failures-warning"
   alarm_description   = "Service reached the max number of callback retries 25 times in 5 minutes"
@@ -1344,7 +1344,7 @@ resource "aws_cloudwatch_metric_alarm" "service-callback-too-many-failures-warni
 }
 
 resource "aws_cloudwatch_metric_alarm" "service-callback-too-many-failures-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "service-callback-too-many-failures-critical"
   alarm_description   = "Service reached the max number of callback retries 100 times in 10 minutes"
@@ -1362,7 +1362,7 @@ resource "aws_cloudwatch_metric_alarm" "service-callback-too-many-failures-criti
 
 
 resource "aws_cloudwatch_metric_alarm" "db-migration-failure-critical" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "db-migration-failure-critical"
   alarm_description   = "The database migration running in the api k8s pods has failed"
@@ -1380,7 +1380,7 @@ resource "aws_cloudwatch_metric_alarm" "db-migration-failure-critical" {
 
 
 resource "aws_cloudwatch_metric_alarm" "logs-1-oom-error-1-minute-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-1-oom-error-1-minute-warning"
   alarm_description   = "One oom error in 1 minute"
@@ -1397,7 +1397,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-1-oom-error-1-minute-warning" {
 
 # both of these are set to warning atm
 resource "aws_cloudwatch_metric_alarm" "logs-10-oom-error-5-minute-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-10-oom-error-5-minute-warning"
   alarm_description   = "Ten oom errors in 5 minute"
@@ -1415,7 +1415,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-10-oom-error-5-minute-warning" {
 ### Velero
 
 resource "aws_cloudwatch_metric_alarm" "logs-1-velero-error-5-minute-warning" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "logs-1-velero-error-5-minute-warning"
   alarm_description   = "Errors In Velero. Verify Backup Status"
@@ -1431,7 +1431,7 @@ resource "aws_cloudwatch_metric_alarm" "logs-1-velero-error-5-minute-warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "velero_deployment_unavailable" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "velero-deployment-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -1459,7 +1459,7 @@ resource "aws_cloudwatch_metric_alarm" "velero_deployment_unavailable" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "velero_daemonset_unavailable" {
-  provider = aws.core_services
+  provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "velero-daemonset-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -3,35 +3,35 @@
 ###
 
 resource "aws_cloudwatch_log_group" "notification-canada-ca-eks-cluster-logs" {
-  provider = aws.core_services
+  provider          = aws.core_services
   count             = var.cloudwatch_enabled ? 1 : 0
   name              = "/aws/eks/${var.eks_cluster_name}/cluster"
   retention_in_days = var.log_retention_period_days
 }
 
 resource "aws_cloudwatch_log_group" "notification-canada-ca-eks-application-logs" {
-  provider = aws.core_services
+  provider          = aws.core_services
   count             = var.cloudwatch_enabled ? 1 : 0
   name              = "/aws/containerinsights/${var.eks_cluster_name}/application"
   retention_in_days = var.log_retention_period_days
 }
 
 resource "aws_cloudwatch_log_group" "notification-canada-ca-eks-prometheus-logs" {
-  provider = aws.core_services
+  provider          = aws.core_services
   count             = var.cloudwatch_enabled ? 1 : 0
   name              = "/aws/containerinsights/${var.eks_cluster_name}/prometheus"
   retention_in_days = var.log_retention_period_days
 }
 
 resource "aws_cloudwatch_log_group" "notification-canada-ca-eks-host-logs" {
-  provider = aws.core_services
+  provider          = aws.core_services
   count             = var.cloudwatch_enabled ? 1 : 0
   name              = "/aws/containerinsights/${var.eks_cluster_name}/host"
   retention_in_days = var.log_retention_period_days
 }
 
 resource "aws_cloudwatch_log_group" "blazer" {
-  provider = aws.core_services
+  provider          = aws.core_services
   count             = var.cloudwatch_enabled ? 1 : 0
   name              = "blazer"
   retention_in_days = 1827 # 5 years
@@ -42,7 +42,7 @@ resource "aws_cloudwatch_log_group" "blazer" {
 # AWS EKS Cloudwatch log metric filters
 ###
 resource "aws_cloudwatch_log_metric_filter" "web-500-errors" {
-  provider = aws.core_services
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "web-500-errors"
   pattern        = "{ ($.kubernetes.namespace_name = \"notification-canada-ca\") && ($.log = \"*\\\" 500 *\") }"
@@ -211,7 +211,7 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error-xray" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "malware-detected" {
-  provider = aws.core_services
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "malware-detected"
   pattern        = jsonencode("Malicious content detected! Download and attachment failed")
@@ -225,7 +225,7 @@ resource "aws_cloudwatch_log_metric_filter" "malware-detected" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "malware-scan-timeout" {
-  provider = aws.core_services
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "malware-scan-timeout"
   pattern        = "Malware scan timed out for notification.id"
@@ -244,7 +244,7 @@ moved {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "bounce-rate-critical" {
-  provider = aws.core_services
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "bounce-rate-critical"
   pattern        = "critical bounce rate threshold of 10"
@@ -258,7 +258,7 @@ resource "aws_cloudwatch_log_metric_filter" "bounce-rate-critical" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "api-evicted-pods" {
-  provider = aws.core_services
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "api-evicted-pods"
   pattern        = "{ ($.reason = \"Evicted\") && ($.kube_pod_status_reason = 1) && ($.pod = \"notify-api-*\") }"
@@ -272,7 +272,7 @@ resource "aws_cloudwatch_log_metric_filter" "api-evicted-pods" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "celery-evicted-pods" {
-  provider = aws.core_services
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "celery-evicted-pods"
   pattern        = "{ ($.reason = \"Evicted\") && ($.kube_pod_status_reason = 1) && ($.pod = \"notify-celery-*\") }"
@@ -286,7 +286,7 @@ resource "aws_cloudwatch_log_metric_filter" "celery-evicted-pods" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "admin-evicted-pods" {
-  provider = aws.core_services
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "admin-evicted-pods"
   pattern        = "{ ($.reason = \"Evicted\") && ($.kube_pod_status_reason = 1) && ($.pod = \"notify-admin-*\") }"
@@ -300,7 +300,7 @@ resource "aws_cloudwatch_log_metric_filter" "admin-evicted-pods" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "document-download-evicted-pods" {
-  provider = aws.core_services
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "document-download-evicted-pods"
   pattern        = "{ ($.reason = \"Evicted\") && ($.kube_pod_status_reason = 1) && ($.pod = \"notify-document-download-*\") }"
@@ -314,7 +314,7 @@ resource "aws_cloudwatch_log_metric_filter" "document-download-evicted-pods" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "documentation-evicted-pods" {
-  provider = aws.core_services
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "documentation-evicted-pods"
   pattern        = "{ ($.reason = \"Evicted\") && ($.kube_pod_status_reason = 1) && ($.pod = \"notify-documentation-*\") }"
@@ -328,7 +328,7 @@ resource "aws_cloudwatch_log_metric_filter" "documentation-evicted-pods" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "aggregating-queues-are-active" {
-  provider = aws.core_services
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "aggregating-queues-are-active"
   pattern        = "Batch saving with"
@@ -342,7 +342,7 @@ resource "aws_cloudwatch_log_metric_filter" "aggregating-queues-are-active" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "callback-request-failures" {
-  provider = aws.core_services
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "callback-request-failures"
   pattern        = "send_delivery_status_to_service request failed for notification_id"
@@ -356,7 +356,7 @@ resource "aws_cloudwatch_log_metric_filter" "callback-request-failures" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "throttling-exceptions" {
-  provider = aws.core_services
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "throttling-exceptions"
   pattern        = "{ ($.log = \"*ThrottlingException*\") && ($.log != \"*awscloudwatchreceiver*\") }"
@@ -370,7 +370,7 @@ resource "aws_cloudwatch_log_metric_filter" "throttling-exceptions" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "db-migration-failure" {
-  provider = aws.core_services
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "db-migration-failure"
   pattern        = "\"database migration failed\""
@@ -386,7 +386,7 @@ resource "aws_cloudwatch_log_metric_filter" "db-migration-failure" {
 
 # AWS EKS host log metric filters
 resource "aws_cloudwatch_log_metric_filter" "oom-errors" {
-  provider = aws.core_services
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "oom-errors"
   pattern        = "%Memory cgroup out of memory%"
@@ -404,7 +404,7 @@ resource "aws_cloudwatch_log_metric_filter" "oom-errors" {
 ###
 
 resource "aws_cloudwatch_log_metric_filter" "velero-error" {
-  provider = aws.core_services
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "velero-error"
   pattern        = "{ ($.kubernetes.pod_name = \"velero*\") && ($.log = *error*) && ($.log != *warning*) && ($.log != \"*file already closed*\")}"
@@ -422,7 +422,7 @@ resource "aws_cloudwatch_log_metric_filter" "velero-error" {
 ###
 
 resource "aws_cloudwatch_log_metric_filter" "coredns-nxdomain-notification-filter" {
-  provider = aws.core_services
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "CoreDNSNXDOMAINNotificationFilter"
   log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs[0].name

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -3,30 +3,35 @@
 ###
 
 resource "aws_cloudwatch_log_group" "notification-canada-ca-eks-cluster-logs" {
+  provider = aws.core_services
   count             = var.cloudwatch_enabled ? 1 : 0
   name              = "/aws/eks/${var.eks_cluster_name}/cluster"
   retention_in_days = var.log_retention_period_days
 }
 
 resource "aws_cloudwatch_log_group" "notification-canada-ca-eks-application-logs" {
+  provider = aws.core_services
   count             = var.cloudwatch_enabled ? 1 : 0
   name              = "/aws/containerinsights/${var.eks_cluster_name}/application"
   retention_in_days = var.log_retention_period_days
 }
 
 resource "aws_cloudwatch_log_group" "notification-canada-ca-eks-prometheus-logs" {
+  provider = aws.core_services
   count             = var.cloudwatch_enabled ? 1 : 0
   name              = "/aws/containerinsights/${var.eks_cluster_name}/prometheus"
   retention_in_days = var.log_retention_period_days
 }
 
 resource "aws_cloudwatch_log_group" "notification-canada-ca-eks-host-logs" {
+  provider = aws.core_services
   count             = var.cloudwatch_enabled ? 1 : 0
   name              = "/aws/containerinsights/${var.eks_cluster_name}/host"
   retention_in_days = var.log_retention_period_days
 }
 
 resource "aws_cloudwatch_log_group" "blazer" {
+  provider = aws.core_services
   count             = var.cloudwatch_enabled ? 1 : 0
   name              = "blazer"
   retention_in_days = 1827 # 5 years
@@ -37,6 +42,7 @@ resource "aws_cloudwatch_log_group" "blazer" {
 # AWS EKS Cloudwatch log metric filters
 ###
 resource "aws_cloudwatch_log_metric_filter" "web-500-errors" {
+  provider = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "web-500-errors"
   pattern        = "{ ($.kubernetes.namespace_name = \"notification-canada-ca\") && ($.log = \"*\\\" 500 *\") }"
@@ -50,6 +56,7 @@ resource "aws_cloudwatch_log_metric_filter" "web-500-errors" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "celery-error-unknown" {
+  provider = aws.core_services
   # This is a catch all log metric filter for Celery when unexpected errors occur. We need
   # to keep an eye on closely and monitor.
   count          = var.cloudwatch_enabled ? 1 : 0
@@ -65,6 +72,7 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error-unknown" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "celery-error-duplicate-record" {
+  provider = aws.core_services
   # This monitors for database duplicate record errors in Celery.
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "celery-error-duplicate-record"
@@ -79,6 +87,7 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error-duplicate-record" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "celery-error-job-incomplete" {
+  provider = aws.core_services
   # This monitors for incomplete jobs that couldn't be completed within Celery.
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "celery-error-job-incomplete"
@@ -93,6 +102,7 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error-job-incomplete" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "celery-error-metrics" {
+  provider = aws.core_services
   # This monitors for incomplete jobs that couldn't be completed within Celery.
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "celery-error-metrics"
@@ -107,6 +117,7 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error-metrics" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "celery-error-notification-not-found" {
+  provider = aws.core_services
   # This monitors for Celery errors when notifications were not found within the system.
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "celery-error-notification-not-found"
@@ -121,6 +132,7 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error-notification-not-found
 }
 
 resource "aws_cloudwatch_log_metric_filter" "celery-error-shutdown" {
+  provider = aws.core_services
   # This monitors for Celery workers shutting down.
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "celery-error-shutdown"
@@ -135,6 +147,7 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error-shutdown" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "celery-error-throttling" {
+  provider = aws.core_services
   # This monitors for Celery errors related to throttling, which could indicate performance issues
   # or capacity limits being hit.
   count          = var.cloudwatch_enabled ? 1 : 0
@@ -150,6 +163,7 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error-throttling" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "celery-error-timeout-client" {
+  provider = aws.core_services
   # This monitors for client library errors related to network timeouts occurring within Celery,
   # which could indicate performance issues or external dependencies not responding in time.
   count          = var.cloudwatch_enabled ? 1 : 0
@@ -165,6 +179,7 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error-timeout-client" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "celery-error-timeout-notification" {
+  provider = aws.core_services
   # This monitors for Celery errors related to network timeouts, which could indicate 
   # performance issues or external dependencies not responding in time.
   count          = var.cloudwatch_enabled ? 1 : 0
@@ -180,6 +195,7 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error-timeout-notification" 
 }
 
 resource "aws_cloudwatch_log_metric_filter" "celery-error-xray" {
+  provider = aws.core_services
   # This monitors for Celery errors related to AWS X-Ray, which could indicate issues
   # with observability tracing.
   count          = var.cloudwatch_enabled ? 1 : 0
@@ -195,6 +211,7 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error-xray" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "malware-detected" {
+  provider = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "malware-detected"
   pattern        = jsonencode("Malicious content detected! Download and attachment failed")
@@ -208,6 +225,7 @@ resource "aws_cloudwatch_log_metric_filter" "malware-detected" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "malware-scan-timeout" {
+  provider = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "malware-scan-timeout"
   pattern        = "Malware scan timed out for notification.id"
@@ -226,6 +244,7 @@ moved {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "bounce-rate-critical" {
+  provider = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "bounce-rate-critical"
   pattern        = "critical bounce rate threshold of 10"
@@ -239,6 +258,7 @@ resource "aws_cloudwatch_log_metric_filter" "bounce-rate-critical" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "api-evicted-pods" {
+  provider = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "api-evicted-pods"
   pattern        = "{ ($.reason = \"Evicted\") && ($.kube_pod_status_reason = 1) && ($.pod = \"notify-api-*\") }"
@@ -252,6 +272,7 @@ resource "aws_cloudwatch_log_metric_filter" "api-evicted-pods" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "celery-evicted-pods" {
+  provider = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "celery-evicted-pods"
   pattern        = "{ ($.reason = \"Evicted\") && ($.kube_pod_status_reason = 1) && ($.pod = \"notify-celery-*\") }"
@@ -265,6 +286,7 @@ resource "aws_cloudwatch_log_metric_filter" "celery-evicted-pods" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "admin-evicted-pods" {
+  provider = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "admin-evicted-pods"
   pattern        = "{ ($.reason = \"Evicted\") && ($.kube_pod_status_reason = 1) && ($.pod = \"notify-admin-*\") }"
@@ -278,6 +300,7 @@ resource "aws_cloudwatch_log_metric_filter" "admin-evicted-pods" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "document-download-evicted-pods" {
+  provider = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "document-download-evicted-pods"
   pattern        = "{ ($.reason = \"Evicted\") && ($.kube_pod_status_reason = 1) && ($.pod = \"notify-document-download-*\") }"
@@ -291,6 +314,7 @@ resource "aws_cloudwatch_log_metric_filter" "document-download-evicted-pods" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "documentation-evicted-pods" {
+  provider = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "documentation-evicted-pods"
   pattern        = "{ ($.reason = \"Evicted\") && ($.kube_pod_status_reason = 1) && ($.pod = \"notify-documentation-*\") }"
@@ -304,6 +328,7 @@ resource "aws_cloudwatch_log_metric_filter" "documentation-evicted-pods" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "aggregating-queues-are-active" {
+  provider = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "aggregating-queues-are-active"
   pattern        = "Batch saving with"
@@ -317,6 +342,7 @@ resource "aws_cloudwatch_log_metric_filter" "aggregating-queues-are-active" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "callback-request-failures" {
+  provider = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "callback-request-failures"
   pattern        = "send_delivery_status_to_service request failed for notification_id"
@@ -330,6 +356,7 @@ resource "aws_cloudwatch_log_metric_filter" "callback-request-failures" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "throttling-exceptions" {
+  provider = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "throttling-exceptions"
   pattern        = "{ ($.log = \"*ThrottlingException*\") && ($.log != \"*awscloudwatchreceiver*\") }"
@@ -343,6 +370,7 @@ resource "aws_cloudwatch_log_metric_filter" "throttling-exceptions" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "db-migration-failure" {
+  provider = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "db-migration-failure"
   pattern        = "\"database migration failed\""
@@ -358,6 +386,7 @@ resource "aws_cloudwatch_log_metric_filter" "db-migration-failure" {
 
 # AWS EKS host log metric filters
 resource "aws_cloudwatch_log_metric_filter" "oom-errors" {
+  provider = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "oom-errors"
   pattern        = "%Memory cgroup out of memory%"
@@ -375,6 +404,7 @@ resource "aws_cloudwatch_log_metric_filter" "oom-errors" {
 ###
 
 resource "aws_cloudwatch_log_metric_filter" "velero-error" {
+  provider = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "velero-error"
   pattern        = "{ ($.kubernetes.pod_name = \"velero*\") && ($.log = *error*) && ($.log != *warning*) && ($.log != \"*file already closed*\")}"
@@ -392,6 +422,7 @@ resource "aws_cloudwatch_log_metric_filter" "velero-error" {
 ###
 
 resource "aws_cloudwatch_log_metric_filter" "coredns-nxdomain-notification-filter" {
+  provider = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "CoreDNSNXDOMAINNotificationFilter"
   log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs[0].name

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -110,7 +110,7 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error-metrics" {
   log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs[0].name
 
   metric_transformation {
-    name      = "celery-error-metrics"
+    name      = "celery-error-job-incomplete"
     namespace = "LogMetrics"
     value     = "1"
   }

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -110,7 +110,7 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error-metrics" {
   log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs[0].name
 
   metric_transformation {
-    name      = "celery-error-job-incomplete"
+    name      = "celery-error-metrics"
     namespace = "LogMetrics"
     value     = "1"
   }

--- a/aws/eks/cloudwatch_queries.tf
+++ b/aws/eks/cloudwatch_queries.tf
@@ -325,7 +325,7 @@ QUERY
 resource "aws_cloudwatch_query_definition" "api-gunicorn-total-time" {
   provider = aws.core_services
   count    = var.cloudwatch_enabled ? 1 : 0
-  name     = "API / GUnicorn total running time"
+  name     = "API / Gunicorn total running time"
 
   log_group_names = [
     local.eks_application_log_group

--- a/aws/eks/cloudwatch_queries.tf
+++ b/aws/eks/cloudwatch_queries.tf
@@ -10,6 +10,7 @@ locals {
 ################################ CELERY FOLDER ################################
 
 resource "aws_cloudwatch_query_definition" "celery-errors" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Celery / Errors"
 
@@ -27,6 +28,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "celery-filter-by-job" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Celery / Filter by job"
 
@@ -44,6 +46,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "celery-filter-by-notification-id" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Celery / Filter by notification id"
 
@@ -61,6 +64,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "celery-memory-usage-by-pod" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Celery / Memory Usage By Pod"
 
@@ -77,6 +81,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "celery-pods-over-cpu-limit" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Celery / Pods over CPU Limit"
 
@@ -93,6 +98,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "celery-queues" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Celery / Queues"
 
@@ -110,6 +116,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "celery-starts" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Celery / Starts"
 
@@ -127,6 +134,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "celery-worker-exited-normally" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Celery / Worker exited normally"
 
@@ -143,6 +151,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "celery-worker-exited-prematurely" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Celery / Worker exited prematurely"
 
@@ -159,6 +168,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "celery-worker-exits-cold-vs-warm" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Celery / Worker exits, cold vs warm"
 
@@ -178,6 +188,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "retry-attemps-by-duration" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Celery / Retry attempts by duration"
 
@@ -195,6 +206,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "celery-count-known-errors" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Celery / Count of known errors"
 
@@ -214,6 +226,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "celery-unknown-errors" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Celery / Unknown errors"
 
@@ -232,6 +245,7 @@ QUERY
 ################################ UNSORTED YET #################################
 
 resource "aws_cloudwatch_query_definition" "admin-50X-errors" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Admin / 50X errors"
 
@@ -249,6 +263,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "admin-svc-audit-removed-users" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Admin / Service audit - removed users"
 
@@ -269,6 +284,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "admin-slow-dashboards" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Admin / Slow Dashboards"
 
@@ -289,6 +305,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "api-50X-errors" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "API / 50X errors"
 
@@ -306,6 +323,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "api-gunicorn-total-time" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "API / GUnicorn total running time"
 
@@ -322,6 +340,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "api-non-existent-domain-resolution-errors" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "API / Non-existent domain resolution errors"
 
@@ -336,6 +355,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "api-non-existent-domain-resolution-errors-stats" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "API / Non-existent domain resolution error stats"
 
@@ -354,6 +374,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "api-non-existent-domain-resolution-errors-stats-by-5-minutes" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "API / Non-existent domain resolution errors by 5 minutes"
 
@@ -373,6 +394,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "bounce-rate-critical" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Bounces / Critical bounces"
 
@@ -390,6 +412,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "bounce-rate-warning" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Bounces / Warning bounces"
 
@@ -407,6 +430,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "bounce-rate-warnings-and-criticals" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Bounces / Bounce warnings and criticals grouped by type"
 
@@ -425,6 +449,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "callback-errors-by-url" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Callbacks / Callback errors by URL"
 
@@ -443,6 +468,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "callback-max-retry-failures-by-service" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Callbacks / Callbacks that exceeded MaxRetries by service"
 
@@ -462,6 +488,7 @@ QUERY
 }
 
 resource "aws_cloudwatch_query_definition" "callback-failures" {
+  provider = aws.core_services
   count = var.cloudwatch_enabled ? 1 : 0
   name  = "Callbacks / Callback errors by notification_id"
 

--- a/aws/eks/cloudwatch_queries.tf
+++ b/aws/eks/cloudwatch_queries.tf
@@ -11,8 +11,8 @@ locals {
 
 resource "aws_cloudwatch_query_definition" "celery-errors" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "Celery / Errors"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "Celery / Errors"
 
   log_group_names = [
     local.eks_application_log_group
@@ -29,8 +29,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "celery-filter-by-job" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "Celery / Filter by job"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "Celery / Filter by job"
 
   log_group_names = [
     local.eks_application_log_group
@@ -47,8 +47,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "celery-filter-by-notification-id" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "Celery / Filter by notification id"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "Celery / Filter by notification id"
 
   log_group_names = [
     local.eks_application_log_group
@@ -65,8 +65,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "celery-memory-usage-by-pod" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "Celery / Memory Usage By Pod"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "Celery / Memory Usage By Pod"
 
   log_group_names = [
     local.eks_application_log_group
@@ -82,8 +82,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "celery-pods-over-cpu-limit" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "Celery / Pods over CPU Limit"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "Celery / Pods over CPU Limit"
 
   log_group_names = [
     local.eks_application_log_group
@@ -99,8 +99,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "celery-queues" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "Celery / Queues"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "Celery / Queues"
 
   log_group_names = [
     local.eks_application_log_group
@@ -117,8 +117,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "celery-starts" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "Celery / Starts"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "Celery / Starts"
 
   log_group_names = [
     local.eks_application_log_group
@@ -135,8 +135,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "celery-worker-exited-normally" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "Celery / Worker exited normally"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "Celery / Worker exited normally"
 
   log_group_names = [
     local.eks_application_log_group
@@ -152,8 +152,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "celery-worker-exited-prematurely" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "Celery / Worker exited prematurely"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "Celery / Worker exited prematurely"
 
   log_group_names = [
     local.eks_application_log_group
@@ -169,8 +169,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "celery-worker-exits-cold-vs-warm" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "Celery / Worker exits, cold vs warm"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "Celery / Worker exits, cold vs warm"
 
   log_group_names = [
     local.eks_application_log_group
@@ -189,8 +189,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "retry-attemps-by-duration" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "Celery / Retry attempts by duration"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "Celery / Retry attempts by duration"
 
   log_group_names = [
     local.eks_application_log_group
@@ -207,8 +207,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "celery-count-known-errors" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "Celery / Count of known errors"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "Celery / Count of known errors"
 
   log_group_names = [
     local.eks_application_log_group
@@ -227,8 +227,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "celery-unknown-errors" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "Celery / Unknown errors"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "Celery / Unknown errors"
 
   log_group_names = [
     local.eks_application_log_group
@@ -246,8 +246,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "admin-50X-errors" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "Admin / 50X errors"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "Admin / 50X errors"
 
   log_group_names = [
     local.eks_application_log_group
@@ -264,8 +264,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "admin-svc-audit-removed-users" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "Admin / Service audit - removed users"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "Admin / Service audit - removed users"
 
   log_group_names = [
     local.eks_application_log_group
@@ -285,8 +285,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "admin-slow-dashboards" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "Admin / Slow Dashboards"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "Admin / Slow Dashboards"
 
   log_group_names = [
     local.eks_application_log_group
@@ -306,8 +306,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "api-50X-errors" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "API / 50X errors"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "API / 50X errors"
 
   log_group_names = [
     local.eks_application_log_group
@@ -324,8 +324,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "api-gunicorn-total-time" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "API / GUnicorn total running time"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "API / GUnicorn total running time"
 
   log_group_names = [
     local.eks_application_log_group
@@ -341,8 +341,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "api-non-existent-domain-resolution-errors" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "API / Non-existent domain resolution errors"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "API / Non-existent domain resolution errors"
 
   log_group_names = [
     local.eks_application_log_group
@@ -356,8 +356,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "api-non-existent-domain-resolution-errors-stats" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "API / Non-existent domain resolution error stats"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "API / Non-existent domain resolution error stats"
 
   log_group_names = [
     local.eks_application_log_group
@@ -375,8 +375,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "api-non-existent-domain-resolution-errors-stats-by-5-minutes" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "API / Non-existent domain resolution errors by 5 minutes"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "API / Non-existent domain resolution errors by 5 minutes"
 
   log_group_names = [
     local.eks_application_log_group
@@ -395,8 +395,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "bounce-rate-critical" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "Bounces / Critical bounces"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "Bounces / Critical bounces"
 
   log_group_names = [
     local.eks_application_log_group
@@ -413,8 +413,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "bounce-rate-warning" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "Bounces / Warning bounces"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "Bounces / Warning bounces"
 
   log_group_names = [
     local.eks_application_log_group
@@ -431,8 +431,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "bounce-rate-warnings-and-criticals" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "Bounces / Bounce warnings and criticals grouped by type"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "Bounces / Bounce warnings and criticals grouped by type"
 
   log_group_names = [
     local.eks_application_log_group
@@ -450,8 +450,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "callback-errors-by-url" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "Callbacks / Callback errors by URL"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "Callbacks / Callback errors by URL"
 
   log_group_names = [
     local.eks_application_log_group
@@ -469,8 +469,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "callback-max-retry-failures-by-service" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "Callbacks / Callbacks that exceeded MaxRetries by service"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "Callbacks / Callbacks that exceeded MaxRetries by service"
 
   log_group_names = [
     local.eks_application_log_group
@@ -489,8 +489,8 @@ QUERY
 
 resource "aws_cloudwatch_query_definition" "callback-failures" {
   provider = aws.core_services
-  count = var.cloudwatch_enabled ? 1 : 0
-  name  = "Callbacks / Callback errors by notification_id"
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "Callbacks / Callback errors by notification_id"
 
   log_group_names = [
     local.eks_application_log_group

--- a/aws/eks/dashboards.tf
+++ b/aws/eks/dashboards.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_dashboard" "notify_system" {
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   dashboard_name = "Notify-System-Overview"
   dashboard_body = <<EOF
@@ -711,6 +712,7 @@ EOF
 }
 
 resource "aws_cloudwatch_dashboard" "elb" {
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   dashboard_name = "Elastic-Load-Balancers"
   dashboard_body = <<EOF
@@ -1010,6 +1012,7 @@ EOF
 }
 
 resource "aws_cloudwatch_dashboard" "errors" {
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   dashboard_name = "Errors"
   dashboard_body = <<EOF
@@ -1079,6 +1082,7 @@ EOF
 }
 
 resource "aws_cloudwatch_dashboard" "kubernetes" {
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   dashboard_name = "Kubernetes"
   dashboard_body = <<EOF
@@ -1219,6 +1223,7 @@ EOF
 }
 
 resource "aws_cloudwatch_dashboard" "new-slo" {
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   dashboard_name = "New-SLO"
   dashboard_body = <<EOF
@@ -1480,6 +1485,7 @@ EOF
 }
 
 resource "aws_cloudwatch_dashboard" "slos" {
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   dashboard_name = "SLOs"
   dashboard_body = <<EOF

--- a/aws/eks/performance_bottleneck_dashboard.tf
+++ b/aws/eks/performance_bottleneck_dashboard.tf
@@ -4,6 +4,7 @@ locals {
 }
 
 resource "aws_cloudwatch_dashboard" "performance_bottlenecks" {
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   dashboard_name = "Performance-Bottlenecks"
   dashboard_body = <<EOF

--- a/aws/lambda-api/dashboards.tf
+++ b/aws/lambda-api/dashboards.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_dashboard" "api-lambda" {
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   dashboard_name = "API-Lambda"
   dashboard_body = <<EOF

--- a/aws/pinpoint_to_sqs_sms_callbacks/dashboards.tf
+++ b/aws/pinpoint_to_sqs_sms_callbacks/dashboards.tf
@@ -3,6 +3,7 @@ locals {
 }
 
 resource "aws_cloudwatch_dashboard" "pinpoint" {
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   dashboard_name = "SMS-Pinpoint"
   dashboard_body = <<EOF
@@ -618,6 +619,7 @@ EOF
 }
 
 resource "aws_cloudwatch_dashboard" "sms-send-rate" {
+  provider       = aws.core_services
   count          = var.cloudwatch_enabled ? 1 : 0
   dashboard_name = "Specialized-sms-send-rate"
   dashboard_body = <<EOF

--- a/aws/rds/backup.tf
+++ b/aws/rds/backup.tf
@@ -70,11 +70,6 @@ resource "aws_kms_alias" "backup_vault" {
   target_key_id = aws_kms_key.backup_vault.key_id
 }
 
-resource "aws_kms_alias" "backup_vault" {
-  name          = "alias/backup-vault-${var.env}"
-  target_key_id = aws_kms_key.backup_vault.key_id
-}
-
 # KMS key for encrypting backups in secondary region
 resource "aws_kms_key" "backup_vault_secondary" {
   provider                = aws.ca-west-1

--- a/aws/rds/backup.tf
+++ b/aws/rds/backup.tf
@@ -61,7 +61,13 @@ resource "aws_kms_key" "backup_vault" {
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
     Terraform  = "true"
+    ssc_cbrid  = "22DH"
   }
+}
+
+resource "aws_kms_alias" "backup_vault" {
+  name          = "alias/backup-vault-${var.env}"
+  target_key_id = aws_kms_key.backup_vault.key_id
 }
 
 resource "aws_kms_alias" "backup_vault" {
@@ -80,6 +86,7 @@ resource "aws_kms_key" "backup_vault_secondary" {
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
     Terraform  = "true"
+    ssc_cbrid  = "22DH"
   }
 }
 
@@ -97,6 +104,7 @@ resource "aws_backup_vault" "rds" {
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
     Terraform  = "true"
+    ssc_cbrid  = "22DH"
   }
 }
 
@@ -109,6 +117,7 @@ resource "aws_backup_vault" "rds_secondary" {
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
     Terraform  = "true"
+    ssc_cbrid  = "22DH"
   }
 }
 

--- a/aws/rds/dashboards.tf
+++ b/aws/rds/dashboards.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_dashboard" "database" {
+  provider       = aws.core_services
   dashboard_name = "Database"
   dashboard_body = <<EOF
 {

--- a/aws/rds/kms.tf
+++ b/aws/rds/kms.tf
@@ -91,5 +91,8 @@ resource "aws_kms_key" "rds_snapshot" {
         }
     ]
 }
+  tags = {
+    ssc_cbrid = "22DH"
+  }
     POLICY
 }

--- a/aws/rds/kms.tf
+++ b/aws/rds/kms.tf
@@ -91,8 +91,11 @@ resource "aws_kms_key" "rds_snapshot" {
         }
     ]
 }
+POLICY
+
   tags = {
-    ssc_cbrid = "22DH"
+    CostCenter = "notification-canada-ca-${var.env}"
+    Terraform  = "true"
+    ssc_cbrid  = "22DH"
   }
-    POLICY
 }

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -42,24 +42,60 @@ terraform {
 provider "aws" {
   region              = "${local.config_inputs.region}"
   allowed_account_ids = [${local.secret_inputs.account_id}]
+
+  default_tags {
+    tags = {
+      ssc_cbrid = "21JC"
+    }
+  }
+}
+
+provider "aws" {
+  alias               = "core_services"
+  region              = "${local.config_inputs.region}"
+  allowed_account_ids = [${local.secret_inputs.account_id}]
+
+  default_tags {
+    tags = {
+      ssc_cbrid = "22DH"
+    }
+  }
 }
 
 provider "aws" {
   alias               = "us-west-2"
   region              = "us-west-2"
   allowed_account_ids = [${local.secret_inputs.account_id}]
+
+  default_tags {
+    tags = {
+      ssc_cbrid = "21JC"
+    }
+  }
 }
 
 provider "aws" {
   alias               = "us-east-1"
   region              = "us-east-1"
   allowed_account_ids = [${local.secret_inputs.account_id}]
+
+  default_tags {
+    tags = {
+      ssc_cbrid = "21JC"
+    }
+  }
 }
 
 provider "aws" {
   alias               = "ca-west-1"
   region              = "ca-west-1"
   allowed_account_ids = [${local.secret_inputs.account_id}]
+
+  default_tags {
+    tags = {
+      ssc_cbrid = "21JC"
+    }
+  }
 }
 
 # For whatever reason, Dev uses the DNS from the Staging account and 


### PR DESCRIPTION
# Summary | Résumé
This pull request updates the handling of Terraform plan output in GitHub Actions workflows and standardizes the provider configuration for CloudWatch alarms in Terraform. The main improvements are to prevent excessively large plan outputs from being posted as PR comments, and to ensure CloudWatch alarms use the correct AWS provider.

**GitHub Actions workflow improvements:**

* Adds logic to both `terragrunt_plan_production.yml` and `terragrunt_plan_staging.yml` workflows to check the size of the Terraform plan output. If the output is larger than 60,000 characters, a summary message is posted instead of the full output, instructing users to view the logs for details. This prevents PR comments from becoming unwieldy. [[1]](diffhunk://#diff-802419eb4011db8b0383c00d82deb2496ff3b0ec9ab86f024ef0213205cbfb7eR63-R72) [[2]](diffhunk://#diff-802419eb4011db8b0383c00d82deb2496ff3b0ec9ab86f024ef0213205cbfb7eR130-R139) [[3]](diffhunk://#diff-802419eb4011db8b0383c00d82deb2496ff3b0ec9ab86f024ef0213205cbfb7eR192-R201) [[4]](diffhunk://#diff-802419eb4011db8b0383c00d82deb2496ff3b0ec9ab86f024ef0213205cbfb7eR256-R265) [[5]](diffhunk://#diff-802419eb4011db8b0383c00d82deb2496ff3b0ec9ab86f024ef0213205cbfb7eR349-R358) [[6]](diffhunk://#diff-802419eb4011db8b0383c00d82deb2496ff3b0ec9ab86f024ef0213205cbfb7eR413-R422) [[7]](diffhunk://#diff-802419eb4011db8b0383c00d82deb2496ff3b0ec9ab86f024ef0213205cbfb7eR479-R488) [[8]](diffhunk://#diff-802419eb4011db8b0383c00d82deb2496ff3b0ec9ab86f024ef0213205cbfb7eR540-R549) [[9]](diffhunk://#diff-3833d7ad13443f9ea0dd285e7f341227df116554e5e2fac3bcd75567fcb499e8R215-R224) [[10]](diffhunk://#diff-3833d7ad13443f9ea0dd285e7f341227df116554e5e2fac3bcd75567fcb499e8R285-R294) [[11]](diffhunk://#diff-3833d7ad13443f9ea0dd285e7f341227df116554e5e2fac3bcd75567fcb499e8R350-R359) [[12]](diffhunk://#diff-3833d7ad13443f9ea0dd285e7f341227df116554e5e2fac3bcd75567fcb499e8R417-R426) [[13]](diffhunk://#diff-3833d7ad13443f9ea0dd285e7f341227df116554e5e2fac3bcd75567fcb499e8R514-R523) [[14]](diffhunk://#diff-3833d7ad13443f9ea0dd285e7f341227df116554e5e2fac3bcd75567fcb499e8R580-R589) [[15]](diffhunk://#diff-3833d7ad13443f9ea0dd285e7f341227df116554e5e2fac3bcd75567fcb499e8R650-R659) [[16]](diffhunk://#diff-3833d7ad13443f9ea0dd285e7f341227df116554e5e2fac3bcd75567fcb499e8R715-R724)

**Terraform CloudWatch alarm configuration:**

* Updates all SQS and healthcheck CloudWatch alarm resources in `aws/common/cloudwatch_alarms.tf` to explicitly specify the `aws.core_services` provider. This ensures alarms are created in the correct AWS account and region, improving consistency and maintainability. [[1]](diffhunk://#diff-417acc2f515a0ee1066bdf30f554433be2709d5f6af99a673a836ccca1b1005aR8) [[2]](diffhunk://#diff-417acc2f515a0ee1066bdf30f554433be2709d5f6af99a673a836ccca1b1005aR27) [[3]](diffhunk://#diff-417acc2f515a0ee1066bdf30f554433be2709d5f6af99a673a836ccca1b1005aR49) [[4]](diffhunk://#diff-417acc2f515a0ee1066bdf30f554433be2709d5f6af99a673a836ccca1b1005aR68) [[5]](diffhunk://#diff-417acc2f515a0ee1066bdf30f554433be2709d5f6af99a673a836ccca1b1005aR89) [[6]](diffhunk://#diff-417acc2f515a0ee1066bdf30f554433be2709d5f6af99a673a836ccca1b1005aR108) [[7]](diffhunk://#diff-417acc2f515a0ee1066bdf30f554433be2709d5f6af99a673a836ccca1b1005aR129) [[8]](diffhunk://#diff-417acc2f515a0ee1066bdf30f554433be2709d5f6af99a673a836ccca1b1005aR148) [[9]](diffhunk://#diff-417acc2f515a0ee1066bdf30f554433be2709d5f6af99a673a836ccca1b1005aR169) [[10]](diffhunk://#diff-417acc2f515a0ee1066bdf30f554433be2709d5f6af99a673a836ccca1b1005aR188) [[11]](diffhunk://#diff-417acc2f515a0ee1066bdf30f554433be2709d5f6af99a673a836ccca1b1005aR210) [[12]](diffhunk://#diff-417acc2f515a0ee1066bdf30f554433be2709d5f6af99a673a836ccca1b1005aR229)


## Related Issues | Cartes liées
https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/859


## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
