### PR TITLE
Add new scan verdict callback token

### DIFF
--- a/aws/manifest_secrets/secrets.tf
+++ b/aws/manifest_secrets/secrets.tf
@@ -520,3 +520,13 @@ resource "aws_secretsmanager_secret_version" "manifest_falco_slack_webhook_url_v
   secret_id     = aws_secretsmanager_secret.manifest_falco_slack_webhook_url.id
   secret_string = var.manifest_falco_slack_webhook_url
 }
+
+resource "aws_secretsmanager_secret" "manifest_scan_verdict_callback_token" {
+  name                    = "MANIFEST_SCAN_VERDICT_CALLBACK_TOKEN"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_scan_verdict_callback_token" {
+  secret_id     = aws_secretsmanager_secret.manifest_scan_verdict_callback_token.id
+  secret_string = var.manifest_scan_verdict_callback_token
+}

--- a/env/variables.tf
+++ b/env/variables.tf
@@ -979,6 +979,11 @@ variable "manifest_falco_slack_webhook_url" {
   default   = "changeme"
 }
 
+variable "manifest_scan_verdict_callback_token" {
+  type      = string
+  sensitive = true
+}
+
 variable "github_app_id" {
   type      = string
   sensitive = true
@@ -1109,9 +1114,4 @@ variable "security_txt_content" {
     Preferred-Languages: en, fr
     Expires: 2026-03-29T12:00:00.000Z
   EOT
-}
-
-variable "manifest_scan_verdict_callback_token" {
-  type = string
-  sensitive = true
 }

--- a/env/variables.tf
+++ b/env/variables.tf
@@ -1110,3 +1110,8 @@ variable "security_txt_content" {
     Expires: 2026-03-29T12:00:00.000Z
   EOT
 }
+
+variable "manifest_scan_verdict_callback_token" {
+  type = string
+  sensitive = true
+}


### PR DESCRIPTION
# Summary | Résumé

This PR adds a new auth token that will be used by an EventBridge API connection to pass scan verdicts to API in order to update file statuses in the DB.

More details [in this document](https://docs.google.com/document/d/1y6ewfFY88CMJZNr715KS1SZwmZrOV4xdpsgCd7lNo4Q/edit?pli=1&tab=t.0#heading=h.391r7d2h1d4k)

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/3283
* https://github.com/cds-snc/notification-manifests/pull/4843

## Test instructions | Instructions pour tester la modification
- [ ] The plan plans correctly

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
