### PR TITLE
JA4 count rules and athena table recreate

### DIFF
--- a/aws/common/sql/waf_log_create_table.sql.tmpl
+++ b/aws/common/sql/waf_log_create_table.sql.tmpl
@@ -97,11 +97,12 @@ CREATE EXTERNAL TABLE `${database_name}.${table_name}` (
                         responsecode:string,
                         solvetimestamp:bigint,
                         failurereason:string
-                    >
+                    >,
+  `ja4fingerprint` string
 )
 ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
 WITH SERDEPROPERTIES (
- 'paths'='action,formatVersion,httpRequest,httpSourceId,httpSourceName,labels,nonTerminatingMatchingRules,rateBasedRuleList,requestHeadersInserted,responseCodeSent,ruleGroupList,terminatingRuleId,terminatingRuleMatchDetails,terminatingRuleType,timestamp,webaclId,captchaResponse')
+ 'paths'='action,formatVersion,httpRequest,httpSourceId,httpSourceName,ja4Fingerprint,labels,nonTerminatingMatchingRules,rateBasedRuleList,requestHeadersInserted,responseCodeSent,ruleGroupList,terminatingRuleId,terminatingRuleMatchDetails,terminatingRuleType,timestamp,webaclId,captchaResponse')
 STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'
 OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
 LOCATION '${bucket_location}';

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -1026,7 +1026,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
         aggregate_key_type = "CUSTOM_KEYS"
         custom_key {
           ja4_fingerprint {
-            fallback_behavior = "MATCH"
+            fallback_behavior = "NO_MATCH"
           }
         }
         scope_down_statement {
@@ -1111,7 +1111,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
         aggregate_key_type = "CUSTOM_KEYS"
         custom_key {
           ja4_fingerprint {
-            fallback_behavior = "MATCH"
+            fallback_behavior = "NO_MATCH"
           }
         }
         scope_down_statement {

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -1004,6 +1004,162 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     }
   }
 
+  # ~22 WCU - JA4 fingerprint rate limit on sign-in paths; catches credential-stuffing tools that rotate IPs
+  # Count-only until baseline is established. Move before priority 8 when switching to block.
+  rule {
+    name     = "SigninRateLimitRule_JA4"
+    priority = 18
+
+    action {
+      count {}
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "SigninRateLimitRule_JA4"
+      sampled_requests_enabled   = true
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.sign_in_ja4_waf_rate_limit
+        aggregate_key_type = "CUSTOM_KEYS"
+        custom_key {
+          ja4_fingerprint {
+            fallback_behavior = "MATCH"
+          }
+        }
+        scope_down_statement {
+          or_statement {
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                positional_constraint = "STARTS_WITH"
+                search_string         = "/sign-in"
+                text_transformation {
+                  type     = "LOWERCASE"
+                  priority = 0
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                positional_constraint = "STARTS_WITH"
+                search_string         = "/register"
+                text_transformation {
+                  type     = "LOWERCASE"
+                  priority = 1
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                positional_constraint = "STARTS_WITH"
+                search_string         = "/forgot-password"
+                text_transformation {
+                  type     = "LOWERCASE"
+                  priority = 2
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                positional_constraint = "STARTS_WITH"
+                search_string         = "/forced-password-reset"
+                text_transformation {
+                  type     = "LOWERCASE"
+                  priority = 3
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  # ~22 WCU - JA4 fingerprint rate limit on the API host; catches API abuse tools that rotate IPs
+  # Count-only until baseline is established. Move before priority 8 when switching to block.
+  rule {
+    name     = "ApiRateLimit_JA4"
+    priority = 19
+
+    action {
+      count {}
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "ApiRateLimit_JA4"
+      sampled_requests_enabled   = true
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.api_ja4_waf_rate_limit
+        aggregate_key_type = "CUSTOM_KEYS"
+        custom_key {
+          ja4_fingerprint {
+            fallback_behavior = "MATCH"
+          }
+        }
+        scope_down_statement {
+          and_statement {
+            statement {
+              byte_match_statement {
+                positional_constraint = "STARTS_WITH"
+                field_to_match {
+                  single_header {
+                    name = "host"
+                  }
+                }
+                search_string = "api"
+                text_transformation {
+                  priority = 1
+                  type     = "COMPRESS_WHITE_SPACE"
+                }
+                text_transformation {
+                  priority = 2
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+            statement {
+              not_statement {
+                statement {
+                  byte_match_statement {
+                    positional_constraint = "EXACTLY"
+                    field_to_match {
+                      single_header {
+                        name = "waf-secret"
+                      }
+                    }
+                    search_string = var.waf_secret
+                    text_transformation {
+                      priority = 1
+                      type     = "NONE"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
   }

--- a/env/dev_config.tfvars
+++ b/env/dev_config.tfvars
@@ -26,6 +26,8 @@ eks_karpenter_ami_id            = "ami-0e7496e747026e14c"
 non_api_waf_rate_limit          = 750
 api_waf_rate_limit              = 30000
 sign_in_waf_rate_limit          = 100
+sign_in_ja4_waf_rate_limit      = 500
+api_ja4_waf_rate_limit          = 150000
 celery_queue_prefix             = "eks-notification-canada-ca"
 notify_k8s_namespace            = "notification-canada-ca"
 

--- a/env/production_config.tfvars
+++ b/env/production_config.tfvars
@@ -34,6 +34,8 @@ eks_karpenter_ami_id            = "ami-0e7496e747026e14c"
 non_api_waf_rate_limit          = 750
 api_waf_rate_limit              = 30000
 sign_in_waf_rate_limit          = 100
+sign_in_ja4_waf_rate_limit      = 500
+api_ja4_waf_rate_limit          = 150000
 celery_queue_prefix             = "eks-notification-canada-ca"
 notify_k8s_namespace            = "notification-canada-ca"
 

--- a/env/staging_config.tfvars
+++ b/env/staging_config.tfvars
@@ -27,6 +27,8 @@ eks_karpenter_ami_id            = "ami-0e7496e747026e14c"
 non_api_waf_rate_limit          = 750
 api_waf_rate_limit              = 30000
 sign_in_waf_rate_limit          = 100
+sign_in_ja4_waf_rate_limit      = 500
+api_ja4_waf_rate_limit          = 150000
 celery_queue_prefix             = "eks-notification-canada-ca"
 notify_k8s_namespace            = "notification-canada-ca"
 

--- a/env/variables.tf
+++ b/env/variables.tf
@@ -255,6 +255,14 @@ variable "sign_in_waf_rate_limit" {
   type = number
 }
 
+variable "sign_in_ja4_waf_rate_limit" {
+  type = number
+}
+
+variable "api_ja4_waf_rate_limit" {
+  type = number
+}
+
 variable "celery_queue_prefix" {
   type = string
 }


### PR DESCRIPTION
# Summary | Résumé

Implement JA4 fingerprinting rate limits. The rate limits are very high because these JA4 fingerprints are not client specific - they are tool specific. This prevents attacks with rotating IPs but could also block legitimate traffic. These rules are set to count right now. 

I've also updated the waf_logs athena table to pull the JA4 fingerprint so that we can identify P99 request rates and tune our rate limits accordingly.

## Related Issues | Cartes liées

*  https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/875

## Test instructions | Instructions pour tester la modification

TF Apply Works
Monitor rule

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
