### PR TITLE
Change the duplicate error critical alarm to warning

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -176,10 +176,10 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-duplicate-record-warni
   ok_actions          = [var.sns_alert_warning_arn]
 }
 
-resource "aws_cloudwatch_metric_alarm" "logs-celery-error-duplicate-record-critical" {
+resource "aws_cloudwatch_metric_alarm" "logs-celery-error-duplicate-record-warning-high" {
   provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
-  alarm_name          = "logs-celery-error-duplicate-record-critical"
+  alarm_name          = "logs-celery-error-duplicate-record-warning-high"
   alarm_description   = "200 Celery duplicate record errors in 1 minute"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -189,8 +189,8 @@ resource "aws_cloudwatch_metric_alarm" "logs-celery-error-duplicate-record-criti
   statistic           = "Sum"
   threshold           = 200
   treat_missing_data  = "notBreaching"
-  alarm_actions       = [var.sns_alert_critical_arn]
-  ok_actions          = [var.sns_alert_ok_arn]
+  alarm_actions       = [var.sns_alert_warning_arn]
+  ok_actions          = [var.sns_alert_warning_arn]
 }
 
 # JOB_INCOMPLETE


### PR DESCRIPTION
# Summary | Résumé

Change the duplicate error critical alarm to warning

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
