### PR TITLE
Migrate Lambda API cloudwatch queries to EKS

### DIFF
--- a/aws/eks/cloudwatch_queries.tf
+++ b/aws/eks/cloudwatch_queries.tf
@@ -524,3 +524,252 @@ fields @timestamp, @notification_id, @url, @error
 | limit 10000
 QUERY
 }
+
+### API Queries
+
+resource "aws_cloudwatch_query_definition" "api-errors" {
+  provider = aws.core_services
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "API / API errors"
+
+  log_group_names = [
+    local.eks_application_log_group
+  ]
+
+  query_string = <<QUERY
+fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as pod_name, @logStream
+| filter kubernetes.container_name like /^${local.api_name}/
+| filter @message like /rror/
+| sort @timestamp desc
+| limit 20
+QUERY
+}
+
+resource "aws_cloudwatch_query_definition" "services-over-daily-rate-limit" {
+  provider = aws.core_services
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "API / Services going over daily rate limits"
+
+  log_group_names = [
+    local.eks_application_log_group
+  ]
+
+  query_string = <<QUERY
+fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as pod_name, @logStream
+| filter kubernetes.container_name like /^${local.api_name}/
+| filter @message like /has been rate limited/
+| parse @message /service (?<service>.*?) has been rate limited for (?<limit_type>..........).*/
+| stats count(*) by service, limit_type
+QUERY
+}
+
+resource "aws_cloudwatch_query_definition" "api-504-timeouts" {
+  provider = aws.core_services
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "API / 504 timeouts grouped by hour"
+
+  log_group_names = [
+    local.eks_application_log_group
+  ]
+
+  query_string = <<QUERY
+fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as pod_name, @logStream
+| filter kubernetes.container_name like /^${local.api_name}/
+| filter @message like /HTTP\/\d+\.\d+\\" 504/
+| stats count() as error_count by bin(@timestamp, 1h)
+| sort @timestamp desc
+| limit 1000
+QUERY
+}
+
+resource "aws_cloudwatch_query_definition" "api_response_code_counts" {
+  provider = aws.core_services
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "API / Response Code Counts"
+
+  log_group_names = [
+    local.eks_application_log_group
+  ]
+
+  query_string = <<QUERY
+fields @timestamp, log, kubernetes.container_name as app, @logStream
+| filter kubernetes.container_name like /^${local.api_name}/
+| parse @message /HTTP\/\d+\.\d+ (?<status>\d{3})/
+| filter ispresent(status)
+| stats count(*) by status
+QUERY
+}
+
+resource "aws_cloudwatch_query_definition" "api_count_requests_by_minute" {
+  provider = aws.core_services
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "API / Requests By Minute"
+
+  log_group_names = [
+    local.eks_application_log_group
+  ]
+
+  query_string = <<QUERY
+fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as pod_name, @logStream
+| filter kubernetes.container_name like /^${local.api_name}/
+| parse @message /(?<httpMethod>GET|POST|PUT|DELETE|PATCH) /
+| filter ispresent(httpMethod)
+| stats count(*) by httpMethod, bin(1m) as minute
+| order by minute asc
+| limit 100
+QUERY
+}
+
+resource "aws_cloudwatch_query_definition" "get-trace-by-notification-id" {
+  provider = aws.core_services
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "API / Get Trace By Notification ID"
+
+  log_group_names = [
+    local.eks_application_log_group
+  ]
+
+  query_string = <<QUERY
+fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as pod_name, @logStream
+| filter kubernetes.container_name like /^${local.api_name}/
+| filter @message like /d9cc47e6-b1a3-4c83-8d3c-ab40874307b1/
+| sort @timestamp asc
+| limit 100
+QUERY
+}
+
+resource "aws_cloudwatch_query_definition" "api-sending-times-aggregate" {
+  provider = aws.core_services
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "API / API send times aggregate"
+
+  log_group_names = [
+    local.eks_application_log_group
+  ]
+
+  query_string = <<QUERY
+fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as pod_name, @logStream
+| filter kubernetes.container_name like /^${local.api_name}/
+| filter @message like /time_taken/ and @message like /Batch saving/
+| parse @message "time_taken: *ms" as duration
+| parse @message "full_path: '/v2/notifications/*'" as send_type
+| parse @message "template_id: '*'" as template_id
+| sort @timestamp desc
+| stats 
+    count(*) as total_sends,
+    sum(if(duration <= 400, 1, 0)) as requests_under_400ms,
+    sum(if(duration > 400 and duration <= 1000, 1, 0)) as requests_under_1s,
+    sum(if(duration > 1000, 1, 0)) as requests_over_1s,
+    (sum(if(duration <= 400, 1, 0)) * 100.0 / count(*)) as percent_under_400ms,
+    (sum(if(duration > 400 and duration <= 1000, 1, 0)) * 100.0 / count(*)) as percent_under_1s, 
+    (sum(if(duration > 1000, 1, 0)) * 100.0 / count(*)) as percent_over_1s
+| limit 20
+QUERY
+}
+
+resource "aws_cloudwatch_query_definition" "api-slowest-sends" {
+  provider = aws.core_services
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "API / API slowest sends"
+
+  log_group_names = [
+    local.eks_application_log_group
+  ]
+
+  query_string = <<QUERY
+fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as pod_name, @logStream
+| filter kubernetes.container_name like /^${local.api_name}/
+| filter @message like /time_taken/ and @message like /Batch saving/
+| parse @message "time_taken: *ms" as duration
+| parse @message "full_path: '/v2/notifications/*'" as send_type
+| parse @message "template_id: '*'" as template_id
+| sort duration desc
+| limit 20
+QUERY
+}
+
+resource "aws_cloudwatch_query_definition" "api_errors_by_ip_address" {
+  provider = aws.core_services
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "API / API error by IP address"
+
+  log_group_names = [
+    local.eks_application_log_group
+  ]
+
+  query_string = <<QUERY
+fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as pod_name, @logStream
+| filter kubernetes.container_name like /^${local.api_name}/
+| filter @message like /HTTP\/\d+\.\d+\\" 50\d/
+| parse @message /"clientIP":"*"/ as ip
+| stats count() as total by ip
+| order by total desc
+| limit 1000
+QUERY
+}
+
+resource "aws_cloudwatch_query_definition" "api_average_latency" {
+  provider = aws.core_services
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "API / Average Latency"
+
+  log_group_names = [
+    local.eks_application_log_group
+  ]
+
+  query_string = <<QUERY
+fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as pod_name, @logStream
+| filter kubernetes.container_name like /^${local.api_name}/
+| parse @message "full_path: '*'" as resourcePath
+| parse @message "time_taken: *ms" as responseLatency
+| filter ispresent(responseLatency)
+| stats 
+    count() as requests,
+    avg(responseLatency) as avgLatency,
+    pct(responseLatency, 95) as p95Latency,
+    max(responseLatency) as maxLatency
+    by resourcePath,
+       if(responseLatency < 400, "under 400ms",
+          if(responseLatency < 1000, "400ms - 1s", "over 1s")
+       ) as latencyBucket
+| sort avgLatency desc
+QUERY
+}
+
+resource "aws_cloudwatch_query_definition" "api_concurrent_running_per_min" {
+  provider = aws.core_services
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "API / Concurrent API requests per min"
+
+  log_group_names = [
+    local.eks_application_log_group
+  ]
+
+  query_string = <<QUERY
+fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as pod_name, @logStream
+| filter kubernetes.container_name like /^${local.api_name}/
+| parse @message /(?<httpMethod>GET|POST|PUT|DELETE|PATCH) (?<path>\/[^ ]*)/
+| filter ispresent(httpMethod)
+| stats count() as requests by bin(1m)
+| sort requests desc
+QUERY
+}
+
+resource "aws_cloudwatch_query_definition" "api_gunicorn_total_running_time" {
+  provider = aws.core_services
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "API / Gunicorn total running time"
+
+  log_group_names = [
+    local.eks_application_log_group
+  ]
+
+  query_string = <<QUERY
+fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as pod_name, @logStream
+| filter kubernetes.container_name like /^${local.api_name}/
+| filter @message like /Total gunicorn running time/
+| parse @message /Total gunicorn API running time: (?<@gunicorn_time>.*?) seconds/
+| order by @timestamp asc
+| display @timestamp, @gunicorn_time
+QUERY
+}


### PR DESCRIPTION
# Summary | Résumé

Move the aws cloudwatch log insights queries for API lambda to EKS since we deleted the API Lambda. I've tested this a bit in dev and it works but will need further testing once deployed to staging.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/906

## Test instructions | Instructions pour tester la modification

TF Apply works
Check the queries in log analytics

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
