### PR TITLE
allow flag to set prod local

### DIFF
--- a/env/dev/aws-auth/terragrunt.hcl
+++ b/env/dev/aws-auth/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/aws-auth?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//aws-auth"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/aws-auth?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//aws-auth"}"
 }
 
 include {

--- a/env/dev/cloudfront/terragrunt.hcl
+++ b/env/dev/cloudfront/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/cloudfront?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//cloudfront"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/cloudfront?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//cloudfront"}"
 }
 
 dependencies {

--- a/env/dev/common/terragrunt.hcl
+++ b/env/dev/common/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/common?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//common"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/common?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//common"}"
 
   before_hook "get-admin" {
     commands     = ["apply", "plan"]

--- a/env/dev/database-tools/terragrunt.hcl
+++ b/env/dev/database-tools/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/database-tools?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//database-tools"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/database-tools?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//database-tools"}"
 }
 
 dependencies {

--- a/env/dev/dns/terragrunt.hcl
+++ b/env/dev/dns/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/dns?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//dns"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/dns?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//dns"}"
 }
 
 dependencies {

--- a/env/dev/ecr-us-east/terragrunt.hcl
+++ b/env/dev/ecr-us-east/terragrunt.hcl
@@ -3,7 +3,7 @@ include {
 }
 
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr-us-east?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr-us-east"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr-us-east?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr-us-east"}"
 
   after_hook "cleanup-admin" {
     commands     = ["apply"]

--- a/env/dev/ecr-us-west-2/terragrunt.hcl
+++ b/env/dev/ecr-us-west-2/terragrunt.hcl
@@ -3,7 +3,7 @@ include {
 }
 
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr-us-west-2?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr-us-west-2"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr-us-west-2?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr-us-west-2"}"
 
   after_hook "cleanup-lambdas" {
     commands     = ["apply"]

--- a/env/dev/ecr/terragrunt.hcl
+++ b/env/dev/ecr/terragrunt.hcl
@@ -3,7 +3,7 @@ include {
 }
 
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr"}"
 
   after_hook "cleanup-admin" {
     commands     = ["apply"]

--- a/env/dev/eks/terragrunt.hcl
+++ b/env/dev/eks/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/eks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//eks"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/eks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//eks"}"
 }
 
 dependencies {

--- a/env/dev/elasticache/terragrunt.hcl
+++ b/env/dev/elasticache/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/elasticache?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//elasticache"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/elasticache?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//elasticache"}"
 }
 
 dependencies {

--- a/env/dev/github/terragrunt.hcl
+++ b/env/dev/github/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/github?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//github"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/github?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//github"}"
 }
 
 dependencies {

--- a/env/dev/heartbeat/terragrunt.hcl
+++ b/env/dev/heartbeat/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/heartbeat?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//heartbeat"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/heartbeat?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//heartbeat"}"
 }
 
 dependencies {

--- a/env/dev/lambda-admin-pr/terragrunt.hcl
+++ b/env/dev/lambda-admin-pr/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/lambda-admin-pr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//lambda-admin-pr"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/lambda-admin-pr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//lambda-admin-pr"}"
 }
 
 dependencies {

--- a/env/dev/lambda-google-cidr/terragrunt.hcl
+++ b/env/dev/lambda-google-cidr/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/lambda-google-cidr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//lambda-google-cidr"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/lambda-google-cidr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//lambda-google-cidr"}"
 }
 
 dependencies {

--- a/env/dev/manifest_secrets/terragrunt.hcl
+++ b/env/dev/manifest_secrets/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/manifest_secrets?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//manifest_secrets"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/manifest_secrets?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//manifest_secrets"}"
 }
 
 dependencies {

--- a/env/dev/performance-test/terragrunt.hcl
+++ b/env/dev/performance-test/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/performance-test?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//performance-test"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/performance-test?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//performance-test"}"
 }
 
 dependencies {

--- a/env/dev/pinpoint_to_sqs_sms_callbacks/terragrunt.hcl
+++ b/env/dev/pinpoint_to_sqs_sms_callbacks/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/pinpoint_to_sqs_sms_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//pinpoint_to_sqs_sms_callbacks"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/pinpoint_to_sqs_sms_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//pinpoint_to_sqs_sms_callbacks"}"
 }
 
 dependencies {

--- a/env/dev/quicksight/terragrunt.hcl
+++ b/env/dev/quicksight/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/quicksight?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//quicksight"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/quicksight?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//quicksight"}"
 }
 
 dependencies {

--- a/env/dev/rds/terragrunt.hcl
+++ b/env/dev/rds/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/rds?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//rds"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/rds?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//rds"}"
 }
 
 dependencies {

--- a/env/dev/ses_receiving_emails/terragrunt.hcl
+++ b/env/dev/ses_receiving_emails/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_receiving_emails?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_receiving_emails"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_receiving_emails?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_receiving_emails"}"
 }
 
 dependencies {

--- a/env/dev/ses_to_sqs_email_callbacks/terragrunt.hcl
+++ b/env/dev/ses_to_sqs_email_callbacks/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_to_sqs_email_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_to_sqs_email_callbacks"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_to_sqs_email_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_to_sqs_email_callbacks"}"
 }
 
 dependencies {

--- a/env/dev/ses_validation_dns_entries/terragrunt.hcl
+++ b/env/dev/ses_validation_dns_entries/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_validation_dns_entries?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_validation_dns_entries"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_validation_dns_entries?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_validation_dns_entries"}"
 }
 
 dependencies {

--- a/env/dev/sns_to_sqs_sms_callbacks/terragrunt.hcl
+++ b/env/dev/sns_to_sqs_sms_callbacks/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/sns_to_sqs_sms_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//sns_to_sqs_sms_callbacks"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/sns_to_sqs_sms_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//sns_to_sqs_sms_callbacks"}"
 }
 
 dependencies {

--- a/env/dev/system_status/terragrunt.hcl
+++ b/env/dev/system_status/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/system_status?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//system_status"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/system_status?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//system_status"}"
 }
 
 dependencies {

--- a/env/dev/system_status_static_site/terragrunt.hcl
+++ b/env/dev/system_status_static_site/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/system_status_static_site?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//system_status_static_site"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/system_status_static_site?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//system_status_static_site"}"
 }
 
 include {

--- a/env/production/aws-auth/terragrunt.hcl
+++ b/env/production/aws-auth/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/aws-auth?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//aws-auth"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/aws-auth?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//aws-auth"}"
 }
 
 include {

--- a/env/production/cloudfront/terragrunt.hcl
+++ b/env/production/cloudfront/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/cloudfront?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//cloudfront"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/cloudfront?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//cloudfront"}"
 }
 
 dependencies {

--- a/env/production/common/terragrunt.hcl
+++ b/env/production/common/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/common?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//common"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/common?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//common"}"
 
   before_hook "get-admin" {
     commands     = ["apply", "plan"]

--- a/env/production/database-tools/terragrunt.hcl
+++ b/env/production/database-tools/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/database-tools?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//database-tools"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/database-tools?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//database-tools"}"
 }
 
 dependencies {

--- a/env/production/dns/terragrunt.hcl
+++ b/env/production/dns/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/dns?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//dns"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/dns?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//dns"}"
 }
 
 dependencies {

--- a/env/production/ecr-us-east/terragrunt.hcl
+++ b/env/production/ecr-us-east/terragrunt.hcl
@@ -3,7 +3,7 @@ include {
 }
 
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr-us-east?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr-us-east"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr-us-east?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr-us-east"}"
 
   after_hook "cleanup-admin" {
     commands     = ["apply"]

--- a/env/production/ecr-us-west-2/terragrunt.hcl
+++ b/env/production/ecr-us-west-2/terragrunt.hcl
@@ -3,7 +3,7 @@ include {
 }
 
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr-us-west-2?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr-us-west-2"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr-us-west-2?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr-us-west-2"}"
 
   after_hook "cleanup-lambdas" {
     commands     = ["apply"]

--- a/env/production/ecr/terragrunt.hcl
+++ b/env/production/ecr/terragrunt.hcl
@@ -3,7 +3,7 @@ include {
 }
 
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr"}"
 
   after_hook "cleanup-admin" {
     commands     = ["apply"]

--- a/env/production/eks/terragrunt.hcl
+++ b/env/production/eks/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/eks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//eks"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/eks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//eks"}"
 }
 
 dependencies {

--- a/env/production/elasticache/terragrunt.hcl
+++ b/env/production/elasticache/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/elasticache?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//elasticache"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/elasticache?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//elasticache"}"
 }
 
 dependencies {

--- a/env/production/github/terragrunt.hcl
+++ b/env/production/github/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/github?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//github"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/github?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//github"}"
 }
 
 dependencies {

--- a/env/production/heartbeat/terragrunt.hcl
+++ b/env/production/heartbeat/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/heartbeat?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//heartbeat"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/heartbeat?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//heartbeat"}"
 }
 
 dependencies {

--- a/env/production/lambda-admin-pr/terragrunt.hcl
+++ b/env/production/lambda-admin-pr/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/lambda-admin-pr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//lambda-admin-pr"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/lambda-admin-pr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//lambda-admin-pr"}"
 }
 
 dependencies {

--- a/env/production/lambda-google-cidr/terragrunt.hcl
+++ b/env/production/lambda-google-cidr/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/lambda-google-cidr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//lambda-google-cidr"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/lambda-google-cidr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//lambda-google-cidr"}"
 }
 
 dependencies {

--- a/env/production/manifest_secrets/terragrunt.hcl
+++ b/env/production/manifest_secrets/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/manifest_secrets?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//manifest_secrets"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/manifest_secrets?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//manifest_secrets"}"
 }
 
 dependencies {

--- a/env/production/performance-test/terragrunt.hcl
+++ b/env/production/performance-test/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/performance-test?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//performance-test"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/performance-test?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//performance-test"}"
 }
 
 dependencies {

--- a/env/production/pinpoint_to_sqs_sms_callbacks/terragrunt.hcl
+++ b/env/production/pinpoint_to_sqs_sms_callbacks/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/pinpoint_to_sqs_sms_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//pinpoint_to_sqs_sms_callbacks"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/pinpoint_to_sqs_sms_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//pinpoint_to_sqs_sms_callbacks"}"
 }
 
 dependencies {

--- a/env/production/quicksight/terragrunt.hcl
+++ b/env/production/quicksight/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/quicksight?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//quicksight"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/quicksight?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//quicksight"}"
 }
 
 dependencies {

--- a/env/production/rds/terragrunt.hcl
+++ b/env/production/rds/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/rds?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//rds"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/rds?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//rds"}"
 }
 
 dependencies {

--- a/env/production/ses_receiving_emails/terragrunt.hcl
+++ b/env/production/ses_receiving_emails/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_receiving_emails?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_receiving_emails"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_receiving_emails?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_receiving_emails"}"
 }
 
 dependencies {

--- a/env/production/ses_to_sqs_email_callbacks/terragrunt.hcl
+++ b/env/production/ses_to_sqs_email_callbacks/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_to_sqs_email_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_to_sqs_email_callbacks"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_to_sqs_email_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_to_sqs_email_callbacks"}"
 }
 
 dependencies {

--- a/env/production/ses_validation_dns_entries/terragrunt.hcl
+++ b/env/production/ses_validation_dns_entries/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_validation_dns_entries?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_validation_dns_entries"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_validation_dns_entries?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_validation_dns_entries"}"
 }
 
 dependencies {

--- a/env/production/sns_to_sqs_sms_callbacks/terragrunt.hcl
+++ b/env/production/sns_to_sqs_sms_callbacks/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/sns_to_sqs_sms_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//sns_to_sqs_sms_callbacks"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/sns_to_sqs_sms_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//sns_to_sqs_sms_callbacks"}"
 }
 
 dependencies {

--- a/env/production/system_status/terragrunt.hcl
+++ b/env/production/system_status/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/system_status?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//system_status"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/system_status?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//system_status"}"
 }
 
 dependencies {

--- a/env/production/system_status_static_site/terragrunt.hcl
+++ b/env/production/system_status_static_site/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/system_status_static_site?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//system_status_static_site"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/system_status_static_site?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//system_status_static_site"}"
 }
 
 include {

--- a/env/sandbox/aws-auth/terragrunt.hcl
+++ b/env/sandbox/aws-auth/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/aws-auth?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//aws-auth"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/aws-auth?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//aws-auth"}"
 }
 
 include {

--- a/env/sandbox/cloudfront/terragrunt.hcl
+++ b/env/sandbox/cloudfront/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/cloudfront?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//cloudfront"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/cloudfront?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//cloudfront"}"
 }
 
 dependencies {

--- a/env/sandbox/common/terragrunt.hcl
+++ b/env/sandbox/common/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/common?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//common"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/common?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//common"}"
 
   before_hook "get-admin" {
     commands     = ["apply", "plan"]

--- a/env/sandbox/database-tools/terragrunt.hcl
+++ b/env/sandbox/database-tools/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/database-tools?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//database-tools"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/database-tools?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//database-tools"}"
 }
 
 dependencies {

--- a/env/sandbox/dns/terragrunt.hcl
+++ b/env/sandbox/dns/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/dns?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//dns"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/dns?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//dns"}"
 }
 
 dependencies {

--- a/env/sandbox/ecr-us-east/terragrunt.hcl
+++ b/env/sandbox/ecr-us-east/terragrunt.hcl
@@ -3,7 +3,7 @@ include {
 }
 
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr-us-east?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr-us-east"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr-us-east?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr-us-east"}"
 
   after_hook "cleanup-admin" {
     commands     = ["apply"]

--- a/env/sandbox/ecr-us-west-2/terragrunt.hcl
+++ b/env/sandbox/ecr-us-west-2/terragrunt.hcl
@@ -3,7 +3,7 @@ include {
 }
 
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr-us-west-2?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr-us-west-2"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr-us-west-2?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr-us-west-2"}"
 
   after_hook "cleanup-lambdas" {
     commands     = ["apply"]

--- a/env/sandbox/ecr/terragrunt.hcl
+++ b/env/sandbox/ecr/terragrunt.hcl
@@ -3,7 +3,7 @@ include {
 }
 
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr"}"
 
   after_hook "cleanup-admin" {
     commands     = ["apply"]

--- a/env/sandbox/eks/terragrunt.hcl
+++ b/env/sandbox/eks/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/eks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//eks"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/eks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//eks"}"
 }
 
 dependencies {

--- a/env/sandbox/elasticache/terragrunt.hcl
+++ b/env/sandbox/elasticache/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/elasticache?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//elasticache"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/elasticache?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//elasticache"}"
 }
 
 dependencies {

--- a/env/sandbox/github/terragrunt.hcl
+++ b/env/sandbox/github/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/github?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//github"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/github?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//github"}"
 }
 
 dependencies {

--- a/env/sandbox/heartbeat/terragrunt.hcl
+++ b/env/sandbox/heartbeat/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/heartbeat?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//heartbeat"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/heartbeat?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//heartbeat"}"
 }
 
 dependencies {

--- a/env/sandbox/lambda-admin-pr/terragrunt.hcl
+++ b/env/sandbox/lambda-admin-pr/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/lambda-admin-pr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//lambda-admin-pr"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/lambda-admin-pr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//lambda-admin-pr"}"
 }
 
 dependencies {

--- a/env/sandbox/lambda-google-cidr/terragrunt.hcl
+++ b/env/sandbox/lambda-google-cidr/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/lambda-google-cidr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//lambda-google-cidr"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/lambda-google-cidr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//lambda-google-cidr"}"
 }
 
 dependencies {

--- a/env/sandbox/manifest_secrets/terragrunt.hcl
+++ b/env/sandbox/manifest_secrets/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/manifest_secrets?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//manifest_secrets"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/manifest_secrets?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//manifest_secrets"}"
 }
 
 dependencies {

--- a/env/sandbox/performance-test/terragrunt.hcl
+++ b/env/sandbox/performance-test/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/performance-test?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//performance-test"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/performance-test?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//performance-test"}"
 }
 
 dependencies {

--- a/env/sandbox/pinpoint_to_sqs_sms_callbacks/terragrunt.hcl
+++ b/env/sandbox/pinpoint_to_sqs_sms_callbacks/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/pinpoint_to_sqs_sms_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//pinpoint_to_sqs_sms_callbacks"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/pinpoint_to_sqs_sms_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//pinpoint_to_sqs_sms_callbacks"}"
 }
 
 dependencies {

--- a/env/sandbox/quicksight/terragrunt.hcl
+++ b/env/sandbox/quicksight/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/quicksight?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//quicksight"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/quicksight?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//quicksight"}"
 }
 
 dependencies {

--- a/env/sandbox/rds/terragrunt.hcl
+++ b/env/sandbox/rds/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/rds?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//rds"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/rds?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//rds"}"
 }
 
 dependencies {

--- a/env/sandbox/ses_receiving_emails/terragrunt.hcl
+++ b/env/sandbox/ses_receiving_emails/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_receiving_emails?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_receiving_emails"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_receiving_emails?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_receiving_emails"}"
 }
 
 dependencies {

--- a/env/sandbox/ses_to_sqs_email_callbacks/terragrunt.hcl
+++ b/env/sandbox/ses_to_sqs_email_callbacks/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_to_sqs_email_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_to_sqs_email_callbacks"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_to_sqs_email_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_to_sqs_email_callbacks"}"
 }
 
 dependencies {

--- a/env/sandbox/ses_validation_dns_entries/terragrunt.hcl
+++ b/env/sandbox/ses_validation_dns_entries/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_validation_dns_entries?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_validation_dns_entries"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_validation_dns_entries?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_validation_dns_entries"}"
 }
 
 dependencies {

--- a/env/sandbox/sns_to_sqs_sms_callbacks/terragrunt.hcl
+++ b/env/sandbox/sns_to_sqs_sms_callbacks/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/sns_to_sqs_sms_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//sns_to_sqs_sms_callbacks"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/sns_to_sqs_sms_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//sns_to_sqs_sms_callbacks"}"
 }
 
 dependencies {

--- a/env/sandbox/system_status/terragrunt.hcl
+++ b/env/sandbox/system_status/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/system_status?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//system_status"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/system_status?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//system_status"}"
 }
 
 dependencies {

--- a/env/sandbox/system_status_static_site/terragrunt.hcl
+++ b/env/sandbox/system_status_static_site/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/system_status_static_site?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//system_status_static_site"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/system_status_static_site?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//system_status_static_site"}"
 }
 
 include {

--- a/env/staging/aws-auth/terragrunt.hcl
+++ b/env/staging/aws-auth/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/aws-auth?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//aws-auth"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/aws-auth?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//aws-auth"}"
 }
 
 include {

--- a/env/staging/cloudfront/terragrunt.hcl
+++ b/env/staging/cloudfront/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/cloudfront?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//cloudfront"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/cloudfront?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//cloudfront"}"
 }
 
 dependencies {

--- a/env/staging/common/terragrunt.hcl
+++ b/env/staging/common/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/common?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//common"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/common?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//common"}"
 
   before_hook "get-admin" {
     commands     = ["apply", "plan"]

--- a/env/staging/database-tools/terragrunt.hcl
+++ b/env/staging/database-tools/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/database-tools?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//database-tools"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/database-tools?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//database-tools"}"
 }
 
 dependencies {

--- a/env/staging/dns/terragrunt.hcl
+++ b/env/staging/dns/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/dns?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//dns"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/dns?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//dns"}"
 }
 
 dependencies {

--- a/env/staging/ecr-us-east/terragrunt.hcl
+++ b/env/staging/ecr-us-east/terragrunt.hcl
@@ -3,7 +3,7 @@ include {
 }
 
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr-us-east?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr-us-east"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr-us-east?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr-us-east"}"
 
   after_hook "cleanup-admin" {
     commands     = ["apply"]

--- a/env/staging/ecr-us-west-2/terragrunt.hcl
+++ b/env/staging/ecr-us-west-2/terragrunt.hcl
@@ -3,7 +3,7 @@ include {
 }
 
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr-us-west-2?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr-us-west-2"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr-us-west-2?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr-us-west-2"}"
 
   after_hook "cleanup-lambdas" {
     commands     = ["apply"]

--- a/env/staging/ecr/terragrunt.hcl
+++ b/env/staging/ecr/terragrunt.hcl
@@ -3,7 +3,7 @@ include {
 }
 
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ecr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ecr"}"
 
   after_hook "cleanup-admin" {
     commands     = ["apply"]

--- a/env/staging/eks/terragrunt.hcl
+++ b/env/staging/eks/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/eks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//eks"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/eks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//eks"}"
 }
 
 dependencies {

--- a/env/staging/elasticache/terragrunt.hcl
+++ b/env/staging/elasticache/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/elasticache?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//elasticache"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/elasticache?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//elasticache"}"
 }
 
 dependencies {

--- a/env/staging/github/terragrunt.hcl
+++ b/env/staging/github/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/github?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//github"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/github?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//github"}"
 }
 
 dependencies {

--- a/env/staging/heartbeat/terragrunt.hcl
+++ b/env/staging/heartbeat/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/heartbeat?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//heartbeat"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/heartbeat?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//heartbeat"}"
 }
 
 dependencies {

--- a/env/staging/lambda-admin-pr/terragrunt.hcl
+++ b/env/staging/lambda-admin-pr/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/lambda-admin-pr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//lambda-admin-pr"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/lambda-admin-pr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//lambda-admin-pr"}"
 }
 
 dependencies {

--- a/env/staging/lambda-google-cidr/terragrunt.hcl
+++ b/env/staging/lambda-google-cidr/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/lambda-google-cidr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//lambda-google-cidr"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/lambda-google-cidr?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//lambda-google-cidr"}"
 }
 
 dependencies {

--- a/env/staging/manifest_secrets/terragrunt.hcl
+++ b/env/staging/manifest_secrets/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/manifest_secrets?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//manifest_secrets"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/manifest_secrets?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//manifest_secrets"}"
 }
 
 dependencies {

--- a/env/staging/performance-test/terragrunt.hcl
+++ b/env/staging/performance-test/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/performance-test?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//performance-test"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/performance-test?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//performance-test"}"
 }
 
 dependencies {

--- a/env/staging/pinpoint_to_sqs_sms_callbacks/terragrunt.hcl
+++ b/env/staging/pinpoint_to_sqs_sms_callbacks/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/pinpoint_to_sqs_sms_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//pinpoint_to_sqs_sms_callbacks"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/pinpoint_to_sqs_sms_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//pinpoint_to_sqs_sms_callbacks"}"
 }
 
 dependencies {

--- a/env/staging/quicksight/terragrunt.hcl
+++ b/env/staging/quicksight/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/quicksight?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//quicksight"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/quicksight?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//quicksight"}"
 }
 
 dependencies {

--- a/env/staging/rds/terragrunt.hcl
+++ b/env/staging/rds/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/rds?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//rds"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/rds?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//rds"}"
 }
 
 dependencies {

--- a/env/staging/ses_receiving_emails/terragrunt.hcl
+++ b/env/staging/ses_receiving_emails/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_receiving_emails?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_receiving_emails"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_receiving_emails?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_receiving_emails"}"
 }
 
 dependencies {

--- a/env/staging/ses_to_sqs_email_callbacks/terragrunt.hcl
+++ b/env/staging/ses_to_sqs_email_callbacks/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_to_sqs_email_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_to_sqs_email_callbacks"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_to_sqs_email_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_to_sqs_email_callbacks"}"
 }
 
 dependencies {

--- a/env/staging/ses_validation_dns_entries/terragrunt.hcl
+++ b/env/staging/ses_validation_dns_entries/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_validation_dns_entries?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_validation_dns_entries"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/ses_validation_dns_entries?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//ses_validation_dns_entries"}"
 }
 
 dependencies {

--- a/env/staging/sns_to_sqs_sms_callbacks/terragrunt.hcl
+++ b/env/staging/sns_to_sqs_sms_callbacks/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/sns_to_sqs_sms_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//sns_to_sqs_sms_callbacks"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/sns_to_sqs_sms_callbacks?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//sns_to_sqs_sms_callbacks"}"
 }
 
 dependencies {

--- a/env/staging/system_status/terragrunt.hcl
+++ b/env/staging/system_status/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/system_status?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//system_status"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/system_status?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//system_status"}"
 }
 
 dependencies {

--- a/env/staging/system_status_static_site/terragrunt.hcl
+++ b/env/staging/system_status_static_site/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "${get_env("ENVIRONMENT") == "production" ? "git::https://github.com/cds-snc/notification-terraform//aws/system_status_static_site?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//system_status_static_site"}"
+  source = "${(get_env("ENVIRONMENT") == "production" && get_env("LOCAL_PROD", "false") != "true") ? "git::https://github.com/cds-snc/notification-terraform//aws/system_status_static_site?ref=v${get_env("INFRASTRUCTURE_VERSION")}" : "../../../aws//system_status_static_site"}"
 }
 
 include {


### PR DESCRIPTION
# Summary | Résumé

In prep for the target group migration which will require manual steps in order to minimize downtime. This PR allows setting a flag PROD_LOCAL=true to bypass having to use INFRASTRUCTURE_VERSION when running multi-step (multi-branch) migrations for terraform.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/873

## Test instructions | Instructions pour tester la modification

export PROD_LOCAL=true
cd env/production/common
terragrunt plan

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
