### PR TITLE
Turn on GuardDuty scan verdicts in prod

### DIFF
--- a/env/production_config.tfvars
+++ b/env/production_config.tfvars
@@ -171,7 +171,7 @@ sqs_send_email_low_queue_name                                      = "send-email
 sqs_send_sms_high_queue_name                                       = "send-sms-high"
 sqs_send_sms_medium_queue_name                                     = "send-sms-medium"
 sqs_send_sms_low_queue_name                                        = "send-sms-low"
-enable_guardduty_scan_api_destination                              = false
+enable_guardduty_scan_api_destination                              = true
 scan_verdict_callback_url                                          = "https://api.notification.canada.ca/templates/scan-verdict-callback"
 
 # RANDOM DOCKER TAGS (These are only used during BCP processes)


### PR DESCRIPTION
# Summary | Résumé

Enables GuardDuty scan api destination infra to forward template attachment scan verdicts to API.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/3290
 
## Test instructions | Instructions pour tester la modification

- [ ] CI is passing

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
