### PR TITLE
Cbrid Tags -- Last Sweep

### DIFF
--- a/aws/common/kms.tf
+++ b/aws/common/kms.tf
@@ -1,6 +1,7 @@
 data "aws_caller_identity" "current" {}
 
 resource "aws_kms_key" "notification-canada-ca" {
+  provider            = aws.core_services
   description         = "notification-canada-ca ${var.env} encryption key"
   enable_key_rotation = true
 

--- a/aws/common/vpc.tf
+++ b/aws/common/vpc.tf
@@ -22,7 +22,8 @@ resource "aws_vpc" "notification-canada-ca" {
 ###
 
 resource "aws_default_security_group" "default" {
-  vpc_id = aws_vpc.notification-canada-ca.id
+  provider = aws.core_services
+  vpc_id   = aws_vpc.notification-canada-ca.id
 }
 
 ###
@@ -44,6 +45,7 @@ resource "aws_internet_gateway" "notification-canada-ca" {
 ###
 
 resource "aws_eip" "notification-canada-ca-natgw" {
+  provider   = aws.core_services
   count      = 3
   depends_on = [aws_internet_gateway.notification-canada-ca]
 
@@ -54,6 +56,7 @@ resource "aws_eip" "notification-canada-ca-natgw" {
 }
 
 resource "aws_eip" "notification-canada-ca-natgw-k8s" {
+  provider   = aws.core_services
   count      = 3
   depends_on = [aws_internet_gateway.notification-canada-ca]
 
@@ -228,6 +231,7 @@ resource "aws_route_table_association" "notification-canada-ca-private-k8s" {
 ###
 
 resource "aws_default_network_acl" "notification-canada-ca" {
+  provider               = aws.core_services
   default_network_acl_id = aws_vpc.notification-canada-ca.default_network_acl_id
 
   ingress {
@@ -277,6 +281,7 @@ resource "aws_default_network_acl" "notification-canada-ca" {
 }
 
 resource "aws_flow_log" "cloud-based-sensor" {
+  provider = aws.core_services
   depends_on = [
     module.cbs_logs_bucket
   ]

--- a/aws/database-tools/rds.tf
+++ b/aws/database-tools/rds.tf
@@ -5,6 +5,7 @@ resource "random_string" "random" {
 }
 
 resource "aws_db_subnet_group" "database-tools-rds-subnet" {
+  provider   = aws.core_services
   name       = "database-tools-rds-subnet"
   subnet_ids = var.vpc_private_subnets
 

--- a/aws/ec2/network.tf
+++ b/aws/ec2/network.tf
@@ -50,7 +50,8 @@ resource "aws_nat_gateway" "nat_gateway" {
 
 # Create an EIP for the NAT gateway
 resource "aws_eip" "nat_eip" {
-  vpc = true
+  provider = aws.core_services
+  vpc      = true
 }
 
 # Create a public route table and associate it with the public subnet

--- a/aws/eks/alb.tf
+++ b/aws/eks/alb.tf
@@ -3,6 +3,7 @@
 ###
 
 resource "aws_alb" "notification-canada-ca" {
+  provider           = aws.core_services
   name               = "notification-${var.env}-alb"
   internal           = false #tfsec:ignore:AWS005
   load_balancer_type = "application"
@@ -28,6 +29,7 @@ resource "aws_alb" "notification-canada-ca" {
 }
 
 resource "aws_alb_listener" "notification-canada-ca" {
+  provider = aws.core_services
 
   depends_on = [aws_acm_certificate_validation.notification-canada-ca, aws_acm_certificate_validation.notification-canada-ca-alt]
 
@@ -102,6 +104,7 @@ resource "aws_lb_listener_rule" "security-txt" {
 ###
 
 resource "aws_alb_target_group" "notification-canada-ca-document-api" {
+  provider             = aws.core_services
   name                 = "notification-document-api"
   port                 = 7000
   protocol             = "HTTP"
@@ -161,6 +164,7 @@ resource "aws_lb_listener_rule" "document-api-host-route" {
 ###
 
 resource "aws_alb_target_group" "notification-canada-ca-document" {
+  provider = aws.core_services
   name     = "notification-alb-document"
   port     = 7001
   protocol = "HTTP"
@@ -220,6 +224,7 @@ resource "aws_lb_listener_rule" "document-host-route" {
 ###
 
 resource "aws_alb_target_group" "notification-canada-ca-api" {
+  provider             = aws.core_services
   name                 = "notification-canada-ca-alb-api"
   port                 = 6011
   protocol             = "HTTP"
@@ -281,6 +286,7 @@ resource "aws_lb_listener_rule" "alt-domain-host-route" {
 }
 
 resource "aws_alb_target_group" "notification-canada-ca-admin" {
+  provider = aws.core_services
   name     = "notification-canada-ca-alb-admin"
   port     = 6012
   protocol = "HTTP"
@@ -326,6 +332,7 @@ resource "aws_lb_listener_rule" "www-domain-host-route" {
 ###
 
 resource "aws_alb_target_group" "notification-canada-ca-documentation" {
+  provider = aws.core_services
   name     = "notification-documentation"
   port     = 80
   protocol = "HTTP"
@@ -384,6 +391,7 @@ resource "aws_lb_listener_rule" "documentation-host-redirect" {
 ###
 
 resource "aws_alb_target_group" "public_nginx_http" {
+  provider    = aws.core_services
   name        = "notification-public-nginx-http"
   port        = 80
   protocol    = "HTTP"

--- a/aws/eks/alb_internal.tf
+++ b/aws/eks/alb_internal.tf
@@ -24,6 +24,7 @@ resource "aws_lb" "internal_alb" {
 }
 
 resource "aws_alb_listener" "internal_alb_tls" {
+  provider = aws.core_services
 
   load_balancer_arn = aws_lb.internal_alb.arn
   port              = 443
@@ -57,6 +58,7 @@ resource "aws_lb_listener" "internal_alb-80" {
 }
 
 resource "aws_alb_target_group" "internal_nginx_http" {
+  provider    = aws.core_services
   name        = "notification-internal-nginx-http"
   port        = 80
   protocol    = "HTTP"

--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -3,6 +3,7 @@
 ###
 
 resource "aws_eks_cluster" "notification-canada-ca-eks-cluster" {
+  provider = aws.core_services
   name     = var.eks_cluster_name
   role_arn = aws_iam_role.eks-cluster-role.arn
   version  = var.eks_cluster_version
@@ -56,6 +57,7 @@ resource "aws_eks_cluster" "notification-canada-ca-eks-cluster" {
 ###
 
 resource "aws_eks_node_group" "notification-canada-ca-eks-node-group-k8s" {
+  provider             = aws.core_services
   cluster_name         = aws_eks_cluster.notification-canada-ca-eks-cluster.name
   node_group_name      = "notification-canada-ca-${var.env}-eks-primary-node-group-k8s"
   node_role_arn        = aws_iam_role.eks-worker-role.arn
@@ -97,6 +99,7 @@ resource "aws_eks_node_group" "notification-canada-ca-eks-node-group-k8s" {
 }
 
 resource "aws_eks_node_group" "notification-canada-ca-eks-secondary-node-group" {
+  provider             = aws.core_services
   count                = var.node_upgrade ? 1 : 0
   cluster_name         = aws_eks_cluster.notification-canada-ca-eks-cluster.name
   node_group_name      = "notification-canada-ca-${var.env}-eks-secondary-node-group"
@@ -141,6 +144,7 @@ resource "aws_eks_node_group" "notification-canada-ca-eks-secondary-node-group" 
 }
 
 resource "aws_eks_node_group" "signoz_node_group" {
+  provider             = aws.core_services
   count                = var.enable_signoz ? 1 : 0
   cluster_name         = aws_eks_cluster.notification-canada-ca-eks-cluster.name
   node_group_name      = "notification-canada-ca-${var.env}-signoz-node-group"

--- a/aws/eks/securitygroups.tf
+++ b/aws/eks/securitygroups.tf
@@ -187,6 +187,7 @@ resource "aws_security_group_rule" "notification-canada-ca-alb-perf-test-ingress
 # Google CIDR security groups
 
 resource "aws_ec2_managed_prefix_list" "google_cidrs" {
+  provider       = aws.core_services
   name           = "Google Service CIDRs"
   address_family = "IPv4"
   max_entries    = var.env == "production" || var.env == "staging" ? 100 : 20

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -700,6 +700,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
 # WAF logging to Cloud Based Sensor satellite bucket
 #
 resource "aws_kinesis_firehose_delivery_stream" "firehose-waf-logs" {
+  provider    = aws.core_services
   name        = "aws-waf-logs-notification-canada-ca-waf"
   destination = "extended_s3"
 

--- a/aws/elasticache/elasticache.tf
+++ b/aws/elasticache/elasticache.tf
@@ -3,6 +3,7 @@
 ###
 
 resource "aws_elasticache_subnet_group" "notification-canada-ca-cache-subnet" {
+  provider   = aws.core_services
   name       = "notification-canada-ca-${var.env}-cache-subnet"
   subnet_ids = var.vpc_private_subnets
 }
@@ -12,6 +13,7 @@ resource "aws_elasticache_subnet_group" "notification-canada-ca-cache-subnet" {
 ###
 
 resource "aws_elasticache_replication_group" "notification-cluster-cache-multiaz-group" {
+  provider = aws.core_services
   # Default is false with this param, it looks counter-intuitive because
   # applied changes would only happen during maintenance window if false.
   apply_immediately           = true
@@ -59,6 +61,7 @@ resource "aws_elasticache_replication_group" "notification-cluster-cache-multiaz
 ###
 
 resource "aws_elasticache_replication_group" "elasticache_queue_cache" {
+  provider = aws.core_services
 
   apply_immediately           = true
   automatic_failover_enabled  = true

--- a/aws/lambda-api/waf.tf
+++ b/aws/lambda-api/waf.tf
@@ -401,6 +401,7 @@ resource "aws_wafv2_web_acl" "api_lambda" {
 # WAF logging to Cloud Based Sensor satellite bucket
 #
 resource "aws_kinesis_firehose_delivery_stream" "firehose-api-lambda-waf-logs" {
+  provider    = aws.core_services
   name        = "aws-waf-logs-notification-canada-ca-api-lambda-waf"
   destination = "extended_s3"
 

--- a/aws/rds/backup.tf
+++ b/aws/rds/backup.tf
@@ -95,6 +95,7 @@ resource "aws_kms_alias" "backup_vault_secondary" {
 
 # Backup vault with encryption
 resource "aws_backup_vault" "rds" {
+  provider    = aws.core_services
   name        = "notification-canada-ca-${var.env}-rds-vault"
   kms_key_arn = aws_kms_key.backup_vault.arn
 

--- a/aws/rds/kms.tf
+++ b/aws/rds/kms.tf
@@ -1,4 +1,5 @@
 resource "aws_kms_key" "rds_snapshot" {
+  provider                = aws.core_services
   count                   = var.env == "staging" ? 1 : 0
   description             = "A KMS key for encrypting RDS snapshots"
   enable_key_rotation     = true

--- a/aws/rds/rds.tf
+++ b/aws/rds/rds.tf
@@ -5,6 +5,7 @@ resource "random_string" "random" {
 }
 
 resource "aws_db_subnet_group" "notification-canada-ca" {
+  provider   = aws.core_services
   name       = "notification-canada-ca-${var.env}"
   subnet_ids = var.vpc_private_subnets
 
@@ -173,6 +174,7 @@ resource "aws_rds_cluster_parameter_group" "pgaudit" {
 }
 
 resource "aws_rds_cluster" "notification-canada-ca" {
+  provider = aws.core_services
 
   depends_on = [
     aws_cloudwatch_log_group.logs_exports


### PR DESCRIPTION
# Summary | Résumé
This pull request standardizes the use of the `aws.core_services` provider across various Terraform resources in the AWS infrastructure codebase. By explicitly specifying the provider for key resources, the configuration ensures consistent resource management and reduces the risk of provider-related issues in multi-provider environments.

**Provider Standardization Across Modules:**

* Added `provider = aws.core_services` to all major AWS resources in the following modules to ensure consistent provider usage:
  - EKS ALB resources, including load balancers, listeners, and target groups (`aws/eks/alb.tf`, `aws/eks/alb_internal.tf`) [[1]](diffhunk://#diff-545ff751c7060a2b887afe7c6d4bb1eef805da89591981f5fd353c8424bea66dR6) [[2]](diffhunk://#diff-545ff751c7060a2b887afe7c6d4bb1eef805da89591981f5fd353c8424bea66dR32) [[3]](diffhunk://#diff-545ff751c7060a2b887afe7c6d4bb1eef805da89591981f5fd353c8424bea66dR107) [[4]](diffhunk://#diff-545ff751c7060a2b887afe7c6d4bb1eef805da89591981f5fd353c8424bea66dR167) [[5]](diffhunk://#diff-545ff751c7060a2b887afe7c6d4bb1eef805da89591981f5fd353c8424bea66dR227) [[6]](diffhunk://#diff-545ff751c7060a2b887afe7c6d4bb1eef805da89591981f5fd353c8424bea66dR289) [[7]](diffhunk://#diff-545ff751c7060a2b887afe7c6d4bb1eef805da89591981f5fd353c8424bea66dR335) [[8]](diffhunk://#diff-545ff751c7060a2b887afe7c6d4bb1eef805da89591981f5fd353c8424bea66dR394) [[9]](diffhunk://#diff-d3305797358284b2160d6ed4eb3b0324244a9721ba2a711b1e9c6a911ceacc73R27) [[10]](diffhunk://#diff-d3305797358284b2160d6ed4eb3b0324244a9721ba2a711b1e9c6a911ceacc73R61)
  - ElastiCache subnet groups and replication groups (`aws/elasticache/elasticache.tf`) [[1]](diffhunk://#diff-1f11e99e7d5161983a75a92f9c461650aaed97d12795d88eedd6b363f85e23a5R6) [[2]](diffhunk://#diff-1f11e99e7d5161983a75a92f9c461650aaed97d12795d88eedd6b363f85e23a5R16) [[3]](diffhunk://#diff-1f11e99e7d5161983a75a92f9c461650aaed97d12795d88eedd6b363f85e23a5R64)
  - RDS subnet groups and clusters, and KMS key for RDS snapshots (`aws/rds/rds.tf`, `aws/rds/kms.tf`) [[1]](diffhunk://#diff-21d3fcdd0e8903cf2f841210bc0997d902afc789a3bca5db698dd8db04c1c34cR8) [[2]](diffhunk://#diff-21d3fcdd0e8903cf2f841210bc0997d902afc789a3bca5db698dd8db04c1c34cR177) [[3]](diffhunk://#diff-e7d5e0ae16494d0936efd635e2990cc2f5c89b0c5679393a2158a302c9f1a7d7R2)
  - Database tools subnet group (`aws/database-tools/rds.tf`)
  - KMS key for notification (`aws/common/kms.tf`)

**Key Management:**

* Ensured that KMS keys used for encryption in RDS and notification modules are now explicitly managed by the `aws.core_services` provider (`aws/common/kms.tf`, `aws/rds/kms.tf`) [[1]](diffhunk://#diff-53c82433dc3f27a371d7203b847048aaba62ab3083f5a066a57b6d4d535d2223R4) [[2]](diffhunk://#diff-e7d5e0ae16494d0936efd635e2990cc2f5c89b0c5679393a2158a302c9f1a7d7R2)

This change improves clarity, maintainability, and reliability of the Terraform codebase by making provider usage explicit and consistent.

## Related Issues | Cartes liées
https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/859

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
