### PR TITLE
converted the expired inflight alarm to warning from critical

### DIFF
--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -907,6 +907,7 @@ resource "aws_cloudwatch_metric_alarm" "expired-inflight-poisoned-message-warnin
   }
 }
 
+/*
 resource "aws_cloudwatch_metric_alarm" "expired-inflight-queue-warning" {
   for_each = var.cloudwatch_enabled ? { for q in local.inflight_queues : q.name => q } : {}
   provider = aws.core_services
@@ -966,6 +967,7 @@ resource "aws_cloudwatch_metric_alarm" "expired-inflight-queue-warning" {
     return_data = "true"
   }
 }
+*/
 
 locals {
   inflight_queues = [
@@ -978,18 +980,18 @@ locals {
   ]
 }
 
-resource "aws_cloudwatch_metric_alarm" "expired-inflight-queue-critical" {
+resource "aws_cloudwatch_metric_alarm" "expired-inflight-queue-warning" {
   for_each = var.cloudwatch_enabled ? { for q in local.inflight_queues : q.name => q } : {}
   provider = aws.core_services
 
-  alarm_name          = "expired-inflight-${each.key}-critical"
+  alarm_name          = "expired-inflight-${each.key}-warning"
   alarm_description   = "More than ${var.alarm_critical_expired_inflights_threshold} inflights expired in 5 minutes on the ${each.key} queue AND celery acknowledgment throughput for that queue is zero - queue is stuck, check the Redis-batch-saving dashboard"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   threshold           = 1
   treat_missing_data  = "notBreaching"
 
-  alarm_actions = [aws_sns_topic.notification-canada-ca-alert-critical.arn]
+  alarm_actions = [aws_sns_topic.notification-canada-ca-alert-warning.arn]
   ok_actions    = [aws_sns_topic.notification-canada-ca-alert-ok.arn]
 
   metric_query {

--- a/aws/common/cloudwatch_alarms.tf
+++ b/aws/common/cloudwatch_alarms.tf
@@ -907,12 +907,11 @@ resource "aws_cloudwatch_metric_alarm" "expired-inflight-poisoned-message-warnin
   }
 }
 
-/*
-resource "aws_cloudwatch_metric_alarm" "expired-inflight-queue-warning" {
+resource "aws_cloudwatch_metric_alarm" "expired-inflight-queue-outnumber-warning" {
   for_each = var.cloudwatch_enabled ? { for q in local.inflight_queues : q.name => q } : {}
   provider = aws.core_services
 
-  alarm_name          = "expired-inflight-${each.key}-warning"
+  alarm_name          = "expired-inflight-queue-outnumber-${each.key}-warning"
   alarm_description   = "Inflights are expiring faster than they are being acknowledged on the ${each.key} queue in two consecutive 5-minute periods - queue is deteriorating. Check the Redis-batch-saving dashboard"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "2"
@@ -967,7 +966,6 @@ resource "aws_cloudwatch_metric_alarm" "expired-inflight-queue-warning" {
     return_data = "true"
   }
 }
-*/
 
 locals {
   inflight_queues = [
@@ -980,11 +978,11 @@ locals {
   ]
 }
 
-resource "aws_cloudwatch_metric_alarm" "expired-inflight-queue-warning" {
+resource "aws_cloudwatch_metric_alarm" "expired-inflight-zero-throughput-queue-warning" {
   for_each = var.cloudwatch_enabled ? { for q in local.inflight_queues : q.name => q } : {}
   provider = aws.core_services
 
-  alarm_name          = "expired-inflight-${each.key}-warning"
+  alarm_name          = "expired-inflight-zero-throughput-${each.key}-warning"
   alarm_description   = "More than ${var.alarm_critical_expired_inflights_threshold} inflights expired in 5 minutes on the ${each.key} queue AND celery acknowledgment throughput for that queue is zero - queue is stuck, check the Redis-batch-saving dashboard"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"


### PR DESCRIPTION
# Summary | Résumé

Converted the expired-inflight-critical alarm to Warning.
Commented out the warning alarm. 
Most times when we get paged by this alarm there is nothing that the OL can do. We need to investigate this alarm, but for now want to make it a non-paging alarm.