### PR TITLE
Fix guardduty_scan_verdict event_pattern

### DIFF
--- a/aws/common/cloudwatch_events.tf
+++ b/aws/common/cloudwatch_events.tf
@@ -91,7 +91,7 @@ resource "aws_cloudwatch_event_rule" "guardduty_scan_verdict" {
   "detail": {
     "s3ObjectDetails": {
       "bucketName": ["notification-canada-ca-${var.env}-document-download-scan-files"],
-      "objectKey": [{"prefix": "template/"}]
+      "objectKey": [{"prefix": "template_attachments/"}]
     }
   }
 }

--- a/env/dev_config.tfvars
+++ b/env/dev_config.tfvars
@@ -158,7 +158,7 @@ sqs_send_sms_high_queue_name                                       = "send-sms-h
 sqs_send_sms_medium_queue_name                                     = "send-sms-medium"
 sqs_send_sms_low_queue_name                                        = "send-sms-low"
 enable_guardduty_scan_api_destination                              = true
-scan_verdict_callback_url                                          = "https://api.dev.notification.cdssandbox.xyz/template_attachments/scan-verdict-callback"
+scan_verdict_callback_url                                          = "https://api.dev.notification.cdssandbox.xyz/templates/scan-verdict-callback"
 
 # RANDOM DOCKER TAGS
 system_status_docker_tag                 = "bootstrap"

--- a/env/production_config.tfvars
+++ b/env/production_config.tfvars
@@ -168,7 +168,7 @@ sqs_send_sms_high_queue_name                                       = "send-sms-h
 sqs_send_sms_medium_queue_name                                     = "send-sms-medium"
 sqs_send_sms_low_queue_name                                        = "send-sms-low"
 enable_guardduty_scan_api_destination                              = false
-scan_verdict_callback_url                                          = "https://api.notification.canada.ca/template_attachments/scan-verdict-callback"
+scan_verdict_callback_url                                          = "https://api.notification.canada.ca/templates/scan-verdict-callback"
 
 # RANDOM DOCKER TAGS (These are only used during BCP processes)
 system_status_docker_tag                 = "bootstrap"

--- a/env/staging_config.tfvars
+++ b/env/staging_config.tfvars
@@ -158,7 +158,7 @@ sqs_send_sms_high_queue_name                                       = "send-sms-h
 sqs_send_sms_medium_queue_name                                     = "send-sms-medium"
 sqs_send_sms_low_queue_name                                        = "send-sms-low"
 enable_guardduty_scan_api_destination                              = true
-scan_verdict_callback_url                                          = "https://api.staging.notification.cdssandbox.xyz/template_attachments/scan-verdict-callback"
+scan_verdict_callback_url                                          = "https://api.staging.notification.cdssandbox.xyz/templates/scan-verdict-callback"
 
 # RANDOM DOCKER TAGS
 system_status_docker_tag                 = "bootstrap"


### PR DESCRIPTION
# Summary | Résumé

Followup to https://github.com/cds-snc/notification-terraform/pull/2656. I changed the `scan_verdict_callback_urls` when I meant to change the event pattern to point to the correct folder inside the scan files bucket. 

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/3283

## Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
