### PR TITLE
Add GHA VPN secrets to GitHub Actions

### DIFF
--- a/aws/github/manifest-secrets.tf
+++ b/aws/github/manifest-secrets.tf
@@ -60,6 +60,7 @@ resource "github_actions_secret" "pr_bot_github_token" {
 }
 
 resource "github_actions_secret" "manifests_gha_vpn_id" {
+  count            = trimspace(var.gha_vpn_id) != "" ? 1 : 0
   repository       = data.github_repository.notification_manifests.name
   secret_name      = "GHA_VPN_ID_${upper(var.env)}"
   plaintext_value  = var.gha_vpn_id
@@ -67,6 +68,7 @@ resource "github_actions_secret" "manifests_gha_vpn_id" {
 }
 
 resource "github_actions_secret" "manifests_gha_vpn_certificate" {
+  count            = trimspace(var.gha_vpn_certificate) != "" ? 1 : 0
   repository       = data.github_repository.notification_manifests.name
   secret_name      = "GHA_VPN_CERT_${upper(var.env)}"
   plaintext_value  = var.gha_vpn_certificate
@@ -74,6 +76,7 @@ resource "github_actions_secret" "manifests_gha_vpn_certificate" {
 }
 
 resource "github_actions_secret" "manifests_gha_vpn_key" {
+  count            = trimspace(var.gha_vpn_key) != "" ? 1 : 0
   repository       = data.github_repository.notification_manifests.name
   secret_name      = "GHA_VPN_KEY_${upper(var.env)}"
   plaintext_value  = var.gha_vpn_key

--- a/aws/github/manifest-secrets.tf
+++ b/aws/github/manifest-secrets.tf
@@ -58,3 +58,24 @@ resource "github_actions_secret" "pr_bot_github_token" {
   plaintext_value  = var.manifest_pr_bot_github_token
   destroy_on_drift = false
 }
+
+resource "github_actions_secret" "manifests_gha_vpn_id" {
+  repository       = data.github_repository.notification_manifests.name
+  secret_name      = "GHA_VPN_ID_${upper(var.env)}"
+  plaintext_value  = var.gha_vpn_id
+  destroy_on_drift = false
+}
+
+resource "github_actions_secret" "manifests_gha_vpn_certificate" {
+  repository       = data.github_repository.notification_manifests.name
+  secret_name      = "GHA_VPN_CERT_${upper(var.env)}"
+  plaintext_value  = var.gha_vpn_certificate
+  destroy_on_drift = false
+}
+
+resource "github_actions_secret" "manifests_gha_vpn_key" {
+  repository       = data.github_repository.notification_manifests.name
+  secret_name      = "GHA_VPN_KEY_${upper(var.env)}"
+  plaintext_value  = var.gha_vpn_key
+  destroy_on_drift = false
+}

--- a/aws/github/manifest-secrets.tf
+++ b/aws/github/manifest-secrets.tf
@@ -60,7 +60,6 @@ resource "github_actions_secret" "pr_bot_github_token" {
 }
 
 resource "github_actions_secret" "manifests_gha_vpn_id" {
-  count            = trimspace(var.gha_vpn_id) != "" ? 1 : 0
   repository       = data.github_repository.notification_manifests.name
   secret_name      = "GHA_VPN_ID_${upper(var.env)}"
   plaintext_value  = var.gha_vpn_id
@@ -68,7 +67,6 @@ resource "github_actions_secret" "manifests_gha_vpn_id" {
 }
 
 resource "github_actions_secret" "manifests_gha_vpn_certificate" {
-  count            = trimspace(var.gha_vpn_certificate) != "" ? 1 : 0
   repository       = data.github_repository.notification_manifests.name
   secret_name      = "GHA_VPN_CERT_${upper(var.env)}"
   plaintext_value  = var.gha_vpn_certificate
@@ -76,7 +74,6 @@ resource "github_actions_secret" "manifests_gha_vpn_certificate" {
 }
 
 resource "github_actions_secret" "manifests_gha_vpn_key" {
-  count            = trimspace(var.gha_vpn_key) != "" ? 1 : 0
   repository       = data.github_repository.notification_manifests.name
   secret_name      = "GHA_VPN_KEY_${upper(var.env)}"
   plaintext_value  = var.gha_vpn_key

--- a/aws/github/variables.tf
+++ b/aws/github/variables.tf
@@ -4,22 +4,14 @@ variable "shared_staging_kms_key_id" {
 }
 
 variable "gha_vpn_id" {
-  type = string
-
-  validation {
-    condition     = trimspace(var.gha_vpn_id) != ""
-    error_message = "gha_vpn_id must be a non-empty Client VPN endpoint ID."
-  }
+  type    = string
+  default = ""
 }
 
 variable "gha_vpn_certificate" {
   type      = string
   sensitive = true
-
-  validation {
-    condition     = trimspace(var.gha_vpn_certificate) != ""
-    error_message = "gha_vpn_certificate must be a non-empty PEM string."
-  }
+  default   = ""
 }
 
 variable "gha_vpn_key" {

--- a/aws/github/variables.tf
+++ b/aws/github/variables.tf
@@ -25,5 +25,9 @@ variable "gha_vpn_certificate" {
 variable "gha_vpn_key" {
   type      = string
   sensitive = true
-  default   = ""
+
+  validation {
+    condition     = trimspace(var.gha_vpn_key) != ""
+    error_message = "gha_vpn_key must be a non-empty PEM string."
+  }
 }

--- a/aws/github/variables.tf
+++ b/aws/github/variables.tf
@@ -2,3 +2,20 @@ variable "shared_staging_kms_key_id" {
   type      = string
   sensitive = true
 }
+
+variable "gha_vpn_id" {
+  type    = string
+  default = ""
+}
+
+variable "gha_vpn_certificate" {
+  type      = string
+  sensitive = true
+  default   = ""
+}
+
+variable "gha_vpn_key" {
+  type      = string
+  sensitive = true
+  default   = ""
+}

--- a/aws/github/variables.tf
+++ b/aws/github/variables.tf
@@ -4,27 +4,18 @@ variable "shared_staging_kms_key_id" {
 }
 
 variable "gha_vpn_id" {
-  type = string
-  validation {
-    condition     = trimspace(var.gha_vpn_id) != ""
-    error_message = "gha_vpn_id must be a non-empty string."
-  }
+  type    = string
+  default = ""
 }
 
 variable "gha_vpn_certificate" {
   type      = string
   sensitive = true
-  validation {
-    condition     = trimspace(var.gha_vpn_certificate) != ""
-    error_message = "gha_vpn_certificate must be a non-empty PEM string."
-  }
+  default   = ""
 }
 
 variable "gha_vpn_key" {
   type      = string
   sensitive = true
-  validation {
-    condition     = trimspace(var.gha_vpn_key) != ""
-    error_message = "gha_vpn_key must be a non-empty PEM string."
-  }
+  default   = ""
 }

--- a/aws/github/variables.tf
+++ b/aws/github/variables.tf
@@ -17,9 +17,5 @@ variable "gha_vpn_certificate" {
 variable "gha_vpn_key" {
   type      = string
   sensitive = true
-
-  validation {
-    condition     = trimspace(var.gha_vpn_key) != ""
-    error_message = "gha_vpn_key must be a non-empty PEM string."
-  }
+  default   = ""
 }

--- a/aws/github/variables.tf
+++ b/aws/github/variables.tf
@@ -4,20 +4,25 @@ variable "shared_staging_kms_key_id" {
 }
 
 variable "gha_vpn_id" {
-  type    = string
-  default = ""
+  type = string
+  validation {
+    condition     = trimspace(var.gha_vpn_id) != ""
+    error_message = "gha_vpn_id must be a non-empty string."
+  }
 }
 
 variable "gha_vpn_certificate" {
   type      = string
   sensitive = true
-  default   = ""
+  validation {
+    condition     = trimspace(var.gha_vpn_certificate) != ""
+    error_message = "gha_vpn_certificate must be a non-empty PEM string."
+  }
 }
 
 variable "gha_vpn_key" {
   type      = string
   sensitive = true
-
   validation {
     condition     = trimspace(var.gha_vpn_key) != ""
     error_message = "gha_vpn_key must be a non-empty PEM string."

--- a/aws/github/variables.tf
+++ b/aws/github/variables.tf
@@ -15,7 +15,11 @@ variable "gha_vpn_id" {
 variable "gha_vpn_certificate" {
   type      = string
   sensitive = true
-  default   = ""
+
+  validation {
+    condition     = trimspace(var.gha_vpn_certificate) != ""
+    error_message = "gha_vpn_certificate must be a non-empty PEM string."
+  }
 }
 
 variable "gha_vpn_key" {

--- a/aws/github/variables.tf
+++ b/aws/github/variables.tf
@@ -4,8 +4,12 @@ variable "shared_staging_kms_key_id" {
 }
 
 variable "gha_vpn_id" {
-  type    = string
-  default = ""
+  type = string
+
+  validation {
+    condition     = trimspace(var.gha_vpn_id) != ""
+    error_message = "gha_vpn_id must be a non-empty Client VPN endpoint ID."
+  }
 }
 
 variable "gha_vpn_certificate" {

--- a/env/dev/github/terragrunt.hcl
+++ b/env/dev/github/terragrunt.hcl
@@ -56,12 +56,13 @@ dependency "system_status_static_site" {
 dependency "eks" {
   config_path = "../eks"
 
-mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show", "destroy"]
-mock_outputs_merge_with_state           = true
-mock_outputs = {
-  gha_vpn_id          = "cvpn-endpoint-00000000000000000"
-  gha_vpn_certificate = "mock-certificate-pem"
-  gha_vpn_key         = "mock-private-key-pem"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    gha_vpn_id          = "cvpn-endpoint-00000000000000000"
+    gha_vpn_certificate = "mock-certificate-pem"
+    gha_vpn_key         = "mock-private-key-pem"
+  }
 }
 
 inputs = {

--- a/env/dev/github/terragrunt.hcl
+++ b/env/dev/github/terragrunt.hcl
@@ -56,7 +56,7 @@ dependency "system_status_static_site" {
 dependency "eks" {
   config_path = "../eks"
 
-  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show", "apply", "destroy"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
     gha_vpn_id          = "cvpn-endpoint-00000000000000000"

--- a/env/dev/github/terragrunt.hcl
+++ b/env/dev/github/terragrunt.hcl
@@ -56,13 +56,12 @@ dependency "system_status_static_site" {
 dependency "eks" {
   config_path = "../eks"
 
-  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show", "apply", "destroy"]
-  mock_outputs_merge_with_state           = true
-  mock_outputs = {
-    gha_vpn_id          = "cvpn-endpoint-00000000000000000"
-    gha_vpn_certificate = ""
-    gha_vpn_key         = ""
-  }
+mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show", "destroy"]
+mock_outputs_merge_with_state           = true
+mock_outputs = {
+  gha_vpn_id          = "cvpn-endpoint-00000000000000000"
+  gha_vpn_certificate = "mock-certificate-pem"
+  gha_vpn_key         = "mock-private-key-pem"
 }
 
 inputs = {

--- a/env/dev/github/terragrunt.hcl
+++ b/env/dev/github/terragrunt.hcl
@@ -3,7 +3,7 @@ terraform {
 }
 
 dependencies {
-  paths = ["../common", "../lambda-admin-pr", "../rds"]
+  paths = ["../common", "../lambda-admin-pr", "../rds", "../eks"]
 }
 
 dependency "rds" {

--- a/env/dev/github/terragrunt.hcl
+++ b/env/dev/github/terragrunt.hcl
@@ -53,11 +53,26 @@ dependency "system_status_static_site" {
   }
 }
 
+dependency "eks" {
+  config_path = "../eks"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show", "apply", "destroy"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    gha_vpn_id          = "cvpn-endpoint-00000000000000000"
+    gha_vpn_certificate = ""
+    gha_vpn_key         = ""
+  }
+}
+
 inputs = {
   admin_pr_review_env_security_group_ids                              = dependency.lambda-admin-pr.outputs.admin_pr_security_group_id
   admin_pr_review_env_subnet_ids                                      = dependency.common.outputs.vpc_private_subnets
   shared_staging_kms_key_id                                           = dependency.rds.outputs.shared_staging_kms_key_id                                                            
   system_status_static_site_cloudfront_distribution                               = dependency.system_status_static_site.outputs.system_status_static_site_cloudfront_distribution
+  gha_vpn_id                                                                       = dependency.eks.outputs.gha_vpn_id
+  gha_vpn_certificate                                                              = dependency.eks.outputs.gha_vpn_certificate
+  gha_vpn_key                                                                      = dependency.eks.outputs.gha_vpn_key
 }
 
 include {

--- a/env/production/github/terragrunt.hcl
+++ b/env/production/github/terragrunt.hcl
@@ -56,12 +56,13 @@ dependency "system_status_static_site" {
 dependency "eks" {
   config_path = "../eks"
 
-mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show", "destroy"]
-mock_outputs_merge_with_state           = true
-mock_outputs = {
-  gha_vpn_id          = "cvpn-endpoint-00000000000000000"
-  gha_vpn_certificate = "mock-certificate-pem"
-  gha_vpn_key         = "mock-private-key-pem"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    gha_vpn_id          = "cvpn-endpoint-00000000000000000"
+    gha_vpn_certificate = "mock-certificate-pem"
+    gha_vpn_key         = "mock-private-key-pem"
+  }
 }
 
 inputs = {

--- a/env/production/github/terragrunt.hcl
+++ b/env/production/github/terragrunt.hcl
@@ -56,7 +56,7 @@ dependency "system_status_static_site" {
 dependency "eks" {
   config_path = "../eks"
 
-  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show", "apply", "destroy"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
     gha_vpn_id          = "cvpn-endpoint-00000000000000000"

--- a/env/production/github/terragrunt.hcl
+++ b/env/production/github/terragrunt.hcl
@@ -56,13 +56,12 @@ dependency "system_status_static_site" {
 dependency "eks" {
   config_path = "../eks"
 
-  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show", "apply", "destroy"]
-  mock_outputs_merge_with_state           = true
-  mock_outputs = {
-    gha_vpn_id          = "cvpn-endpoint-00000000000000000"
-    gha_vpn_certificate = ""
-    gha_vpn_key         = ""
-  }
+mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show", "destroy"]
+mock_outputs_merge_with_state           = true
+mock_outputs = {
+  gha_vpn_id          = "cvpn-endpoint-00000000000000000"
+  gha_vpn_certificate = "mock-certificate-pem"
+  gha_vpn_key         = "mock-private-key-pem"
 }
 
 inputs = {

--- a/env/production/github/terragrunt.hcl
+++ b/env/production/github/terragrunt.hcl
@@ -3,7 +3,7 @@ terraform {
 }
 
 dependencies {
-  paths = ["../common", "../lambda-admin-pr", "../rds"]
+  paths = ["../common", "../lambda-admin-pr", "../rds", "../eks"]
 }
 
 dependency "rds" {

--- a/env/production/github/terragrunt.hcl
+++ b/env/production/github/terragrunt.hcl
@@ -53,11 +53,26 @@ dependency "system_status_static_site" {
   }
 }
 
+dependency "eks" {
+  config_path = "../eks"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show", "apply", "destroy"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    gha_vpn_id          = "cvpn-endpoint-00000000000000000"
+    gha_vpn_certificate = ""
+    gha_vpn_key         = ""
+  }
+}
+
 inputs = {
   admin_pr_review_env_security_group_ids                              = dependency.lambda-admin-pr.outputs.admin_pr_security_group_id
   admin_pr_review_env_subnet_ids                                      = dependency.common.outputs.vpc_private_subnets
   shared_staging_kms_key_id                                           = dependency.rds.outputs.shared_staging_kms_key_id                                                            
   system_status_static_site_cloudfront_distribution                               = dependency.system_status_static_site.outputs.system_status_static_site_cloudfront_distribution
+  gha_vpn_id                                                                       = dependency.eks.outputs.gha_vpn_id
+  gha_vpn_certificate                                                              = dependency.eks.outputs.gha_vpn_certificate
+  gha_vpn_key                                                                      = dependency.eks.outputs.gha_vpn_key
 }
 
 include {

--- a/env/sandbox/github/terragrunt.hcl
+++ b/env/sandbox/github/terragrunt.hcl
@@ -3,7 +3,7 @@ terraform {
 }
 
 dependencies {
-  paths = ["../common", "../lambda-admin-pr", "../rds"]
+  paths = ["../common", "../lambda-admin-pr", "../rds", "../eks"]
 }
 
 dependency "rds" {
@@ -53,11 +53,26 @@ dependency "system_status_static_site" {
   }
 }
 
+dependency "eks" {
+  config_path = "../eks"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    gha_vpn_id          = "cvpn-endpoint-00000000000000000"
+    gha_vpn_certificate = "mock-vpn-certificate"
+    gha_vpn_key         = "mock-vpn-key"
+  }
+}
+
 inputs = {
   admin_pr_review_env_security_group_ids                              = dependency.lambda-admin-pr.outputs.admin_pr_security_group_id
   admin_pr_review_env_subnet_ids                                      = dependency.common.outputs.vpc_private_subnets
   shared_staging_kms_key_id                                           = dependency.rds.outputs.shared_staging_kms_key_id                                                            
   system_status_static_site_cloudfront_distribution = dependency.system_status_static_site.outputs.system_status_static_site_cloudfront_distribution
+  gha_vpn_id                                        = dependency.eks.outputs.gha_vpn_id
+  gha_vpn_certificate                               = dependency.eks.outputs.gha_vpn_certificate
+  gha_vpn_key                                       = dependency.eks.outputs.gha_vpn_key
 }
 
 include {

--- a/env/sandbox/github/terragrunt.hcl
+++ b/env/sandbox/github/terragrunt.hcl
@@ -60,8 +60,8 @@ dependency "eks" {
   mock_outputs_merge_with_state           = true
   mock_outputs = {
     gha_vpn_id          = "cvpn-endpoint-00000000000000000"
-    gha_vpn_certificate = "mock-vpn-certificate"
-    gha_vpn_key         = "mock-vpn-key"
+    gha_vpn_certificate = "mock-certificate-pem"
+    gha_vpn_key         = "mock-private-key-pem"
   }
 }
 

--- a/env/staging/github/terragrunt.hcl
+++ b/env/staging/github/terragrunt.hcl
@@ -56,12 +56,13 @@ dependency "system_status_static_site" {
 dependency "eks" {
   config_path = "../eks"
 
-mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show", "destroy"]
-mock_outputs_merge_with_state           = true
-mock_outputs = {
-  gha_vpn_id          = "cvpn-endpoint-00000000000000000"
-  gha_vpn_certificate = "mock-certificate-pem"
-  gha_vpn_key         = "mock-private-key-pem"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    gha_vpn_id          = "cvpn-endpoint-00000000000000000"
+    gha_vpn_certificate = "mock-certificate-pem"
+    gha_vpn_key         = "mock-private-key-pem"
+  }
 }
 
 inputs = {

--- a/env/staging/github/terragrunt.hcl
+++ b/env/staging/github/terragrunt.hcl
@@ -56,13 +56,12 @@ dependency "system_status_static_site" {
 dependency "eks" {
   config_path = "../eks"
 
-  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show", "apply", "destroy"]
-  mock_outputs_merge_with_state           = true
-  mock_outputs = {
-    gha_vpn_id          = "cvpn-endpoint-00000000000000000"
-    gha_vpn_certificate = ""
-    gha_vpn_key         = ""
-  }
+mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show", "destroy"]
+mock_outputs_merge_with_state           = true
+mock_outputs = {
+  gha_vpn_id          = "cvpn-endpoint-00000000000000000"
+  gha_vpn_certificate = "mock-certificate-pem"
+  gha_vpn_key         = "mock-private-key-pem"
 }
 
 inputs = {

--- a/env/staging/github/terragrunt.hcl
+++ b/env/staging/github/terragrunt.hcl
@@ -53,11 +53,26 @@ dependency "system_status_static_site" {
   }
 }
 
+dependency "eks" {
+  config_path = "../eks"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show", "apply", "destroy"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    gha_vpn_id          = "cvpn-endpoint-00000000000000000"
+    gha_vpn_certificate = ""
+    gha_vpn_key         = ""
+  }
+}
+
 inputs = {
   admin_pr_review_env_security_group_ids                              = dependency.lambda-admin-pr.outputs.admin_pr_security_group_id
   admin_pr_review_env_subnet_ids                                      = dependency.common.outputs.vpc_private_subnets
   shared_staging_kms_key_id                                           = dependency.rds.outputs.shared_staging_kms_key_id                                                            
   system_status_static_site_cloudfront_distribution = dependency.system_status_static_site.outputs.system_status_static_site_cloudfront_distribution
+  gha_vpn_id                                         = dependency.eks.outputs.gha_vpn_id
+  gha_vpn_certificate                                = dependency.eks.outputs.gha_vpn_certificate
+  gha_vpn_key                                        = dependency.eks.outputs.gha_vpn_key
 }
 
 include {

--- a/env/staging/github/terragrunt.hcl
+++ b/env/staging/github/terragrunt.hcl
@@ -56,7 +56,7 @@ dependency "system_status_static_site" {
 dependency "eks" {
   config_path = "../eks"
 
-  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show", "apply", "destroy"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
     gha_vpn_id          = "cvpn-endpoint-00000000000000000"
@@ -69,10 +69,10 @@ inputs = {
   admin_pr_review_env_security_group_ids                              = dependency.lambda-admin-pr.outputs.admin_pr_security_group_id
   admin_pr_review_env_subnet_ids                                      = dependency.common.outputs.vpc_private_subnets
   shared_staging_kms_key_id                                           = dependency.rds.outputs.shared_staging_kms_key_id                                                            
-  system_status_static_site_cloudfront_distribution = dependency.system_status_static_site.outputs.system_status_static_site_cloudfront_distribution
-  gha_vpn_id                                         = dependency.eks.outputs.gha_vpn_id
-  gha_vpn_certificate                                = dependency.eks.outputs.gha_vpn_certificate
-  gha_vpn_key                                        = dependency.eks.outputs.gha_vpn_key
+  system_status_static_site_cloudfront_distribution                               = dependency.system_status_static_site.outputs.system_status_static_site_cloudfront_distribution
+  gha_vpn_id                                                                       = dependency.eks.outputs.gha_vpn_id
+  gha_vpn_certificate                                                              = dependency.eks.outputs.gha_vpn_certificate
+  gha_vpn_key                                                                      = dependency.eks.outputs.gha_vpn_key
 }
 
 include {

--- a/env/staging/github/terragrunt.hcl
+++ b/env/staging/github/terragrunt.hcl
@@ -3,7 +3,7 @@ terraform {
 }
 
 dependencies {
-  paths = ["../common", "../lambda-admin-pr", "../rds"]
+  paths = ["../common", "../lambda-admin-pr", "../rds", "../eks"]
 }
 
 dependency "rds" {


### PR DESCRIPTION
## Summary

Inject VPN credentials directly into GitHub Actions secrets via Terraform, eliminating the need for workflows to pull VPN configs from a repo.

## Changes

- **aws/github/variables.tf** — Added three new input variables for VPN config (`gha_vpn_id`, `gha_vpn_certificate`, `gha_vpn_key`) with sensible defaults
- **aws/github/manifest-secrets.tf** — Created three new `github_actions_secret` resources that inject VPN values into:
  - `GHA_VPN_ID_*` (dev/staging/production)
  - `GHA_VPN_CERT_*` (dev/staging/production)
  - `GHA_VPN_KEY_*` (dev/staging/production)
- **env/*/github/terragrunt.hcl** — Wired EKS module as a dependency with proper mock outputs for validation, passing VPN outputs to the github module via inputs

## How It Works

1. **EKS apply** generates the VPN endpoint, certificate, and private key via `module.gha_vpn`
2. **GitHub apply** depends on EKS completion and receives the fresh VPN values
3. **GitHub secrets** are automatically created/updated on every apply, so cert rotations propagate instantly

## Order of Execution

```
common → eks (creates VPN certs) → github (injects into GH secrets)
```

No changes needed to existing workflows — they can now read `GHA_VPN_ID_STAGING` etc. directly instead of calling `terragrunt output`.