### PR TITLE
Changing scalable to burst semantic to adapt to new change names

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -573,11 +573,11 @@ resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-static-pods-high-cpu-w
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-scalable-pods-high-cpu-warning" {
+resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-burst-pods-high-cpu-warning" {
   provider                  = aws.core_services
   count                     = var.cloudwatch_enabled ? 1 : 0
-  alarm_name                = "celery-core-tasks-scalable-pods-high-cpu-warning"
-  alarm_description         = "Average CPU of celery-core-tasks-scalable pods >=50% during 10 minutes"
+  alarm_name                = "celery-core-tasks-burst-pods-high-cpu-warning"
+  alarm_description         = "Average CPU of celery-core-tasks-burst pods >=50% during 10 minutes"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "2"
   metric_name               = "pod_cpu_utilization"
@@ -590,7 +590,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-scalable-pods-high-cpu
   treat_missing_data        = "missing"
   dimensions = {
     Namespace   = "notification-canada-ca"
-    Service     = "notify-celery-core-tasks-scalable"
+    Service     = "notify-celery-core-tasks-burst"
     ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
   }
 }
@@ -854,13 +854,13 @@ resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-static-replicas-unavai
 }
 
 
-resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-scalable-replicas-unavailable" {
+resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-burst-replicas-unavailable" {
   provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
-  alarm_name          = "celery-core-tasks-scalable-replicas-unavailable"
+  alarm_name          = "celery-core-tasks-burst-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 3
-  alarm_description   = "Celery Core Tasks Scalable Replicas Unavailable"
+  alarm_description   = "Celery Core Tasks Burst Replicas Unavailable"
   #Setting to warn until we verify that it is working as expected
   alarm_actions      = [var.sns_alert_warning_arn]
   treat_missing_data = "breaching"
@@ -877,7 +877,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-core-tasks-scalable-replicas-unav
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace
-        deployment  = "notify-celery-core-tasks-scalable"
+        deployment  = "notify-celery-core-tasks-burst"
       }
     }
   }
@@ -971,13 +971,13 @@ resource "aws_cloudwatch_metric_alarm" "celery-email-send-static-replicas-unavai
 }
 
 
-resource "aws_cloudwatch_metric_alarm" "celery-email-send-scalable-replicas-unavailable" {
+resource "aws_cloudwatch_metric_alarm" "celery-email-send-burst-replicas-unavailable" {
   provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
-  alarm_name          = "celery-email-send-scalable-replicas-unavailable"
+  alarm_name          = "celery-email-send-burst-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 3
-  alarm_description   = "Celery Email Send Scalable Replicas Unavailable"
+  alarm_description   = "Celery Email Send Burst Replicas Unavailable"
   #Setting to warn until we verify that it is working as expected
   alarm_actions      = [var.sns_alert_warning_arn]
   treat_missing_data = "breaching"
@@ -994,7 +994,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-email-send-scalable-replicas-unav
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace
-        deployment  = "notify-celery-email-send-scalable"
+        deployment  = "notify-celery-email-send-burst"
       }
     }
   }
@@ -1030,13 +1030,13 @@ resource "aws_cloudwatch_metric_alarm" "celery-sms-send-static-replicas-unavaila
 }
 
 
-resource "aws_cloudwatch_metric_alarm" "celery-sms-send-scalable-replicas-unavailable" {
+resource "aws_cloudwatch_metric_alarm" "celery-sms-send-burst-replicas-unavailable" {
   provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
-  alarm_name          = "celery-sms-send-scalable-replicas-unavailable"
+  alarm_name          = "celery-sms-send-burst-replicas-unavailable"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 3
-  alarm_description   = "Celery SMS Send Scalable Replicas Unavailable"
+  alarm_description   = "Celery SMS Send Burst Replicas Unavailable"
   #Setting to warn until we verify that it is working as expected
   alarm_actions      = [var.sns_alert_warning_arn]
   treat_missing_data = "breaching"
@@ -1053,7 +1053,7 @@ resource "aws_cloudwatch_metric_alarm" "celery-sms-send-scalable-replicas-unavai
       dimensions = {
         ClusterName = aws_eks_cluster.notification-canada-ca-eks-cluster.name
         namespace   = var.notify_k8s_namespace
-        deployment  = "notify-celery-sms-send-scalable"
+        deployment  = "notify-celery-sms-send-burst"
       }
     }
   }

