### PR TITLE
waf refinements and queries

### DIFF
--- a/aws/common/athena_queries_support.tf
+++ b/aws/common/athena_queries_support.tf
@@ -79,3 +79,67 @@ resource "aws_athena_named_query" "alb_ip_address_by_url" {
   database    = aws_athena_database.notification_athena.name
   query       = templatefile("${path.module}/sql/alb_ip_lookup_by_url.sql.tmpl", {})
 }
+
+resource "aws_athena_named_query" "waf_ssrf_body_hits" {
+  name        = "WAF: EC2 metadata SSRF body hits"
+  description = "Managed EC2MetaDataSSRF_BODY hits (excluding api.*, which is not covered by the downstream label rule)."
+  workgroup   = aws_athena_workgroup.support.name
+  database    = aws_athena_database.notification_athena.name
+  query       = templatefile("${path.module}/sql/waf_ssrf_body_hits.sql.tmpl", {})
+}
+
+resource "aws_athena_named_query" "waf_ssrf_body_alb_correlation" {
+  name        = "WAF: EC2 metadata SSRF body + ALB correlation"
+  description = "EC2MetaDataSSRF_BODY hits joined with ALB access logs on client IP + timestamp (±5s) so you can see the full URL, user-agent, and response codes."
+  workgroup   = aws_athena_workgroup.support.name
+  database    = aws_athena_database.notification_athena.name
+  query       = templatefile("${path.module}/sql/waf_ssrf_body_alb_correlation.sql.tmpl", {})
+}
+
+resource "aws_athena_named_query" "waf_xss_body_hits" {
+  name        = "WAF: XSS body hits"
+  description = "Managed CrossSiteScripting_BODY hits (excluding api.document.*, where XLSX/DOCX uploads inherently trip the rule and are already excluded by the downstream label rule)."
+  workgroup   = aws_athena_workgroup.support.name
+  database    = aws_athena_database.notification_athena.name
+  query       = templatefile("${path.module}/sql/waf_xss_body_hits.sql.tmpl", {})
+}
+
+resource "aws_athena_named_query" "waf_sqli_body_custom_hits" {
+  name        = "WAF: SQLi body hits (custom rule)"
+  description = "Hits on the custom count-mode rule BlockSQLi_Body_ExcludeContentPaths."
+  workgroup   = aws_athena_workgroup.support.name
+  database    = aws_athena_database.notification_athena.name
+  query       = templatefile("${path.module}/sql/waf_sqli_body_custom_hits.sql.tmpl", {})
+}
+
+resource "aws_athena_named_query" "waf_sqli_body_managed_hits" {
+  name        = "WAF: SQLi body hits (managed rules)"
+  description = "Managed SQLi_BODY / SQLi_BODY_RC_COUNT / SQLiExtendedPatterns_Body_RC_COUNT hits (excluding api.*, which is not covered by the downstream label rule)."
+  workgroup   = aws_athena_workgroup.support.name
+  database    = aws_athena_database.notification_athena.name
+  query       = templatefile("${path.module}/sql/waf_sqli_body_managed_hits.sql.tmpl", {})
+}
+
+resource "aws_athena_named_query" "waf_hosting_provider_hits" {
+  name        = "WAF: HostingProviderIPList hits"
+  description = "Managed HostingProviderIPList hits (AWSManagedRulesAnonymousIpList)."
+  workgroup   = aws_athena_workgroup.support.name
+  database    = aws_athena_database.notification_athena.name
+  query       = templatefile("${path.module}/sql/waf_hosting_provider_hits.sql.tmpl", {})
+}
+
+resource "aws_athena_named_query" "waf_admin_geo_restriction_hits" {
+  name        = "WAF: admin geo restriction hits"
+  description = "Hits on the custom AdminAuthenticatedPagesGeoRestriction rule (non-CA/US traffic on admin-authenticated paths)."
+  workgroup   = aws_athena_workgroup.support.name
+  database    = aws_athena_database.notification_athena.name
+  query       = templatefile("${path.module}/sql/waf_admin_geo_restriction_hits.sql.tmpl", {})
+}
+
+resource "aws_athena_named_query" "waf_size_restrictions_body_hits" {
+  name        = "WAF: SizeRestrictions body hits"
+  description = "Managed SizeRestrictions_BODY hits (~8 KB threshold), excluding api.* which is guarded by the 7 MB BlockLargeRequests_Body_Api rule."
+  workgroup   = aws_athena_workgroup.support.name
+  database    = aws_athena_database.notification_athena.name
+  query       = templatefile("${path.module}/sql/waf_size_restrictions_body_hits.sql.tmpl", {})
+}

