### PR TITLE
Deleted duplicate query

### DIFF
--- a/aws/eks/cloudwatch_queries.tf
+++ b/aws/eks/cloudwatch_queries.tf
@@ -342,23 +342,6 @@ fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as
 QUERY
 }
 
-resource "aws_cloudwatch_query_definition" "api-gunicorn-total-time" {
-  provider = aws.core_services
-  count    = var.cloudwatch_enabled ? 1 : 0
-  name     = "API / GUnicorn total running time"
-
-  log_group_names = [
-    local.eks_application_log_group
-  ]
-
-  query_string = <<QUERY
-filter @message like /Total gunicorn API running time/
-| parse @message /Total gunicorn API running time: (?<@gunicorn_time>.*?) seconds/
-| order by @timestamp asc
-| display @timestamp, @gunicorn_time
-QUERY
-}
-
 resource "aws_cloudwatch_query_definition" "api-non-existent-domain-resolution-errors" {
   provider = aws.core_services
   count    = var.cloudwatch_enabled ? 1 : 0


### PR DESCRIPTION
# Summary | Résumé

Deleted duplicate query

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/906

## Test instructions | Instructions pour tester la modification

Verify the query doesn't exist anymore in cloudwatch log analysis saved queries.

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
