### PR TITLE
remaining waf rules

### DIFF
--- a/aws/common/athena_queries_support.tf
+++ b/aws/common/athena_queries_support.tf
@@ -1,3 +1,11 @@
+resource "aws_athena_named_query" "waf_rule_hit_counts" {
+  name        = "WAF: rule hit counts"
+  description = "Counts of requests matched per WAF rule (last 7 days), split by BLOCK and COUNT mode. Use to baseline count-mode rules before switching to block."
+  workgroup   = aws_athena_workgroup.support.name
+  database    = aws_athena_database.notification_athena.name
+  query       = templatefile("${path.module}/sql/waf_rule_hit_counts.sql.tmpl", {})
+}
+
 resource "aws_athena_named_query" "find_blocked_ips" {
   name        = "WAF: find blocked ips"
   description = "Find ips that Notify has recently blocked"

--- a/aws/common/sql/waf_rule_hit_counts.sql.tmpl
+++ b/aws/common/sql/waf_rule_hit_counts.sql.tmpl
@@ -1,0 +1,65 @@
+-- WAF: rule hit counts
+-- Shows how many requests each WAF rule matched over the last 7 days, split into:
+--   BLOCK         - rule terminated the request (custom or managed group sub-rule)
+--   COUNT (custom)  - custom rule running in count mode (action { count {} })
+--   COUNT (managed) - managed rule group sub-rule overridden to count
+--                     (e.g. CrossSiteScripting_BODY, SQLi_BODY, NoUserAgent_HEADER)
+--
+-- Use this to baseline count-mode rules before switching them to block.
+-- Adjust the INTERVAL value to change the time window.
+
+WITH time_window AS (
+    SELECT
+        terminatingruleid,
+        action,
+        nonterminatingmatchingrules,
+        rulegrouplist
+    FROM waf_logs
+    WHERE from_unixtime(timestamp / 1000e0) >= NOW() - INTERVAL '7' DAY
+),
+
+-- Requests terminated (blocked/challenged) by a rule
+blocking AS (
+    SELECT
+        terminatingruleid AS rule_id,
+        'BLOCK'           AS match_type,
+        COUNT(*)          AS hits
+    FROM time_window
+    WHERE action IN ('BLOCK', 'CAPTCHA', 'CHALLENGE')
+      AND terminatingruleid != 'Default_Action'
+    GROUP BY terminatingruleid
+),
+
+-- Custom rules running in count mode (action { count {} })
+custom_counting AS (
+    SELECT
+        rule.ruleid      AS rule_id,
+        'COUNT (custom)' AS match_type,
+        COUNT(*)         AS hits
+    FROM time_window
+    CROSS JOIN UNNEST(nonterminatingmatchingrules) AS t(rule)
+    GROUP BY rule.ruleid
+),
+
+-- Managed rule group sub-rules overridden to count
+-- (e.g. CrossSiteScripting_BODY, EC2MetaDataSSRF_BODY, SQLi_BODY, NoUserAgent_HEADER)
+managed_counting AS (
+    SELECT
+        rg_rule.ruleid    AS rule_id,
+        'COUNT (managed)' AS match_type,
+        COUNT(*)          AS hits
+    FROM time_window
+    CROSS JOIN UNNEST(rulegrouplist) AS t(rg)
+    CROSS JOIN UNNEST(rg.nonterminatingmatchingrules) AS t(rg_rule)
+    GROUP BY rg_rule.ruleid
+)
+
+SELECT rule_id, match_type, hits
+FROM blocking
+UNION ALL
+SELECT rule_id, match_type, hits
+FROM custom_counting
+UNION ALL
+SELECT rule_id, match_type, hits
+FROM managed_counting
+ORDER BY match_type, hits DESC

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -14,7 +14,7 @@
 #   5 |   ~20 | SigninRateLimitRule                         | BLOCK (rate, IP)
 #   6 |   ~22 | SigninRateLimitRule_JA4                     | count → BLOCK (rate, JA4)
 #   7 |   ~22 | ApiRateLimit_JA4                            | count → BLOCK (rate, JA4)
-#   8 |   ~23 | CanadaUSOnlyGeoRestriction                  | BLOCK (API host, non-CA/US)
+#   8 |   ~23 | CanadaUSOnlyGeoRestriction                  | BLOCK (API host, non-CA)
 #   9 |   ~24 | MutatingApiRateLimit                        | count → BLOCK (rate, IP)
 #  10 |   ~24 | MutatingApiRateLimit_JA4                    | count → BLOCK (rate, JA4)
 #  11 |   ~25 | PreventHostInjections                       | BLOCK
@@ -733,6 +733,20 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
                     }
                   }
                 }
+                # Letter PDF uploads
+                statement {
+                  byte_match_statement {
+                    field_to_match {
+                      uri_path {}
+                    }
+                    positional_constraint = "STARTS_WITH"
+                    search_string         = "/letters"
+                    text_transformation {
+                      priority = 0
+                      type     = "LOWERCASE"
+                    }
+                  }
+                }
               }
             }
           }