--- a/aws/common/athena_queries_support.tf
+++ b/aws/common/athena_queries_support.tf
@@ -114,7 +114,7 @@ resource "aws_athena_named_query" "waf_sqli_body_custom_hits" {
 
 resource "aws_athena_named_query" "waf_sqli_body_managed_hits" {
   name        = "WAF: SQLi body hits (managed rules)"
-  description = "Managed SQLi_BODY / SQLi_BODY_RC_COUNT / SQLiExtendedPatterns_Body_RC_COUNT hits (excluding api.*, which is not covered by the downstream label rule)."
+  description = "Managed SQLi_BODY / SQLi_BODY_RC_COUNT / SQLiExtendedPatterns_Body / SQLiExtendedPatterns_Body_RC_COUNT hits (excluding api.*, which is not covered by the downstream label rule)."
   workgroup   = aws_athena_workgroup.support.name
   database    = aws_athena_database.notification_athena.name
   query       = templatefile("${path.module}/sql/waf_sqli_body_managed_hits.sql.tmpl", {})

--- a/aws/common/sql/waf_admin_geo_restriction_hits.sql.tmpl
+++ b/aws/common/sql/waf_admin_geo_restriction_hits.sql.tmpl
@@ -1,0 +1,22 @@
+-- WAF: AdminAuthenticatedPagesGeoRestriction hits (last 7 days)
+-- Shows requests that matched the custom count-mode rule
+-- AdminAuthenticatedPagesGeoRestriction (non-CA/US traffic on admin-authenticated
+-- paths: /services/, /organisations/, /platform-admin/, /user-profile,
+-- /find-users-by-email, /accounts).
+-- final_action is the terminal action taken on the request.
+
+SELECT
+    from_unixtime(timestamp / 1000e0)    AS request_time,
+    httprequest.clientip                  AS client_ip,
+    httprequest.country                   AS country,
+    httprequest.httpmethod                AS method,
+    TRY(filter(httprequest.headers, h -> lower(h.name) = 'host')[1].value) AS host,
+    httprequest.uri                       AS uri,
+    ja4fingerprint,
+    action                                AS final_action
+FROM waf_logs
+CROSS JOIN UNNEST(nonterminatingmatchingrules) AS t(rule)
+WHERE from_unixtime(timestamp / 1000e0) >= NOW() - INTERVAL '7' DAY
+  AND rule.ruleid = 'AdminAuthenticatedPagesGeoRestriction'
+ORDER BY request_time DESC
+LIMIT 200

--- a/aws/common/sql/waf_hosting_provider_hits.sql.tmpl
+++ b/aws/common/sql/waf_hosting_provider_hits.sql.tmpl
@@ -1,25 +1,45 @@
 -- WAF: HostingProviderIPList hits (last 7 days)
 -- Shows requests that matched the managed rule HostingProviderIPList
 -- (part of AWSManagedRulesAnonymousIpList). Applies to all hosts.
--- other_rules_fired indicates whether this request also matched another
--- non-default rule (useful for triage).
+-- other_rules_fired is true when the request was ALSO acted on by another rule:
+--   - terminated (BLOCK/CAPTCHA/CHALLENGE) by a rule other than Default_Action, OR
+--   - matched a custom rule at the top level (nonterminatingmatchingrules), OR
+--   - matched another managed sub-rule (rulegrouplist[].nonterminatingmatchingrules).
+-- The three component booleans are returned individually for triage.
 
+WITH hits AS (
+    SELECT
+        from_unixtime(timestamp / 1000e0)    AS request_time,
+        httprequest.clientip                  AS client_ip,
+        httprequest.country                   AS country,
+        httprequest.httpmethod                AS method,
+        TRY(filter(httprequest.headers, h -> lower(h.name) = 'host')[1].value) AS host,
+        httprequest.uri                       AS uri,
+        ja4fingerprint,
+        action                                AS final_action,
+        terminatingruleid,
+        (terminatingruleid IS NOT NULL
+            AND terminatingruleid != 'Default_Action') AS terminated_by_other,
+        cardinality(filter(
+            nonterminatingmatchingrules,
+            r -> r.ruleid != 'Default_Action'
+        )) > 0                                AS custom_count_rule_fired,
+        cardinality(filter(
+            flatten(transform(rulegrouplist, rg -> rg.nonterminatingmatchingrules)),
+            rg_rule -> rg_rule.ruleid != 'HostingProviderIPList'
+        )) > 0                                AS other_managed_rule_fired
+    FROM waf_logs
+    WHERE from_unixtime(timestamp / 1000e0) >= NOW() - INTERVAL '7' DAY
+      AND cardinality(filter(
+          flatten(transform(rulegrouplist, rg -> rg.nonterminatingmatchingrules)),
+          rg_rule -> rg_rule.ruleid = 'HostingProviderIPList'
+      )) > 0
+)
 SELECT
-    from_unixtime(timestamp / 1000e0)    AS request_time,
-    httprequest.clientip                  AS client_ip,
-    httprequest.country                   AS country,
-    httprequest.httpmethod                AS method,
-    TRY(filter(httprequest.headers, h -> lower(h.name) = 'host')[1].value) AS host,
-    httprequest.uri                       AS uri,
-    ja4fingerprint,
-    cardinality(filter(
-        nonterminatingmatchingrules,
-        r -> r.ruleid != 'Default_Action'
-    )) > 0                               AS other_rules_fired
-FROM waf_logs
-CROSS JOIN UNNEST(rulegrouplist)                  AS t(rg)
-CROSS JOIN UNNEST(rg.nonterminatingmatchingrules) AS t(rg_rule)
-WHERE from_unixtime(timestamp / 1000e0) >= NOW() - INTERVAL '7' DAY
-  AND rg_rule.ruleid = 'HostingProviderIPList'
+    request_time, client_ip, country, method, host, uri, ja4fingerprint,
+    final_action, terminatingruleid,
+    (terminated_by_other OR custom_count_rule_fired OR other_managed_rule_fired) AS other_rules_fired,
+    terminated_by_other, custom_count_rule_fired, other_managed_rule_fired
+FROM hits
 ORDER BY request_time DESC
 LIMIT 200

--- a/aws/common/sql/waf_hosting_provider_hits.sql.tmpl
+++ b/aws/common/sql/waf_hosting_provider_hits.sql.tmpl
@@ -1,0 +1,25 @@
+-- WAF: HostingProviderIPList hits (last 7 days)
+-- Shows requests that matched the managed rule HostingProviderIPList
+-- (part of AWSManagedRulesAnonymousIpList). Applies to all hosts.
+-- other_rules_fired indicates whether this request also matched another
+-- non-default rule (useful for triage).
+
+SELECT
+    from_unixtime(timestamp / 1000e0)    AS request_time,
+    httprequest.clientip                  AS client_ip,
+    httprequest.country                   AS country,
+    httprequest.httpmethod                AS method,
+    TRY(filter(httprequest.headers, h -> lower(h.name) = 'host')[1].value) AS host,
+    httprequest.uri                       AS uri,
+    ja4fingerprint,
+    cardinality(filter(
+        nonterminatingmatchingrules,
+        r -> r.ruleid != 'Default_Action'
+    )) > 0                               AS other_rules_fired
+FROM waf_logs
+CROSS JOIN UNNEST(rulegrouplist)                  AS t(rg)
+CROSS JOIN UNNEST(rg.nonterminatingmatchingrules) AS t(rg_rule)
+WHERE from_unixtime(timestamp / 1000e0) >= NOW() - INTERVAL '7' DAY
+  AND rg_rule.ruleid = 'HostingProviderIPList'
+ORDER BY request_time DESC
+LIMIT 200

--- a/aws/common/sql/waf_rule_hit_counts.sql.tmpl
+++ b/aws/common/sql/waf_rule_hit_counts.sql.tmpl
@@ -1,9 +1,21 @@
 -- WAF: rule hit counts
 -- Shows how many requests each WAF rule matched over the last 7 days, split into:
---   BLOCK         - rule terminated the request (custom or managed group sub-rule)
+--   BLOCK           - rule terminated the request (custom or managed group sub-rule)
 --   COUNT (custom)  - custom rule running in count mode (action { count {} })
 --   COUNT (managed) - managed rule group sub-rule overridden to count
 --                     (e.g. CrossSiteScripting_BODY, SQLi_BODY, NoUserAgent_HEADER)
+--
+-- Managed sub-rules whose downstream custom rule is scoped to non-api hosts
+-- have api.* requests excluded from their COUNT (managed) totals so the counts
+-- match what would actually be blocked in production. See aws/eks/waf.tf:
+--   EC2MetaDataSSRF_BODY / NoUserAgent_HEADER  -> BlockLabeled_SSRF_NoUserAgent_NonCA
+--   SizeRestrictions_BODY                      -> BlockSizeRestrictions_Body_ExcludeUploadPaths
+--   SQLi_BODY* variants                        -> BlockSQLi_Body_ExcludeContentPaths
+-- Additionally, CrossSiteScripting_BODY and GenericLFI_BODY have api.document.*
+-- excluded because that host is the document-download-api and its uploads
+-- (POST /services/<uuid>/documents) contain XLSX/DOCX bytes that inherently
+-- trip both rules. Downstream rules already exclude /services/ so those hits
+-- would not actually block.
 --
 -- Use this to baseline count-mode rules before switching them to block.
 -- Adjust the INTERVAL value to change the time window.
@@ -13,7 +25,11 @@ WITH time_window AS (
         terminatingruleid,
         action,
         nonterminatingmatchingrules,
-        rulegrouplist
+        rulegrouplist,
+        lower(COALESCE(
+            TRY(filter(httprequest.headers, h -> lower(h.name) = 'host')[1].value),
+            ''
+        )) AS host
     FROM waf_logs
     WHERE from_unixtime(timestamp / 1000e0) >= NOW() - INTERVAL '7' DAY
 ),
@@ -30,7 +46,8 @@ blocking AS (
     GROUP BY terminatingruleid
 ),
 
--- Custom rules running in count mode (action { count {} })
+-- Custom rules running in count mode (action { count {} }).
+-- No api exclusion needed: host-scoped custom rules already can't fire on api.
 custom_counting AS (
     SELECT
         rule.ruleid      AS rule_id,
@@ -41,16 +58,36 @@ custom_counting AS (
     GROUP BY rule.ruleid
 ),
 
--- Managed rule group sub-rules overridden to count
--- (e.g. CrossSiteScripting_BODY, EC2MetaDataSSRF_BODY, SQLi_BODY, NoUserAgent_HEADER)
+-- Managed rule group sub-rules overridden to count.
+-- Exclude api.* hits for sub-rules whose downstream custom rule is non-api scoped.
+-- Exclude api.document.* hits for XSS/LFI sub-rules that fire on file uploads.
 managed_counting AS (
     SELECT
         rg_rule.ruleid    AS rule_id,
         'COUNT (managed)' AS match_type,
         COUNT(*)          AS hits
     FROM time_window
-    CROSS JOIN UNNEST(rulegrouplist) AS t(rg)
+    CROSS JOIN UNNEST(rulegrouplist)                  AS t(rg)
     CROSS JOIN UNNEST(rg.nonterminatingmatchingrules) AS t(rg_rule)
+    WHERE NOT (
+        host LIKE 'api%'
+        AND rg_rule.ruleid IN (
+            'EC2MetaDataSSRF_BODY',
+            'NoUserAgent_HEADER',
+            'SizeRestrictions_BODY',
+            'SQLi_BODY',
+            'SQLi_BODY_RC_COUNT',
+            'SQLiExtendedPatterns_Body',
+            'SQLiExtendedPatterns_Body_RC_COUNT'
+        )
+    )
+    AND NOT (
+        host LIKE 'api.document%'
+        AND rg_rule.ruleid IN (
+            'CrossSiteScripting_BODY',
+            'GenericLFI_BODY'
+        )
+    )
     GROUP BY rg_rule.ruleid
 )
 

--- a/aws/common/sql/waf_size_restrictions_body_hits.sql.tmpl
+++ b/aws/common/sql/waf_size_restrictions_body_hits.sql.tmpl
@@ -1,0 +1,36 @@
+-- WAF: SizeRestrictions_BODY hits (last 7 days)
+-- Shows requests that matched the managed CRS sub-rule SizeRestrictions_BODY (~8 KB threshold).
+-- Excludes api.* hosts because BlockLargeRequests_Body_Api (priority 4) is the intended
+-- body-size guard on api (7 MB); the CRS sub-rule fires at ~8 KB regardless of host,
+-- so api hits here are noise.
+-- Downstream custom rule BlockSizeRestrictions_Body_ExcludeUploadPaths is non-api scoped
+-- and additionally excludes /v2/notifications/bulk, /services/, /letters on non-api hosts.
+-- content_length_bytes is taken from the Content-Length header (best proxy for body size
+-- in WAF logs; may be null for chunked requests).
+
+WITH size_hits AS (
+    SELECT
+        from_unixtime(timestamp / 1000e0)            AS request_time,
+        httprequest.clientip                          AS client_ip,
+        httprequest.country                           AS country,
+        httprequest.httpmethod                        AS method,
+        TRY(filter(httprequest.headers, h -> lower(h.name) = 'host')[1].value) AS host,
+        httprequest.uri                               AS uri,
+        TRY(CAST(filter(httprequest.headers, h -> lower(h.name) = 'content-length')[1].value AS bigint)) AS content_length_bytes,
+        ja4fingerprint,
+        TRY(rg_rule.rulematchdetails[1].matcheddata)  AS matched_data,
+        cardinality(filter(
+            nonterminatingmatchingrules,
+            r -> r.ruleid = 'BlockSizeRestrictions_Body_ExcludeUploadPaths'
+        )) > 0                                        AS blocked_by_label_rule
+    FROM waf_logs
+    CROSS JOIN UNNEST(rulegrouplist)                  AS t(rg)
+    CROSS JOIN UNNEST(rg.nonterminatingmatchingrules) AS t(rg_rule)
+    WHERE from_unixtime(timestamp / 1000e0) >= NOW() - INTERVAL '7' DAY
+      AND rg_rule.ruleid = 'SizeRestrictions_BODY'
+      AND lower(COALESCE(TRY(filter(httprequest.headers, h -> lower(h.name) = 'host')[1].value), '')) NOT LIKE 'api%'
+)
+SELECT request_time, client_ip, country, method, host, uri, content_length_bytes, ja4fingerprint, matched_data, blocked_by_label_rule
+FROM size_hits
+ORDER BY request_time DESC
+LIMIT 200

--- a/aws/common/sql/waf_sqli_body_custom_hits.sql.tmpl
+++ b/aws/common/sql/waf_sqli_body_custom_hits.sql.tmpl
@@ -1,7 +1,10 @@
 -- WAF: BlockSQLi_Body_ExcludeContentPaths hits (last 7 days)
 -- Shows requests that matched the custom count-mode rule
 -- BlockSQLi_Body_ExcludeContentPaths (non-api, excludes /services/).
--- sqli_body and sqli_extended_body indicate which upstream SQLi label triggered.
+-- sqli_body and sqli_extended_body indicate which upstream managed SQLi label
+-- triggered the custom rule. The custom rule matches on WAF labels emitted by
+-- AWSManagedRulesSQLiRuleSet (see aws/eks/waf.tf), so we read those labels
+-- from the top-level waf_logs.labels array rather than nonterminatingmatchingrules.
 
 WITH sqli_hits AS (
     SELECT
@@ -13,12 +16,12 @@ WITH sqli_hits AS (
         httprequest.uri                       AS uri,
         ja4fingerprint,
         cardinality(filter(
-            nonterminatingmatchingrules,
-            r -> r.ruleid = 'SQLi_Body'
+            labels,
+            l -> l.name = 'awswaf:managed:aws:sql-database:SQLi_Body'
         )) > 0                               AS sqli_body,
         cardinality(filter(
-            nonterminatingmatchingrules,
-            r -> r.ruleid = 'SQLiExtendedPatterns_Body'
+            labels,
+            l -> l.name = 'awswaf:managed:aws:sql-database:SQLiExtendedPatterns_Body'
         )) > 0                               AS sqli_extended_body
     FROM waf_logs
     CROSS JOIN UNNEST(nonterminatingmatchingrules) AS t(rule)

--- a/aws/common/sql/waf_sqli_body_custom_hits.sql.tmpl
+++ b/aws/common/sql/waf_sqli_body_custom_hits.sql.tmpl
@@ -1,0 +1,31 @@
+-- WAF: BlockSQLi_Body_ExcludeContentPaths hits (last 7 days)
+-- Shows requests that matched the custom count-mode rule
+-- BlockSQLi_Body_ExcludeContentPaths (non-api, excludes /services/).
+-- sqli_body and sqli_extended_body indicate which upstream SQLi label triggered.
+
+WITH sqli_hits AS (
+    SELECT
+        from_unixtime(timestamp / 1000e0)    AS request_time,
+        httprequest.clientip                  AS client_ip,
+        httprequest.country                   AS country,
+        httprequest.httpmethod                AS method,
+        TRY(filter(httprequest.headers, h -> lower(h.name) = 'host')[1].value) AS host,
+        httprequest.uri                       AS uri,
+        ja4fingerprint,
+        cardinality(filter(
+            nonterminatingmatchingrules,
+            r -> r.ruleid = 'SQLi_Body'
+        )) > 0                               AS sqli_body,
+        cardinality(filter(
+            nonterminatingmatchingrules,
+            r -> r.ruleid = 'SQLiExtendedPatterns_Body'
+        )) > 0                               AS sqli_extended_body
+    FROM waf_logs
+    CROSS JOIN UNNEST(nonterminatingmatchingrules) AS t(rule)
+    WHERE from_unixtime(timestamp / 1000e0) >= NOW() - INTERVAL '7' DAY
+      AND rule.ruleid = 'BlockSQLi_Body_ExcludeContentPaths'
+)
+SELECT request_time, client_ip, country, method, host, uri, ja4fingerprint, sqli_body, sqli_extended_body
+FROM sqli_hits
+ORDER BY request_time DESC
+LIMIT 200

--- a/aws/common/sql/waf_sqli_body_managed_hits.sql.tmpl
+++ b/aws/common/sql/waf_sqli_body_managed_hits.sql.tmpl
@@ -1,0 +1,33 @@
+-- WAF: SQLi_BODY managed rule hits, all variants (last 7 days)
+-- Shows requests that matched any of the SQLi managed rules:
+-- SQLi_BODY, SQLi_BODY_RC_COUNT, SQLiExtendedPatterns_Body_RC_COUNT.
+-- Excludes api.* hosts because the downstream custom rule
+-- BlockSQLi_Body_ExcludeContentPaths scopes to non-api.
+-- blocked_by_label_rule indicates whether the downstream label rule also fired.
+
+WITH sqli_hits AS (
+    SELECT
+        from_unixtime(timestamp / 1000e0)            AS request_time,
+        httprequest.clientip                          AS client_ip,
+        httprequest.country                           AS country,
+        httprequest.httpmethod                        AS method,
+        TRY(filter(httprequest.headers, h -> lower(h.name) = 'host')[1].value) AS host,
+        httprequest.uri                               AS uri,
+        ja4fingerprint,
+        rg_rule.ruleid                                AS matched_rule,
+        TRY(rg_rule.rulematchdetails[1].matcheddata)  AS matched_data,
+        cardinality(filter(
+            nonterminatingmatchingrules,
+            r -> r.ruleid = 'BlockSQLi_Body_ExcludeContentPaths'
+        )) > 0                                        AS blocked_by_label_rule
+    FROM waf_logs
+    CROSS JOIN UNNEST(rulegrouplist)                  AS t(rg)
+    CROSS JOIN UNNEST(rg.nonterminatingmatchingrules) AS t(rg_rule)
+    WHERE from_unixtime(timestamp / 1000e0) >= NOW() - INTERVAL '7' DAY
+      AND rg_rule.ruleid IN ('SQLi_BODY', 'SQLi_BODY_RC_COUNT', 'SQLiExtendedPatterns_Body_RC_COUNT')
+      AND lower(COALESCE(TRY(filter(httprequest.headers, h -> lower(h.name) = 'host')[1].value), '')) NOT LIKE 'api%'
+)
+SELECT request_time, client_ip, country, method, host, uri, ja4fingerprint, matched_rule, matched_data, blocked_by_label_rule
+FROM sqli_hits
+ORDER BY request_time DESC
+LIMIT 200

--- a/aws/common/sql/waf_sqli_body_managed_hits.sql.tmpl
+++ b/aws/common/sql/waf_sqli_body_managed_hits.sql.tmpl
@@ -1,6 +1,9 @@
 -- WAF: SQLi_BODY managed rule hits, all variants (last 7 days)
 -- Shows requests that matched any of the SQLi managed rules:
--- SQLi_BODY, SQLi_BODY_RC_COUNT, SQLiExtendedPatterns_Body_RC_COUNT.
+--   SQLi_BODY, SQLi_BODY_RC_COUNT,
+--   SQLiExtendedPatterns_Body, SQLiExtendedPatterns_Body_RC_COUNT.
+-- SQLi_BODY and SQLiExtendedPatterns_Body are explicitly overridden to count in
+-- aws/eks/waf.tf; the *_RC_COUNT variants are shipped in count mode by AWS.
 -- Excludes api.* hosts because the downstream custom rule
 -- BlockSQLi_Body_ExcludeContentPaths scopes to non-api.
 -- blocked_by_label_rule indicates whether the downstream label rule also fired.
@@ -24,7 +27,12 @@ WITH sqli_hits AS (
     CROSS JOIN UNNEST(rulegrouplist)                  AS t(rg)
     CROSS JOIN UNNEST(rg.nonterminatingmatchingrules) AS t(rg_rule)
     WHERE from_unixtime(timestamp / 1000e0) >= NOW() - INTERVAL '7' DAY
-      AND rg_rule.ruleid IN ('SQLi_BODY', 'SQLi_BODY_RC_COUNT', 'SQLiExtendedPatterns_Body_RC_COUNT')
+      AND rg_rule.ruleid IN (
+          'SQLi_BODY',
+          'SQLi_BODY_RC_COUNT',
+          'SQLiExtendedPatterns_Body',
+          'SQLiExtendedPatterns_Body_RC_COUNT'
+      )
       AND lower(COALESCE(TRY(filter(httprequest.headers, h -> lower(h.name) = 'host')[1].value), '')) NOT LIKE 'api%'
 )
 SELECT request_time, client_ip, country, method, host, uri, ja4fingerprint, matched_rule, matched_data, blocked_by_label_rule

--- a/aws/common/sql/waf_ssrf_body_alb_correlation.sql.tmpl
+++ b/aws/common/sql/waf_ssrf_body_alb_correlation.sql.tmpl
@@ -1,0 +1,39 @@
+-- WAF: EC2MetaDataSSRF_BODY correlated with ALB logs (last 7 days)
+-- Joins WAF SSRF hits with ALB access logs on client IP + timestamp (±5s)
+-- so you can see the actual URL, User-Agent, and response codes for each hit.
+-- Excludes api.* hosts (see waf_ssrf_body_hits for rationale).
+
+WITH ssrf_hits AS (
+    SELECT
+        from_unixtime(timestamp / 1000e0)    AS waf_time,
+        timestamp / 1000e0                   AS waf_epoch_s,
+        httprequest.clientip                 AS client_ip,
+        httprequest.country                  AS country,
+        httprequest.httpmethod               AS method,
+        TRY(filter(httprequest.headers, h -> lower(h.name) = 'host')[1].value) AS host,
+        httprequest.uri                      AS waf_uri
+    FROM waf_logs
+    CROSS JOIN UNNEST(rulegrouplist)                  AS t(rg)
+    CROSS JOIN UNNEST(rg.nonterminatingmatchingrules) AS t(rg_rule)
+    WHERE from_unixtime(timestamp / 1000e0) >= NOW() - INTERVAL '7' DAY
+      AND rg_rule.ruleid = 'EC2MetaDataSSRF_BODY'
+      AND lower(COALESCE(TRY(filter(httprequest.headers, h -> lower(h.name) = 'host')[1].value), '')) NOT LIKE 'api%'
+)
+SELECT
+    s.waf_time,
+    s.client_ip,
+    s.country,
+    s.method,
+    s.host,
+    s.waf_uri,
+    a.request_url,
+    a.user_agent,
+    a.elb_status_code,
+    a.target_status_code,
+    a.received_bytes
+FROM ssrf_hits s
+JOIN alb_logs a
+    ON  a.client_ip = s.client_ip
+    AND ABS(to_unixtime(from_iso8601_timestamp(a.time)) - s.waf_epoch_s) < 5
+ORDER BY s.waf_time DESC
+LIMIT 200

--- a/aws/common/sql/waf_ssrf_body_hits.sql.tmpl
+++ b/aws/common/sql/waf_ssrf_body_hits.sql.tmpl
@@ -1,0 +1,32 @@
+-- WAF: EC2MetaDataSSRF_BODY hits (last 7 days)
+-- Shows requests that matched the managed CRS sub-rule EC2MetaDataSSRF_BODY.
+-- Excludes api.* hosts because the downstream custom rule
+-- BlockLabeled_SSRF_NoUserAgent_NonCA scopes to non-api, so api hits are noise
+-- (see aws/eks/waf.tf).
+-- blocked_by_label_rule indicates whether the downstream label rule also fired.
+
+WITH ssrf_hits AS (
+    SELECT
+        from_unixtime(timestamp / 1000e0)                        AS request_time,
+        httprequest.clientip                                      AS client_ip,
+        httprequest.country                                       AS country,
+        httprequest.httpmethod                                    AS method,
+        TRY(filter(httprequest.headers, h -> lower(h.name) = 'host')[1].value) AS host,
+        httprequest.uri                                           AS uri,
+        ja4fingerprint,
+        TRY(rg_rule.rulematchdetails[1].matcheddata)             AS matched_data,
+        cardinality(filter(
+            nonterminatingmatchingrules,
+            r -> r.ruleid = 'BlockLabeled_SSRF_NoUserAgent_NonCA'
+        )) > 0                                                    AS blocked_by_label_rule
+    FROM waf_logs
+    CROSS JOIN UNNEST(rulegrouplist)                  AS t(rg)
+    CROSS JOIN UNNEST(rg.nonterminatingmatchingrules) AS t(rg_rule)
+    WHERE from_unixtime(timestamp / 1000e0) >= NOW() - INTERVAL '7' DAY
+      AND rg_rule.ruleid = 'EC2MetaDataSSRF_BODY'
+      AND lower(COALESCE(TRY(filter(httprequest.headers, h -> lower(h.name) = 'host')[1].value), '')) NOT LIKE 'api%'
+)
+SELECT request_time, client_ip, country, method, host, uri, ja4fingerprint, matched_data, blocked_by_label_rule
+FROM ssrf_hits
+ORDER BY request_time DESC
+LIMIT 200

--- a/aws/common/sql/waf_xss_body_hits.sql.tmpl
+++ b/aws/common/sql/waf_xss_body_hits.sql.tmpl
@@ -1,0 +1,34 @@
+-- WAF: CrossSiteScripting_BODY hits (last 7 days)
+-- Shows requests that matched the managed CRS sub-rule CrossSiteScripting_BODY.
+-- Excludes the api.document.* host: it's the document-download-api and its
+-- only body-carrying endpoint is POST /services/<uuid>/documents (XLSX/DOCX
+-- uploads whose ZIP-embedded XML manifests contain `</` tags). The downstream
+-- rule BlockXSS_Body_ExcludeContentPaths already excludes /services/, so these
+-- are noise here.
+-- blocked_by_label_rule indicates whether the downstream label rule also fired.
+
+WITH xss_hits AS (
+    SELECT
+        from_unixtime(timestamp / 1000e0)            AS request_time,
+        httprequest.clientip                          AS client_ip,
+        httprequest.country                           AS country,
+        httprequest.httpmethod                        AS method,
+        TRY(filter(httprequest.headers, h -> lower(h.name) = 'host')[1].value) AS host,
+        httprequest.uri                               AS uri,
+        ja4fingerprint,
+        TRY(rg_rule.rulematchdetails[1].matcheddata)  AS matched_data,
+        cardinality(filter(
+            nonterminatingmatchingrules,
+            r -> r.ruleid = 'BlockXSS_Body_ExcludeContentPaths'
+        )) > 0                                        AS blocked_by_label_rule
+    FROM waf_logs
+    CROSS JOIN UNNEST(rulegrouplist)                  AS t(rg)
+    CROSS JOIN UNNEST(rg.nonterminatingmatchingrules) AS t(rg_rule)
+    WHERE from_unixtime(timestamp / 1000e0) >= NOW() - INTERVAL '7' DAY
+      AND rg_rule.ruleid = 'CrossSiteScripting_BODY'
+      AND lower(COALESCE(TRY(filter(httprequest.headers, h -> lower(h.name) = 'host')[1].value), '')) NOT LIKE 'api.document%'
+)
+SELECT request_time, client_ip, country, method, host, uri, ja4fingerprint, matched_data, blocked_by_label_rule
+FROM xss_hits
+ORDER BY request_time DESC
+LIMIT 200

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -29,7 +29,7 @@
 #  20 |   200 | AWSManagedRulesLinuxRuleSet                  | BLOCK (managed)
 #  21 |   700 | AWSManagedRulesCommonRuleSet                 | BLOCK (managed, sets labels)
 #  22 |    ~8 | BlockLabeled_SSRF_NoUserAgent_NonCA          | count → BLOCK (label, after 21, non-API)
-#  23 |    ~6 | BlockSizeRestrictions_Body_ExcludeUploadPaths| count → BLOCK (label, after 21)
+#  23 |    ~6 | BlockSizeRestrictions_Body_ExcludeUploadPaths| count → BLOCK (label, after 21, non-API)
 #  24 |    ~6 | BlockLFI_Body_ExcludeTemplatePaths           | count → BLOCK (label, after 21)
 #  25 |    ~8 | BlockXSS_Body_ExcludeContentPaths            | count → BLOCK (label, after 21, excl. /services/)
 #  26 |   200 | AWSManagedRulesSQLiRuleSet                   | BLOCK (managed, sets labels, excl. /services/)
@@ -1491,7 +1491,10 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     }
   }
 
-  # ~6 WCU - Block oversized bodies, except on bulk-send and file upload endpoints
+  # ~6 WCU - Block oversized bodies on non-API hosts, except on bulk-send and file upload endpoints.
+  # API hosts are excluded here because BlockLargeRequests_Body_Api (priority 4) enforces the
+  # correct 7 MB limit for api; the CRS SizeRestrictions_BODY label fires at ~8 KB regardless
+  # of host, which is the admin threshold and would incorrectly block legitimate api traffic.
   rule {
     name     = "BlockSizeRestrictions_Body_ExcludeUploadPaths"
     priority = 23
@@ -1506,6 +1509,26 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
           label_match_statement {
             scope = "LABEL"
             key   = "awswaf:managed:aws:core-rule-set:SizeRestrictions_BODY"
+          }
+        }
+        # Exclude API host: body size on api is enforced by BlockLargeRequests_Body_Api (7 MB)
+        statement {
+          not_statement {
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  single_header {
+                    name = "host"
+                  }
+                }
+                positional_constraint = "STARTS_WITH"
+                search_string         = "api"
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
+            }
           }
         }
         statement {
@@ -1568,7 +1591,9 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     }
   }
 