--- a/aws/eks/dashboards.tf
+++ b/aws/eks/dashboards.tf
@@ -14,7 +14,7 @@ resource "aws_cloudwatch_dashboard" "notify_system" {
             "properties": {
                 "metrics": [
                     [ "ContainerInsights/Prometheus", "kube_deployment_status_replicas_available", "namespace", "notification-canada-ca", "ClusterName", "${aws_eks_cluster.notification-canada-ca-eks-cluster.name}", "deployment", "${local.celery_name}-email-send-static", { "region": "${var.region}", "label": "${local.celery_name}-email-send-static" } ],
-                    [ "ContainerInsights/Prometheus", "kube_deployment_status_replicas_available", "namespace", "notification-canada-ca", "ClusterName", "${aws_eks_cluster.notification-canada-ca-eks-cluster.name}", "deployment", "${local.celery_name}-email-send-scalable", { "region": "${var.region}", "label": "${local.celery_name}-email-send-scalable" } ]
+                    [ "ContainerInsights/Prometheus", "kube_deployment_status_replicas_available", "namespace", "notification-canada-ca", "ClusterName", "${aws_eks_cluster.notification-canada-ca-eks-cluster.name}", "deployment", "${local.celery_name}-email-send-burst", { "region": "${var.region}", "label": "${local.celery_name}-email-send-burst" } ]
                 ],
                 "sparkline": true,
                 "view": "singleValue",
@@ -349,8 +349,8 @@ resource "aws_cloudwatch_dashboard" "notify_system" {
             "properties": {
                 "metrics": [
                     [ "ContainerInsights/Prometheus", "kube_deployment_status_replicas_available", "namespace", "notification-canada-ca", "ClusterName", "${aws_eks_cluster.notification-canada-ca-eks-cluster.name}", "deployment", "${local.celery_name}-core-tasks-static", { "region": "${var.region}", "label": "${local.celery_name}-core-tasks-static" } ],
-                    [ "...", "${local.celery_name}-core-tasks-scalable", { "region": "${var.region}", "label": "${local.celery_name}-core-tasks-scalable" } ],
-                    [ "...", "${local.celery_name}-delivery-receipts-scalable", { "region": "${var.region}", "label": "${local.celery_name}-delivery-receipts-scalable" } ]
+                    [ "...", "${local.celery_name}-core-tasks-burst", { "region": "${var.region}", "label": "${local.celery_name}-core-tasks-burst" } ],
+                    [ "...", "${local.celery_name}-delivery-receipts-burst", { "region": "${var.region}", "label": "${local.celery_name}-delivery-receipts-burst" } ]
                 ],
                 "sparkline": true,
                 "view": "singleValue",
@@ -369,7 +369,7 @@ resource "aws_cloudwatch_dashboard" "notify_system" {
             "properties": {
                 "metrics": [
                     [ "ContainerInsights/Prometheus", "kube_deployment_status_replicas_available", "namespace", "notification-canada-ca", "ClusterName", "${aws_eks_cluster.notification-canada-ca-eks-cluster.name}", "deployment", "${local.celery_name}-sms-send-static", { "region": "${var.region}", "label": "${local.celery_name}-sms-send-static" } ],
-                    [ "...", "${local.celery_name}-sms-send-scalable", { "region": "${var.region}", "label": "${local.celery_name}-sms-send-scalable" } ]
+                    [ "...", "${local.celery_name}-sms-send-burst", { "region": "${var.region}", "label": "${local.celery_name}-sms-send-burst" } ]
                 ],
                 "sparkline": true,
                 "view": "singleValue",

--- a/aws/eks/performance_bottleneck_dashboard.tf
+++ b/aws/eks/performance_bottleneck_dashboard.tf
@@ -337,15 +337,15 @@ resource "aws_cloudwatch_dashboard" "performance_bottlenecks" {
                 "view": "timeSeries",
                 "stacked": false,
                 "metrics": [
-                    [ "ContainerInsights/Prometheus", "kube_deployment_status_replicas_ready", "namespace", "notification-canada-ca", "ClusterName", "notification-canada-ca-${var.env}-eks-cluster", "deployment", "notify-celery-sms-send-scalable" ],
+                    [ "ContainerInsights/Prometheus", "kube_deployment_status_replicas_ready", "namespace", "notification-canada-ca", "ClusterName", "notification-canada-ca-${var.env}-eks-cluster", "deployment", "notify-celery-sms-send-burst" ],
                     [ "...", "notify-celery-core-tasks-static" ],
-                    [ "...", "notify-celery-email-send-scalable" ],
+                    [ "...", "notify-celery-email-send-burst" ],
                     [ "...", "notify-celery-email-send-static" ],
                     [ "...", "notify-celery-generate-reports-static" ],
                     [ "...", "notify-celery-beat" ],
-                    [ "...", "notify-celery-delivery-receipts-scalable" ],
+                    [ "...", "notify-celery-delivery-receipts-burst" ],
                     [ "...", "notify-celery-sms-send-static" ],
-                    [ "...", "notify-celery-core-tasks-scalable" ],
+                    [ "...", "notify-celery-core-tasks-burst" ],
                     [ "...", "notify-celery-sms-dedicated-static" ]
                 ],
                 "region": "ca-central-1",
@@ -539,16 +539,16 @@ resource "aws_cloudwatch_dashboard" "performance_bottlenecks" {
                 "stacked": false,
                 "region": "ca-central-1",
                 "metrics": [
-                    [ "ContainerInsights", "pod_cpu_utilization", "PodName", "notify-celery-sms-send-scalable", "ClusterName", "notification-canada-ca-${var.env}-eks-cluster", "Namespace", "notification-canada-ca" ],
+                    [ "ContainerInsights", "pod_cpu_utilization", "PodName", "notify-celery-sms-send-burst", "ClusterName", "notification-canada-ca-${var.env}-eks-cluster", "Namespace", "notification-canada-ca" ],
                     [ "...", "notify-celery-core-tasks-static", ".", ".", ".", "." ],
                     [ "...", "notify-celery-email-send-static", ".", ".", ".", "." ],
                     [ "...", "notify-celery-sms-dedicated-static", ".", ".", ".", "." ],
-                    [ "...", "notify-celery-delivery-receipts-scalable", ".", ".", ".", "." ],
-                    [ "...", "notify-celery-email-send-scalable", ".", ".", ".", "." ],
+                    [ "...", "notify-celery-delivery-receipts-burst", ".", ".", ".", "." ],
+                    [ "...", "notify-celery-email-send-burst", ".", ".", ".", "." ],
                     [ "...", "notify-celery-beat", ".", ".", ".", "." ],
                     [ "...", "notify-celery-generate-reports-static", ".", ".", ".", "." ],
                     [ "...", "notify-celery-sms-send-static", ".", ".", ".", "." ],
-                    [ "...", "notify-celery-core-tasks-scalable", ".", ".", ".", "." ]
+                    [ "...", "notify-celery-core-tasks-burst", ".", ".", ".", "." ]
                 ],
                 "title": "Celery CPU Utilization"
             }
@@ -569,10 +569,10 @@ resource "aws_cloudwatch_dashboard" "performance_bottlenecks" {
                     [ "...", "notify-celery-sms-dedicated-static", ".", ".", ".", "." ],
                     [ "...", "notify-celery-core-tasks-static", ".", ".", ".", "." ],
                     [ "...", "notify-celery-generate-reports-static", ".", ".", ".", "." ],
-                    [ "...", "notify-celery-email-send-scalable", ".", ".", ".", "." ],
-                    [ "...", "notify-celery-delivery-receipts-scalable", ".", ".", ".", "." ],
-                    [ "...", "notify-celery-sms-send-scalable", ".", ".", ".", "." ],
-                    [ "...", "notify-celery-core-tasks-scalable", ".", ".", ".", "." ],
+                    [ "...", "notify-celery-email-send-burst", ".", ".", ".", "." ],
+                    [ "...", "notify-celery-delivery-receipts-burst", ".", ".", ".", "." ],
+                    [ "...", "notify-celery-sms-send-burst", ".", ".", ".", "." ],
+                    [ "...", "notify-celery-core-tasks-burst", ".", ".", ".", "." ],
                     [ "...", "notify-celery-sms-send-static", ".", ".", ".", "." ]
                 ],
                 "title": "Celery Memory Usage"
@@ -589,15 +589,15 @@ resource "aws_cloudwatch_dashboard" "performance_bottlenecks" {
                 "stacked": false,
                 "region": "ca-central-1",
                 "metrics": [
-                    [ "ContainerInsights", "pod_network_tx_bytes", "PodName", "notify-celery-delivery-receipts-scalable", "ClusterName", "notification-canada-ca-${var.env}-eks-cluster", "Namespace", "notification-canada-ca" ],
+                    [ "ContainerInsights", "pod_network_tx_bytes", "PodName", "notify-celery-delivery-receipts-burst", "ClusterName", "notification-canada-ca-${var.env}-eks-cluster", "Namespace", "notification-canada-ca" ],
                     [ "...", "notify-celery-sms-send-static", ".", ".", ".", "." ],
                     [ "...", "notify-celery-core-tasks-static", ".", ".", ".", "." ],
                     [ "...", "notify-celery-beat", ".", ".", ".", "." ],
                     [ "...", "notify-celery-generate-reports-static", ".", ".", ".", "." ],
-                    [ "...", "notify-celery-email-send-scalable", ".", ".", ".", "." ],
+                    [ "...", "notify-celery-email-send-burst", ".", ".", ".", "." ],
                     [ "...", "notify-celery-sms-dedicated-static", ".", ".", ".", "." ],
-                    [ "...", "notify-celery-sms-send-scalable", ".", ".", ".", "." ],
-                    [ "...", "notify-celery-core-tasks-scalable", ".", ".", ".", "." ],
+                    [ "...", "notify-celery-sms-send-burst", ".", ".", ".", "." ],
+                    [ "...", "notify-celery-core-tasks-burst", ".", ".", ".", "." ],
                     [ "...", "notify-celery-email-send-static", ".", ".", ".", "." ]
                 ],
                 "title": "Celery Network TX Bytes"
@@ -614,15 +614,15 @@ resource "aws_cloudwatch_dashboard" "performance_bottlenecks" {
                 "stacked": false,
                 "region": "ca-central-1",
                 "metrics": [
-                    [ "ContainerInsights", "pod_network_rx_bytes", "PodName", "notify-celery-sms-send-scalable", "ClusterName", "notification-canada-ca-${var.env}-eks-cluster", "Namespace", "notification-canada-ca" ],
-                    [ "...", "notify-celery-email-send-scalable", ".", ".", ".", "." ],
-                    [ "...", "notify-celery-delivery-receipts-scalable", ".", ".", ".", "." ],
+                    [ "ContainerInsights", "pod_network_rx_bytes", "PodName", "notify-celery-sms-send-burst", "ClusterName", "notification-canada-ca-${var.env}-eks-cluster", "Namespace", "notification-canada-ca" ],
+                    [ "...", "notify-celery-email-send-burst", ".", ".", ".", "." ],
+                    [ "...", "notify-celery-delivery-receipts-burst", ".", ".", ".", "." ],
                     [ "...", "notify-celery-generate-reports-static", ".", ".", ".", "." ],
                     [ "...", "notify-celery-beat", ".", ".", ".", "." ],
                     [ "...", "notify-celery-core-tasks-static", ".", ".", ".", "." ],
                     [ "...", "notify-celery-sms-send-static", ".", ".", ".", "." ],
                     [ "...", "notify-celery-email-send-static", ".", ".", ".", "." ],
-                    [ "...", "notify-celery-core-tasks-scalable", ".", ".", ".", "." ],
+                    [ "...", "notify-celery-core-tasks-burst", ".", ".", ".", "." ],
                     [ "...", "notify-celery-sms-dedicated-static", ".", ".", ".", "." ]
                 ],
                 "title": "Celery Network RX Bytes"

--- a/aws/pinpoint_to_sqs_sms_callbacks/dashboards.tf
+++ b/aws/pinpoint_to_sqs_sms_callbacks/dashboards.tf
@@ -669,7 +669,7 @@ resource "aws_cloudwatch_dashboard" "sms-send-rate" {
             "properties": {
                 "metrics": [
                     [ "ContainerInsights/Prometheus", "kube_deployment_status_replicas_available", "namespace", "notification-canada-ca", "ClusterName", "notification-canada-ca-${var.env}-eks-cluster", "deployment", "${local.celery_name}-sms-send-static", { "region": "${var.region}", "label": "${local.celery_name}-sms-send-static" } ],
-                    [ "ContainerInsights/Prometheus", "kube_deployment_status_replicas_available", "namespace", "notification-canada-ca", "ClusterName", "notification-canada-ca-${var.env}-eks-cluster", "deployment", "${local.celery_name}-sms-send-scalable", { "region": "${var.region}", "label": "${local.celery_name}-sms-send-scalable" } ]
+                    [ "ContainerInsights/Prometheus", "kube_deployment_status_replicas_available", "namespace", "notification-canada-ca", "ClusterName", "notification-canada-ca-${var.env}-eks-cluster", "deployment", "${local.celery_name}-sms-send-burst", { "region": "${var.region}", "label": "${local.celery_name}-sms-send-burst" } ]
                 ],
                 "sparkline": true,
                 "view": "singleValue",


### PR DESCRIPTION
# Summary | Résumé

Changing scalable to burst semantic to adapt to new change names, to adapt to [latest changes](https://github.com/cds-snc/notification-manifests/pull/4876) that we did to kubernetes deployment name changes.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/857

## Test instructions | Instructions pour tester la modification

AWS Cloudwatch alarms should be green!

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