@@ -1087,7 +1101,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     }
   }
 
-  # ~30 WCU - Block non-CA/US access to authenticated admin pages.
+  # ~30 WCU - Block non-CA access to authenticated admin pages.
   # Public pages (sign-in, register, auth flows, GCA content, contact, newsletter, /_status) remain accessible worldwide.
   rule {
     name     = "AdminAuthenticatedPagesGeoRestriction"

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -1,3 +1,41 @@
+# =============================================================================
+# WAF Rule Priority Index
+# =============================================================================
+# Rules run in ascending priority order. Low-WCU terminating rules run first
+# so matched requests never reach expensive managed rule groups.
+# WCU figures are approximate. Count-mode rules are noted with (count).
+#
+# Pri | WCU   | Name                                        | Action
+# ----|-------|---------------------------------------------|----------------------------
+#   1 |    ~1 | ip_blocklist                                | BLOCK
+#   2 |   ~10 | BlockLargeRequests_CookiesAndHeaders        | count → BLOCK
+#   3 |   ~15 | BlockLargeRequests_Body                     | count → BLOCK
+#   4 |   ~20 | BlockFFUFUserAgent                          | BLOCK
+#   5 |   ~20 | SigninRateLimitRule                         | BLOCK (rate, IP)
+#   6 |   ~22 | SigninRateLimitRule_JA4                     | count → BLOCK (rate, JA4)
+#   7 |   ~22 | ApiRateLimit_JA4                            | count → BLOCK (rate, JA4)
+#   8 |   ~23 | CanadaUSOnlyGeoRestriction                  | BLOCK (API host, non-CA/US)
+#   9 |   ~24 | MutatingApiRateLimit                        | count → BLOCK (rate, IP)
+#  10 |   ~24 | MutatingApiRateLimit_JA4                    | count → BLOCK (rate, JA4)
+#  11 |   ~25 | PreventHostInjections                       | BLOCK
+#  12 |    25 | AWSManagedRulesAmazonIpReputationList        | BLOCK (managed)
+#  13 |   ~26 | rate_limit_all_except_api                   | BLOCK (rate, IP)
+#  14 |   ~26 | ApiRateLimit                                | BLOCK (rate, IP)
+#  15 |   ~30 | AdminAuthenticatedPagesGeoRestriction        | count → BLOCK (non-CA)
+#  16 |    50 | AWSManagedRulesAnonymousIpList               | BLOCK (managed)
+#  17 |   157 | valid_paths                                 | BLOCK
+#  18 |   200 | AWSManagedRulesKnownBadInputsRuleSet         | BLOCK (managed)
+#  19 |   200 | AWSManagedRulesLinuxRuleSet                  | BLOCK (managed)
+#  20 |   700 | AWSManagedRulesCommonRuleSet                 | BLOCK (managed, sets labels)
+#  21 |    ~3 | BlockLabeled_SSRF_NoUserAgent_NonCA          | count → BLOCK (label, after 20)
+#  22 |    ~6 | BlockSizeRestrictions_Body_ExcludeUploadPaths| count → BLOCK (label, after 20)
+#  23 |    ~6 | BlockLFI_Body_ExcludeTemplatePaths           | count → BLOCK (label, after 20)
+#  24 |    ~8 | BlockXSS_Body_ExcludeContentPaths            | count → BLOCK (label, after 20)
+#  25 |   200 | AWSManagedRulesSQLiRuleSet                   | BLOCK (managed, sets labels)
+#  26 |    ~6 | BlockSQLi_Body_ExcludeContentPaths           | count → BLOCK (label, after 25)
+#  27 |    ?? | AWSManagedRulesAntiDDoSRuleSet               | count (managed, non-API only)
+# =============================================================================
+
 resource "aws_wafv2_web_acl" "notification-canada-ca" {
   provider = aws.core_services
   name     = "notification-canada-ca-waf"
@@ -38,7 +76,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
   # 20 WCU
   rule {
     name     = "BlockFFUFUserAgent"
-    priority = 2
+    priority = 4
 
     action {
       block {}
@@ -70,7 +108,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
   # 23 WCU
   rule {
     name     = "CanadaUSOnlyGeoRestriction"
-    priority = 3
+    priority = 8
 
     action {
       block {}
@@ -118,7 +156,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
   # 25 WCU
   rule {
     name     = "PreventHostInjections"
-    priority = 4
+    priority = 11
 
     statement {
       not_statement {
@@ -243,7 +281,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
   # 26 WCU
   rule {
     name     = "rate_limit_all_except_api"
-    priority = 6
+    priority = 13
 
     action {
       block {
@@ -320,7 +358,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
   # 26 WCU
   rule {
     name     = "ApiRateLimit"
-    priority = 7
+    priority = 14
 
     action {
       block {
@@ -391,7 +429,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
   # 157 WCU
   rule {
     name     = "valid_paths"
-    priority = 8
+    priority = 17
 
     action {
       block {
@@ -546,10 +584,490 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
   # Use a bunch of AWS managed rules
   # See https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html
 
+  # ~10 WCU - Block requests with oversized cookies or headers.
+  # No path exclusions needed: legitimate use cases (including file uploads) do not require large cookies or headers.
+  rule {
+    name     = "BlockLargeRequests_CookiesAndHeaders"
+    priority = 2
+
+    action {
+      count {}
+    }
+
+    statement {
+      or_statement {
+        statement {
+          size_constraint_statement {
+            field_to_match {
+              cookies {
+                match_pattern {
+                  all {}
+                }
+                match_scope       = "ALL"
+                oversize_handling = "MATCH"
+              }
+            }
+            comparison_operator = "GT"
+            size                = 8192
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
+        statement {
+          size_constraint_statement {
+            field_to_match {
+              headers {
+                match_pattern {
+                  all {}
+                }
+                match_scope       = "ALL"
+                oversize_handling = "MATCH"
+              }
+            }
+            comparison_operator = "GT"
+            size                = 8192
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "BlockLargeRequests_CookiesAndHeaders"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # ~15 WCU - Block requests with oversized bodies, excluding file upload and bulk-send paths.
+  # Upload paths: CSV sends, template attachments, letter PDF validation, email branding logos,
+  #               inline bulk notification JSON (/v2/notifications/bulk).
+  # AWS WAF nesting limit (3 operator levels) requires body size and cookie/header size in separate rules.
+  rule {
+    name     = "BlockLargeRequests_Body"
+    priority = 3
+
+    action {
+      count {}
+    }
+
+    statement {
+      and_statement {
+        statement {
+          size_constraint_statement {
+            field_to_match {
+              body {
+                oversize_handling = "MATCH"
+              }
+            }
+            comparison_operator = "GT"
+            size                = 8192
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
+        statement {
+          not_statement {
+            statement {
+              or_statement {
+                # CSV bulk send and per-service file uploads (attachments, branding, letter PDFs)
+                statement {
+                  byte_match_statement {
+                    field_to_match {
+                      uri_path {}
+                    }
+                    positional_constraint = "STARTS_WITH"
+                    search_string         = "/services/"
+                    text_transformation {
+                      priority = 0
+                      type     = "LOWERCASE"
+                    }
+                  }
+                }
+                # Email branding logo uploads
+                statement {
+                  byte_match_statement {
+                    field_to_match {
+                      uri_path {}
+                    }
+                    positional_constraint = "STARTS_WITH"
+                    search_string         = "/email-branding/"
+                    text_transformation {
+                      priority = 0
+                      type     = "LOWERCASE"
+                    }
+                  }
+                }
+                # Platform admin PDF letter validation
+                statement {
+                  byte_match_statement {
+                    field_to_match {
+                      uri_path {}
+                    }
+                    positional_constraint = "STARTS_WITH"
+                    search_string         = "/platform-admin/letter-validation-preview"
+                    text_transformation {
+                      priority = 0
+                      type     = "LOWERCASE"
+                    }
+                  }
+                }
+                # Inline bulk notification JSON body (can be large with many recipients)
+                statement {
+                  byte_match_statement {
+                    field_to_match {
+                      uri_path {}
+                    }
+                    positional_constraint = "STARTS_WITH"
+                    search_string         = "/v2/notifications/bulk"
+                    text_transformation {
+                      priority = 0
+                      type     = "LOWERCASE"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "BlockLargeRequests_Body"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # ~22 WCU - JA4 fingerprint rate limit on sign-in paths; catches credential-stuffing tools that rotate IPs
+  # Count-only until baseline is established.
+  rule {
+    name     = "SigninRateLimitRule_JA4"
+    priority = 6
+
+    action {
+      count {}
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "SigninRateLimitRule_JA4"
+      sampled_requests_enabled   = true
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.sign_in_ja4_waf_rate_limit
+        aggregate_key_type = "CUSTOM_KEYS"
+        custom_key {
+          ja4_fingerprint {
+            fallback_behavior = "NO_MATCH"
+          }
+        }
+        scope_down_statement {
+          or_statement {
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                positional_constraint = "STARTS_WITH"
+                search_string         = "/sign-in"
+                text_transformation {
+                  type     = "LOWERCASE"
+                  priority = 0
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                positional_constraint = "STARTS_WITH"
+                search_string         = "/register"
+                text_transformation {
+                  type     = "LOWERCASE"
+                  priority = 1
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                positional_constraint = "STARTS_WITH"
+                search_string         = "/forgot-password"
+                text_transformation {
+                  type     = "LOWERCASE"
+                  priority = 2
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                positional_constraint = "STARTS_WITH"
+                search_string         = "/forced-password-reset"
+                text_transformation {
+                  type     = "LOWERCASE"
+                  priority = 3
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  # ~22 WCU - JA4 fingerprint rate limit on the API host; catches API abuse tools that rotate IPs
+  # Count-only until baseline is established.
+  rule {
+    name     = "ApiRateLimit_JA4"
+    priority = 7
+
+    action {
+      count {}
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "ApiRateLimit_JA4"
+      sampled_requests_enabled   = true
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.api_ja4_waf_rate_limit
+        aggregate_key_type = "CUSTOM_KEYS"
+        custom_key {
+          ja4_fingerprint {
+            fallback_behavior = "NO_MATCH"
+          }
+        }
+        scope_down_statement {
+          and_statement {
+            statement {
+              byte_match_statement {
+                positional_constraint = "STARTS_WITH"
+                field_to_match {
+                  single_header {
+                    name = "host"
+                  }
+                }
+                search_string = "api"
+                text_transformation {
+                  priority = 1
+                  type     = "COMPRESS_WHITE_SPACE"
+                }
+                text_transformation {
+                  priority = 2
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+            statement {
+              not_statement {
+                statement {
+                  byte_match_statement {
+                    positional_constraint = "EXACTLY"
+                    field_to_match {
+                      single_header {
+                        name = "waf-secret"
+                      }
+                    }
+                    search_string = var.waf_secret
+                    text_transformation {
+                      priority = 1
+                      type     = "NONE"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  # ~24 WCU - IP rate limit on mutating methods (POST/PUT/PATCH/DELETE) to the API host.
+  # Lower threshold than ApiRateLimit to catch write-heavy abuse. Count-only until baseline established.
+  rule {
+    name     = "MutatingApiRateLimit"
+    priority = 9
+
+    action {
+      count {}
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "MutatingApiRateLimit"
+      sampled_requests_enabled   = true
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.api_mutating_waf_rate_limit
+        aggregate_key_type = "IP"
+        scope_down_statement {
+          and_statement {
+            statement {
+              byte_match_statement {
+                positional_constraint = "STARTS_WITH"
+                field_to_match {
+                  single_header {
+                    name = "host"
+                  }
+                }
+                search_string = "api"
+                text_transformation {
+                  priority = 1
+                  type     = "COMPRESS_WHITE_SPACE"
+                }
+                text_transformation {
+                  priority = 2
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+            statement {
+              not_statement {
+                statement {
+                  byte_match_statement {
+                    positional_constraint = "EXACTLY"
+                    field_to_match {
+                      single_header {
+                        name = "waf-secret"
+                      }
+                    }
+                    search_string = var.waf_secret
+                    text_transformation {
+                      priority = 1
+                      type     = "NONE"
+                    }
+                  }
+                }
+              }
+            }
+            statement {
+              regex_match_statement {
+                field_to_match {
+                  method {}
+                }
+                regex_string = "^(delete|patch|post|put)$"
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  # ~24 WCU - JA4 rate limit on mutating methods; catches write-abuse tools that rotate IPs.
+  # Count-only until baseline established.
+  rule {
+    name     = "MutatingApiRateLimit_JA4"
+    priority = 10
+
+    action {
+      count {}
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "MutatingApiRateLimit_JA4"
+      sampled_requests_enabled   = true
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.api_mutating_ja4_waf_rate_limit
+        aggregate_key_type = "CUSTOM_KEYS"
+        custom_key {
+          ja4_fingerprint {
+            fallback_behavior = "NO_MATCH"
+          }
+        }
+        scope_down_statement {
+          and_statement {
+            statement {
+              byte_match_statement {
+                positional_constraint = "STARTS_WITH"
+                field_to_match {
+                  single_header {
+                    name = "host"
+                  }
+                }
+                search_string = "api"
+                text_transformation {
+                  priority = 1
+                  type     = "COMPRESS_WHITE_SPACE"
+                }
+                text_transformation {
+                  priority = 2
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+            statement {
+              not_statement {
+                statement {
+                  byte_match_statement {
+                    positional_constraint = "EXACTLY"
+                    field_to_match {
+                      single_header {
+                        name = "waf-secret"
+                      }
+                    }
+                    search_string = var.waf_secret
+                    text_transformation {
+                      priority = 1
+                      type     = "NONE"
+                    }
+                  }
+                }
+              }
+            }
+            statement {
+              regex_match_statement {
+                field_to_match {
+                  method {}
+                }
+                regex_string = "^(delete|patch|post|put)$"
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   # 25 WCU
   rule {
     name     = "AWSManagedRulesAmazonIpReputationList"
-    priority = 9
+    priority = 12
 
     override_action {
       none {}
@@ -569,10 +1087,123 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     }
   }
 
+  # ~30 WCU - Block non-CA/US access to authenticated admin pages.
+  # Public pages (sign-in, register, auth flows, GCA content, contact, newsletter, /_status) remain accessible worldwide.
+  rule {
+    name     = "AdminAuthenticatedPagesGeoRestriction"
+    priority = 15
+
+    action {
+      count {}
+    }
+
+    statement {
+      and_statement {
+        statement {
+          not_statement {
+            statement {
+              geo_match_statement {
+                country_codes = ["CA"]
+              }
+            }
+          }
+        }
+        statement {
+          or_statement {
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                positional_constraint = "STARTS_WITH"
+                search_string         = "/services/"
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                positional_constraint = "STARTS_WITH"
+                search_string         = "/organisations/"
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                positional_constraint = "STARTS_WITH"
+                search_string         = "/platform-admin/"
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                positional_constraint = "STARTS_WITH"
+                search_string         = "/user-profile"
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                positional_constraint = "STARTS_WITH"
+                search_string         = "/find-users-by-email"
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                positional_constraint = "STARTS_WITH"
+                search_string         = "/accounts"
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AdminAuthenticatedPagesGeoRestriction"
+      sampled_requests_enabled   = true
+    }
+  }
+
   # 50 WCU
   rule {
     name     = "AWSManagedRulesAnonymousIpList"
-    priority = 10
+    priority = 16
 
     override_action {
       none {}
@@ -602,7 +1233,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
   # 200 WCU
   rule {
     name     = "AWSManagedRulesKnownBadInputsRuleSet"
-    priority = 11
+    priority = 18
 
     override_action {
       none {}
@@ -625,7 +1256,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
   # 200 WCU
   rule {
     name     = "AWSManagedRulesLinuxRuleSet"
-    priority = 12
+    priority = 19
 
     override_action {
       none {}
@@ -648,7 +1279,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
   # 700 WCU
   rule {
     name     = "AWSManagedRulesCommonRuleSet"
-    priority = 13
+    priority = 20
 
     override_action {
       none {}
@@ -706,10 +1337,10 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
   }
 
   # ~3 WCU - Block non-CA requests that were labelled by EC2MetaDataSSRF_BODY or NoUserAgent_HEADER
-  # Must run after AWSManagedRulesCommonRuleSet (priority 13) so the labels exist.
+  # Must run after AWSManagedRulesCommonRuleSet (priority 20) so the labels exist.
   rule {
     name     = "BlockLabeled_SSRF_NoUserAgent_NonCA"
-    priority = 14
+    priority = 21
 
     action {
       count {}
@@ -752,11 +1383,162 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     }
   }
 
+  # ~6 WCU - Block oversized bodies, except on bulk-send and file upload endpoints
+  rule {
+    name     = "BlockSizeRestrictions_Body_ExcludeUploadPaths"
+    priority = 22
+
+    action {
+      count {}
+    }
+
+    statement {
+      and_statement {
+        statement {
+          label_match_statement {
+            scope = "LABEL"
+            key   = "awswaf:managed:aws:core-rule-set:SizeRestrictions_BODY"
+          }
+        }
+        statement {
+          not_statement {
+            statement {
+              or_statement {
+                # Bulk notification send
+                statement {
+                  byte_match_statement {
+                    field_to_match {
+                      uri_path {}
+                    }
+                    positional_constraint = "STARTS_WITH"
+                    search_string         = "/v2/notifications/bulk"
+                    text_transformation {
+                      priority = 0
+                      type     = "LOWERCASE"
+                    }
+                  }
+                }
+                # Document / file upload
+                statement {
+                  byte_match_statement {
+                    field_to_match {
+                      uri_path {}
+                    }
+                    positional_constraint = "STARTS_WITH"
+                    search_string         = "/services/"
+                    text_transformation {
+                      priority = 0
+                      type     = "LOWERCASE"
+                    }
+                  }
+                }
+                # Letter uploads (PDFs can be large)
+                statement {
+                  byte_match_statement {
+                    field_to_match {
+                      uri_path {}
+                    }
+                    positional_constraint = "STARTS_WITH"
+                    search_string         = "/letters"
+                    text_transformation {
+                      priority = 0
+                      type     = "LOWERCASE"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "BlockSizeRestrictions_Body_ExcludeUploadPaths"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # ~6 WCU - Block LFI in body, except on template/notification paths where file-like strings are valid content
+  rule {
+    name     = "BlockLFI_Body_ExcludeTemplatePaths"
+    priority = 23
+
+    action {
+      count {}
+    }
+
+    statement {
+      and_statement {
+        statement {
+          label_match_statement {
+            scope = "LABEL"
+            key   = "awswaf:managed:aws:core-rule-set:GenericLFI_BODY"
+          }
+        }
+        statement {
+          not_statement {
+            statement {
+              or_statement {
+                statement {
+                  byte_match_statement {
+                    field_to_match {
+                      uri_path {}
+                    }
+                    positional_constraint = "STARTS_WITH"
+                    search_string         = "/v2/notifications"
+                    text_transformation {
+                      priority = 0
+                      type     = "LOWERCASE"
+                    }
+                  }
+                }
+                statement {
+                  byte_match_statement {
+                    field_to_match {
+                      uri_path {}
+                    }
+                    positional_constraint = "STARTS_WITH"
+                    search_string         = "/templates"
+                    text_transformation {
+                      priority = 0
+                      type     = "LOWERCASE"
+                    }
+                  }
+                }
+                statement {
+                  byte_match_statement {
+                    field_to_match {
+                      uri_path {}
+                    }
+                    positional_constraint = "STARTS_WITH"
+                    search_string         = "/personalise"
+                    text_transformation {
+                      priority = 0
+                      type     = "LOWERCASE"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "BlockLFI_Body_ExcludeTemplatePaths"
+      sampled_requests_enabled   = true
+    }
+  }
+
   # ~8 WCU - Block XSS in body, except on paths where users legitimately send HTML/template content:
   # /v2/notifications (email body), /templates, /personalise, /_email, /_letter (preview rendering)
   rule {
     name     = "BlockXSS_Body_ExcludeContentPaths"
-    priority = 15
+    priority = 24
 
     action {
       count {}
@@ -853,71 +1635,33 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     }
   }
 
-  # ~6 WCU - Block oversized bodies, except on bulk-send and file upload endpoints
+  # 200 WCU
   rule {
-    name     = "BlockSizeRestrictions_Body_ExcludeUploadPaths"
-    priority = 16
+    name     = "AWSManagedRulesSQLiRuleSet"
+    priority = 25
 
-    action {
-      count {}
+    override_action {
+      none {}
     }
 
     statement {
-      and_statement {
-        statement {
-          label_match_statement {
-            scope = "LABEL"
-            key   = "awswaf:managed:aws:core-rule-set:SizeRestrictions_BODY"
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesSQLiRuleSet"
+        vendor_name = "AWS"
+
+        # Notification/template bodies can contain SQL-like text (e.g. "SELECT your plan").
+        # Override to count so labels are set for the follow-up label-match rule below,
+        # which applies path-based exclusions before blocking.
+        rule_action_override {
+          name = "SQLi_BODY"
+          action_to_use {
+            count {}
           }
         }
-        statement {
-          not_statement {
-            statement {
-              or_statement {
-                # Bulk notification send
-                statement {
-                  byte_match_statement {
-                    field_to_match {
-                      uri_path {}
-                    }
-                    positional_constraint = "STARTS_WITH"
-                    search_string         = "/v2/notifications/bulk"
-                    text_transformation {
-                      priority = 0
-                      type     = "LOWERCASE"
-                    }
-                  }
-                }
-                # Document / file upload
-                statement {
-                  byte_match_statement {
-                    field_to_match {
-                      uri_path {}
-                    }
-                    positional_constraint = "STARTS_WITH"
-                    search_string         = "/services/"
-                    text_transformation {
-                      priority = 0
-                      type     = "LOWERCASE"
-                    }
-                  }
-                }
-                # Letter uploads (PDFs can be large)
-                statement {
-                  byte_match_statement {
-                    field_to_match {
-                      uri_path {}
-                    }
-                    positional_constraint = "STARTS_WITH"
-                    search_string         = "/letters"
-                    text_transformation {
-                      priority = 0
-                      type     = "LOWERCASE"
-                    }
-                  }
-                }
-              }
-            }
+        rule_action_override {
+          name = "SQLiExtendedPatterns_Body"
+          action_to_use {
+            count {}
           }
         }
       }
@@ -925,15 +1669,16 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "BlockSizeRestrictions_Body_ExcludeUploadPaths"
+      metric_name                = "AWSManagedRulesSQLiRuleSet"
       sampled_requests_enabled   = true
     }
   }
 
-  # ~6 WCU - Block LFI in body, except on template/notification paths where file-like strings are valid content
+  # ~6 WCU - Block SQLi in body except on paths where user-supplied content is expected.
+  # Count-only until baseline established. Must run after AWSManagedRulesSQLiRuleSet (priority 25).
   rule {
-    name     = "BlockLFI_Body_ExcludeTemplatePaths"
-    priority = 17
+    name     = "BlockSQLi_Body_ExcludeContentPaths"
+    priority = 26
 
     action {
       count {}
@@ -942,9 +1687,19 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     statement {
       and_statement {
         statement {
-          label_match_statement {
-            scope = "LABEL"
-            key   = "awswaf:managed:aws:core-rule-set:GenericLFI_BODY"
+          or_statement {
+            statement {
+              label_match_statement {
+                scope = "LABEL"
+                key   = "awswaf:managed:aws:sql-database:SQLi_Body"
+              }
+            }
+            statement {
+              label_match_statement {
+                scope = "LABEL"
+                key   = "awswaf:managed:aws:sql-database:SQLiExtendedPatterns_Body"
+              }
+            }
           }
         }
         statement {
@@ -999,234 +1754,58 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "BlockLFI_Body_ExcludeTemplatePaths"
+      metric_name                = "BlockSQLi_Body_ExcludeContentPaths"
       sampled_requests_enabled   = true
     }
   }
 
-  # ~22 WCU - JA4 fingerprint rate limit on sign-in paths; catches credential-stuffing tools that rotate IPs
-  # Count-only until baseline is established. Move before priority 8 when switching to block.
+  # Requires Shield Advanced. Uses Challenge action (silent JS browser check) to flag/mitigate L7 DDoS.
+  # Running in count mode to baseline before enabling.
+  # WARNING: ChallengeAllDuringEvent challenges ALL traffic during an active Shield DDoS event,
+  # including API clients that cannot complete a JS challenge. Do not switch to block without
+  # scoping this rule to non-API hosts, or risk breaking API consumers during incidents.
   rule {
-    name     = "SigninRateLimitRule_JA4"
-    priority = 18
+    name     = "AWSManagedRulesAntiDDoSRuleSet"
+    priority = 27
 
-    action {
+    override_action {
       count {}
     }
 
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "SigninRateLimitRule_JA4"
-      sampled_requests_enabled   = true
-    }
-
     statement {
-      rate_based_statement {
-        limit              = var.sign_in_ja4_waf_rate_limit
-        aggregate_key_type = "CUSTOM_KEYS"
-        custom_key {
-          ja4_fingerprint {
-            fallback_behavior = "NO_MATCH"
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAntiDDoSRuleSet"
+        vendor_name = "AWS"
+
+        managed_rule_group_configs {
+          aws_managed_rules_anti_ddos_rule_set {
+            client_side_action_config {
+              challenge {
+                usage_of_action = "ENABLED"
+                sensitivity     = "HIGH"
+                # Paths that cannot complete a silent JS challenge (automated/non-browser callers).
+                # The API host is already excluded via scope_down_statement above.
+                exempt_uri_regular_expression {
+                  regex_string = "^/_status"
+                }
+              }
+            }
+            sensitivity_to_block = "HIGH"
           }
         }
+
+        # Exclude API hosts: JS Challenge action cannot be completed by automated API clients.
         scope_down_statement {
-          or_statement {
+          not_statement {
             statement {
               byte_match_statement {
-                field_to_match {
-                  uri_path {}
-                }
-                positional_constraint = "STARTS_WITH"
-                search_string         = "/sign-in"
-                text_transformation {
-                  type     = "LOWERCASE"
-                  priority = 0
-                }
-              }
-            }
-            statement {
-              byte_match_statement {
-                field_to_match {
-                  uri_path {}
-                }
-                positional_constraint = "STARTS_WITH"
-                search_string         = "/register"
-                text_transformation {
-                  type     = "LOWERCASE"
-                  priority = 1
-                }
-              }
-            }
-            statement {
-              byte_match_statement {
-                field_to_match {
-                  uri_path {}
-                }
-                positional_constraint = "STARTS_WITH"
-                search_string         = "/forgot-password"
-                text_transformation {
-                  type     = "LOWERCASE"
-                  priority = 2
-                }
-              }
-            }
-            statement {
-              byte_match_statement {
-                field_to_match {
-                  uri_path {}
-                }
-                positional_constraint = "STARTS_WITH"
-                search_string         = "/forced-password-reset"
-                text_transformation {
-                  type     = "LOWERCASE"
-                  priority = 3
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-
-  # ~22 WCU - JA4 fingerprint rate limit on the API host; catches API abuse tools that rotate IPs
-  # Count-only until baseline is established. Move before priority 8 when switching to block.
-  rule {
-    name     = "ApiRateLimit_JA4"
-    priority = 19
-
-    action {
-      count {}
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "ApiRateLimit_JA4"
-      sampled_requests_enabled   = true
-    }
-
-    statement {
-      rate_based_statement {
-        limit              = var.api_ja4_waf_rate_limit
-        aggregate_key_type = "CUSTOM_KEYS"
-        custom_key {
-          ja4_fingerprint {
-            fallback_behavior = "NO_MATCH"
-          }
-        }
-        scope_down_statement {
-          and_statement {
-            statement {
-              byte_match_statement {
-                positional_constraint = "STARTS_WITH"
                 field_to_match {
                   single_header {
                     name = "host"
                   }
                 }
-                search_string = "api"
-                text_transformation {
-                  priority = 1
-                  type     = "COMPRESS_WHITE_SPACE"
-                }
-                text_transformation {
-                  priority = 2
-                  type     = "LOWERCASE"
-                }
-              }
-            }
-            statement {
-              not_statement {
-                statement {
-                  byte_match_statement {
-                    positional_constraint = "EXACTLY"
-                    field_to_match {
-                      single_header {
-                        name = "waf-secret"
-                      }
-                    }
-                    search_string = var.waf_secret
-                    text_transformation {
-                      priority = 1
-                      type     = "NONE"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-
-  # ~24 WCU - IP rate limit on mutating methods (POST/PUT/PATCH/DELETE) to the API host.
-  # Lower threshold than ApiRateLimit to catch write-heavy abuse. Count-only until baseline established.
-  # Move before priority 8 when switching to block.
-  rule {
-    name     = "MutatingApiRateLimit"
-    priority = 20
-
-    action {
-      count {}
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "MutatingApiRateLimit"
-      sampled_requests_enabled   = true
-    }
-
-    statement {
-      rate_based_statement {
-        limit              = var.api_mutating_waf_rate_limit
-        aggregate_key_type = "IP"
-        scope_down_statement {
-          and_statement {
-            statement {
-              byte_match_statement {
                 positional_constraint = "STARTS_WITH"
-                field_to_match {
-                  single_header {
-                    name = "host"
-                  }
-                }
-                search_string = "api"
-                text_transformation {
-                  priority = 1
-                  type     = "COMPRESS_WHITE_SPACE"
-                }
-                text_transformation {
-                  priority = 2
-                  type     = "LOWERCASE"
-                }
-              }
-            }
-            statement {
-              not_statement {
-                statement {
-                  byte_match_statement {
-                    positional_constraint = "EXACTLY"
-                    field_to_match {
-                      single_header {
-                        name = "waf-secret"
-                      }
-                    }
-                    search_string = var.waf_secret
-                    text_transformation {
-                      priority = 1
-                      type     = "NONE"
-                    }
-                  }
-                }
-              }
-            }
-            statement {
-              regex_match_statement {
-                field_to_match {
-                  method {}
-                }
-                regex_string = "^(delete|patch|post|put)$"
+                search_string         = "api"
                 text_transformation {
                   priority = 0
                   type     = "LOWERCASE"
@@ -1237,88 +1816,11 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
         }
       }
     }
-  }
-
-  # ~24 WCU - JA4 rate limit on mutating methods; catches write-abuse tools that rotate IPs.
-  # Count-only until baseline established. Move before priority 8 when switching to block.
-  rule {
-    name     = "MutatingApiRateLimit_JA4"
-    priority = 21
-
-    action {
-      count {}
-    }
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "MutatingApiRateLimit_JA4"
+      metric_name                = "AWSManagedRulesAntiDDoSRuleSet"
       sampled_requests_enabled   = true
-    }
-
-    statement {
-      rate_based_statement {
-        limit              = var.api_mutating_ja4_waf_rate_limit
-        aggregate_key_type = "CUSTOM_KEYS"
-        custom_key {
-          ja4_fingerprint {
-            fallback_behavior = "NO_MATCH"
-          }
-        }
-        scope_down_statement {
-          and_statement {
-            statement {
-              byte_match_statement {
-                positional_constraint = "STARTS_WITH"
-                field_to_match {
-                  single_header {
-                    name = "host"
-                  }
-                }
-                search_string = "api"
-                text_transformation {
-                  priority = 1
-                  type     = "COMPRESS_WHITE_SPACE"
-                }
-                text_transformation {
-                  priority = 2
-                  type     = "LOWERCASE"
-                }
-              }
-            }
-            statement {
-              not_statement {
-                statement {
-                  byte_match_statement {
-                    positional_constraint = "EXACTLY"
-                    field_to_match {
-                      single_header {
-                        name = "waf-secret"
-                      }
-                    }
-                    search_string = var.waf_secret
-                    text_transformation {
-                      priority = 1
-                      type     = "NONE"
-                    }
-                  }
-                }
-              }
-            }
-            statement {
-              regex_match_statement {
-                field_to_match {
-                  method {}
-                }
-                regex_string = "^(delete|patch|post|put)$"
-                text_transformation {
-                  priority = 0
-                  type     = "LOWERCASE"
-                }
-              }
-            }
-          }
-        }
-      }
     }
   }
 


### PR DESCRIPTION
# Summary | Résumé

Adding the remaining waf rules according to the Notify — WAF Resources Review & Recommendations in count mode only.

## New WAF rules (all in `count` mode — no blocking changes)

- **`AWSManagedRulesSQLiRuleSet`** — adds the AWS managed SQL injection rule group; `SQLi_BODY` and `SQLiExtendedPatterns_Body` are overridden to count since notification/template bodies can contain SQL-like text (e.g. "SELECT your plan")
- **`BlockSQLi_Body_ExcludeContentPaths`** — label-match follow-up that catches SQLi-labelled body requests, with exclusions for `/v2/notifications`, `/templates`, and `/personalise` where user-supplied SQL-like content is expected
- **`AdminAuthenticatedPagesGeoRestriction`** — restricts non-CA access to authenticated admin pages (`/services/`, `/organisations/`, `/platform-admin/`, `/user-profile`, `/find-users-by-email`, `/accounts`); sign-in, register, and public pages remain globally accessible
- **`BlockLargeRequests_CookiesAndHeaders`** — blocks cookies or headers exceeding 8 KB; no path exclusions needed since legitimate use cases including file uploads do not require large cookies or headers
- **`BlockLargeRequests_Body`** — blocks request bodies exceeding 8 KB, with exclusions for file upload and bulk-send paths (`/services/`, `/email-branding/`, `/platform-admin/letter-validation-preview`, `/v2/notifications/bulk`)
- **`AWSManagedRulesAntiDDoSRuleSet`** — adds the AWS managed L7 DDoS rule group (requires Shield Advanced); scoped to non-API hosts only since API clients cannot complete the JS challenge action; running in count mode for baselining

## Supporting changes

- Rule priorities reordered cheapest-to-most-expensive (1–27) with a priority index table added at the top of `waf.tf`
- Added `ja4fingerprint` column to the WAF Athena table DDL — table must be dropped and recreated to query JA4 data
- Added Athena saved query `WAF: rule hit counts` — shows per-rule match counts split by BLOCK vs COUNT mode over a 7-day window, for use when baselining before switching rules to block


## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/875

## Test instructions | Instructions pour tester la modification

TF Apply
Let it sit in prod for a while to evaluate the new rules in count mode and determine if adjustments need to be made

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
