### PR TITLE
Update duplicate-record alarm to use structured log tag; add unexpected-constraint alarm

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -193,6 +193,42 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-duplicate-record-criti
   ok_actions          = [var.sns_alert_ok_arn]
 }
 
+# UNEXPECTED_DB_CONSTRAINT — raw unique-constraint violations not caught by the
+# known-safe dedup flow. Any hit here is unexpected and should be investigated.
+resource "aws_cloudwatch_metric_alarm" "logs-celery-error-unexpected-db-constraint-warning" {
+  provider            = aws.core_services
+  count               = var.cloudwatch_enabled ? 1 : 0
+  alarm_name          = "logs-celery-error-unexpected-db-constraint-warning"
+  alarm_description   = "One unexpected DB unique-constraint violation (not from the known dedup flow) in 1 minute"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.celery-error-unexpected-db-constraint[0].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.celery-error-unexpected-db-constraint[0].metric_transformation[0].namespace
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [var.sns_alert_warning_arn]
+  ok_actions          = [var.sns_alert_warning_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "logs-celery-error-unexpected-db-constraint-critical" {
+  provider            = aws.core_services
+  count               = var.cloudwatch_enabled ? 1 : 0
+  alarm_name          = "logs-celery-error-unexpected-db-constraint-critical"
+  alarm_description   = "Ten unexpected DB unique-constraint violations (not from the known dedup flow) in 1 minute"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.celery-error-unexpected-db-constraint[0].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.celery-error-unexpected-db-constraint[0].metric_transformation[0].namespace
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 10
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [var.sns_alert_critical_arn]
+  ok_actions          = [var.sns_alert_ok_arn]
+}
+
 # JOB_INCOMPLETE
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-job-incomplete-warning" {
   provider            = aws.core_services

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -176,23 +176,6 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-duplicate-record-warni
   ok_actions          = [var.sns_alert_warning_arn]
 }
 
-resource "aws_cloudwatch_metric_alarm" "logs-celery-error-duplicate-record-critical" {
-  provider            = aws.core_services
-  count               = var.cloudwatch_enabled ? 1 : 0
-  alarm_name          = "logs-celery-error-duplicate-record-critical"
-  alarm_description   = "200 Celery duplicate record errors in 1 minute"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.celery-error-duplicate-record[0].metric_transformation[0].name
-  namespace           = aws_cloudwatch_log_metric_filter.celery-error-duplicate-record[0].metric_transformation[0].namespace
-  period              = 60
-  statistic           = "Sum"
-  threshold           = 200
-  treat_missing_data  = "notBreaching"
-  alarm_actions       = [var.sns_alert_critical_arn]
-  ok_actions          = [var.sns_alert_ok_arn]
-}
-
 # UNEXPECTED_DB_CONSTRAINT — raw unique-constraint violations not caught by the
 # known-safe dedup flow. Any hit here is unexpected and should be investigated.
 resource "aws_cloudwatch_metric_alarm" "logs-celery-error-unexpected-db-constraint-warning" {

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -73,14 +73,35 @@ resource "aws_cloudwatch_log_metric_filter" "celery-error-unknown" {
 
 resource "aws_cloudwatch_log_metric_filter" "celery-error-duplicate-record" {
   provider = aws.core_services
-  # This monitors for database duplicate record errors in Celery.
+  # Monitors for expected duplicate-record errors from SQS redelivery / concurrent
+  # workers. These are caught and handled safely by handle_batch_error_and_forward
+  # and tagged with the structured CELERY_KNOWN_ERROR::DUPLICATE_RECORD marker.
+  # See: https://github.com/cds-snc/notification-api/pull/2944
   count          = var.cloudwatch_enabled ? 1 : 0
   name           = "celery-error-duplicate-record"
-  pattern        = "\"duplicate key value violates unique constraint\""
+  pattern        = "\"CELERY_KNOWN_ERROR::DUPLICATE_RECORD\""
   log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs[0].name
 
   metric_transformation {
     name      = "celery-error-duplicate-record"
+    namespace = "LogMetrics"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "celery-error-unexpected-db-constraint" {
+  provider = aws.core_services
+  # Monitors for unexpected unique-constraint violations that were NOT caught and
+  # classified by handle_batch_error_and_forward. These indicate a DB integrity
+  # problem in a code path outside the known-safe dedup flow and should be
+  # investigated immediately.
+  count          = var.cloudwatch_enabled ? 1 : 0
+  name           = "celery-error-unexpected-db-constraint"
+  pattern        = "\"duplicate key value violates unique constraint\" -\"CELERY_KNOWN_ERROR\""
+  log_group_name = aws_cloudwatch_log_group.notification-canada-ca-eks-application-logs[0].name
+
+  metric_transformation {
+    name      = "celery-error-unexpected-db-constraint"
     namespace = "LogMetrics"
     value     = "1"
   }


### PR DESCRIPTION
## What

Updates the `celery-error-duplicate-record` CloudWatch log filter and adds a new `celery-error-unexpected-db-constraint` filter + alarm pair.

## Why

The notification-api change ([cds-snc/notification-api#2947](https://github.com/cds-snc/notification-api/pull/2947)) classifies expected duplicate-record errors from SQS redelivery with the structured tag `CELERY_KNOWN_ERROR::DUPLICATE_RECORD`. This allows the two cases to be monitored separately:

| Filter | Matches | Meaning |
|---|---|---|
| `celery-error-duplicate-record` | `CELERY_KNOWN_ERROR::DUPLICATE_RECORD` | Known-safe dedup — SQS redelivery caught and handled correctly |
| `celery-error-unexpected-db-constraint` | raw Postgres string **without** the structured tag | Unexpected constraint violation in a different code path — investigate |

Previously both cases matched the same raw Postgres string filter, so the alarm was firing on expected behaviour introduced by cds-snc/notification-api#2944.

## Dependency

Requires cds-snc/notification-api#2947 to be deployed before this terraform change takes effect. Until then the `celery-error-duplicate-record` alarm will stop firing (because the structured tag won't appear in logs yet) — this is acceptable since the current alarm is firing on expected behaviour anyway.