### PR TITLE
mutating request rate limit

### DIFF
--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -1160,6 +1160,168 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     }
   }
 
+  # ~24 WCU - IP rate limit on mutating methods (POST/PUT/PATCH/DELETE) to the API host.
+  # Lower threshold than ApiRateLimit to catch write-heavy abuse. Count-only until baseline established.
+  # Move before priority 8 when switching to block.
+  rule {
+    name     = "MutatingApiRateLimit"
+    priority = 20
+
+    action {
+      count {}
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "MutatingApiRateLimit"
+      sampled_requests_enabled   = true
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.api_mutating_waf_rate_limit
+        aggregate_key_type = "IP"
+        scope_down_statement {
+          and_statement {
+            statement {
+              byte_match_statement {
+                positional_constraint = "STARTS_WITH"
+                field_to_match {
+                  single_header {
+                    name = "host"
+                  }
+                }
+                search_string = "api"
+                text_transformation {
+                  priority = 1
+                  type     = "COMPRESS_WHITE_SPACE"
+                }
+                text_transformation {
+                  priority = 2
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+            statement {
+              not_statement {
+                statement {
+                  byte_match_statement {
+                    positional_constraint = "EXACTLY"
+                    field_to_match {
+                      single_header {
+                        name = "waf-secret"
+                      }
+                    }
+                    search_string = var.waf_secret
+                    text_transformation {
+                      priority = 1
+                      type     = "NONE"
+                    }
+                  }
+                }
+              }
+            }
+            statement {
+              regex_match_statement {
+                field_to_match {
+                  method {}
+                }
+                regex_string = "^(delete|patch|post|put)$"
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  # ~24 WCU - JA4 rate limit on mutating methods; catches write-abuse tools that rotate IPs.
+  # Count-only until baseline established. Move before priority 8 when switching to block.
+  rule {
+    name     = "MutatingApiRateLimit_JA4"
+    priority = 21
+
+    action {
+      count {}
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "MutatingApiRateLimit_JA4"
+      sampled_requests_enabled   = true
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.api_mutating_ja4_waf_rate_limit
+        aggregate_key_type = "CUSTOM_KEYS"
+        custom_key {
+          ja4_fingerprint {
+            fallback_behavior = "NO_MATCH"
+          }
+        }
+        scope_down_statement {
+          and_statement {
+            statement {
+              byte_match_statement {
+                positional_constraint = "STARTS_WITH"
+                field_to_match {
+                  single_header {
+                    name = "host"
+                  }
+                }
+                search_string = "api"
+                text_transformation {
+                  priority = 1
+                  type     = "COMPRESS_WHITE_SPACE"
+                }
+                text_transformation {
+                  priority = 2
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+            statement {
+              not_statement {
+                statement {
+                  byte_match_statement {
+                    positional_constraint = "EXACTLY"
+                    field_to_match {
+                      single_header {
+                        name = "waf-secret"
+                      }
+                    }
+                    search_string = var.waf_secret
+                    text_transformation {
+                      priority = 1
+                      type     = "NONE"
+                    }
+                  }
+                }
+              }
+            }
+            statement {
+              regex_match_statement {
+                field_to_match {
+                  method {}
+                }
+                regex_string = "^(delete|patch|post|put)$"
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   tags = {
     CostCenter = "notification-canada-ca-${var.env}"
   }

--- a/env/dev_config.tfvars
+++ b/env/dev_config.tfvars
@@ -28,6 +28,8 @@ api_waf_rate_limit              = 30000
 sign_in_waf_rate_limit          = 100
 sign_in_ja4_waf_rate_limit      = 500
 api_ja4_waf_rate_limit          = 150000
+api_mutating_waf_rate_limit     = 10000
+api_mutating_ja4_waf_rate_limit = 50000
 celery_queue_prefix             = "eks-notification-canada-ca"
 notify_k8s_namespace            = "notification-canada-ca"
 

--- a/env/production_config.tfvars
+++ b/env/production_config.tfvars
@@ -36,6 +36,8 @@ api_waf_rate_limit              = 30000
 sign_in_waf_rate_limit          = 100
 sign_in_ja4_waf_rate_limit      = 500
 api_ja4_waf_rate_limit          = 150000
+api_mutating_waf_rate_limit     = 10000
+api_mutating_ja4_waf_rate_limit = 50000
 celery_queue_prefix             = "eks-notification-canada-ca"
 notify_k8s_namespace            = "notification-canada-ca"
 

--- a/env/staging_config.tfvars
+++ b/env/staging_config.tfvars
@@ -29,6 +29,8 @@ api_waf_rate_limit              = 30000
 sign_in_waf_rate_limit          = 100
 sign_in_ja4_waf_rate_limit      = 500
 api_ja4_waf_rate_limit          = 150000
+api_mutating_waf_rate_limit     = 10000
+api_mutating_ja4_waf_rate_limit = 50000
 celery_queue_prefix             = "eks-notification-canada-ca"
 notify_k8s_namespace            = "notification-canada-ca"
 

--- a/env/variables.tf
+++ b/env/variables.tf
@@ -263,6 +263,14 @@ variable "api_ja4_waf_rate_limit" {
   type = number
 }
 
+variable "api_mutating_waf_rate_limit" {
+  type = number
+}
+
+variable "api_mutating_ja4_waf_rate_limit" {
+  type = number
+}
+
 variable "celery_queue_prefix" {
   type = string
 }


### PR DESCRIPTION
# Summary | Résumé

Rate limit mutating requests. 

Set to count only to verify the counts.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/875

## Test instructions | Instructions pour tester la modification

TF Apply works

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