-  # ~6 WCU - Block LFI in body, except on template/notification paths where file-like strings are valid content
+  # ~6 WCU - Block LFI in body, except on paths where file-like strings are valid content:
+  # /v2/notifications (personalisation), /templates, /personalise (template references),
+  # /services/ (XLSX/DOCX uploads contain XML paths like xl/worksheets/sheet1.xml that trip LFI detection)
   rule {
     name     = "BlockLFI_Body_ExcludeTemplatePaths"
     priority = 24
@@ -1622,6 +1647,20 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
                     }
                     positional_constraint = "STARTS_WITH"
                     search_string         = "/personalise"
+                    text_transformation {
+                      priority = 0
+                      type     = "LOWERCASE"
+                    }
+                  }
+                }
+                # Service document uploads (XLSX/DOCX zips contain XML paths that trip LFI detection)
+                statement {
+                  byte_match_statement {
+                    field_to_match {
+                      uri_path {}
+                    }
+                    positional_constraint = "STARTS_WITH"
+                    search_string         = "/services/"
                     text_transformation {
                       priority = 0
                       type     = "LOWERCASE"


### PR DESCRIPTION
# Summary | Résumé

Adding more tuning to the waf.

There are a bunch of rules in count that will show false positives due to how the waf rules behave with labels. I've added athena queries that will filter out false positives that we can use in the future to determine if the waf is working as expected.

## Related Issues | Cartes liées

*  https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/875

## Test instructions | Instructions pour tester la modification

TF Apply
Watch prod after release

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
