### PR TITLE
Check if a service is sending more than 100 international messages per hour

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -1490,7 +1490,7 @@ resource "aws_cloudwatch_metric_alarm" "international-sms-sent-warning" {
   provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "international-sms-sent-warning"
-  alarm_description   = "A service has sent more than 100 international SMS in 24 hours"
+  alarm_description   = "A service has sent more than 100 international SMS in 1 hour"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   threshold           = 100
@@ -1505,7 +1505,7 @@ resource "aws_cloudwatch_metric_alarm" "international-sms-sent-warning" {
       GROUP BY service_id
       ORDER BY SUM() DESC
     EOT
-    period      = 86400
+    period      = 3600
     return_data = true
     label       = "International SMS sent per service"
   }

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -1510,3 +1510,28 @@ resource "aws_cloudwatch_metric_alarm" "international-sms-sent-warning" {
     label       = "International SMS sent per service"
   }
 }
+
+resource "aws_cloudwatch_metric_alarm" "international-sms-sent-critical" {
+  provider            = aws.core_services
+  count               = var.cloudwatch_enabled ? 1 : 0
+  alarm_name          = "international-sms-sent-warning"
+  alarm_description   = "A service has sent more than 100 international SMS in 1 hour"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  threshold           = 100
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [var.sns_alert_warning_arn]
+
+  metric_query {
+    id          = "q1"
+    expression  = <<-EOT
+      SELECT SUM(international_sms_sent)
+      FROM SCHEMA("NotificationCanadaCa", service_id)
+      GROUP BY service_id
+      ORDER BY SUM() DESC
+    EOT
+    period      = 3600
+    return_data = true
+    label       = "International SMS sent per service"
+  }
+}

--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -1485,3 +1485,28 @@ resource "aws_cloudwatch_metric_alarm" "velero_daemonset_unavailable" {
     }
   }
 }
+
+resource "aws_cloudwatch_metric_alarm" "international-sms-sent-warning" {
+  provider            = aws.core_services
+  count               = var.cloudwatch_enabled ? 1 : 0
+  alarm_name          = "international-sms-sent-warning"
+  alarm_description   = "A service has sent more than 100 international SMS in 24 hours"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  threshold           = 100
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [var.sns_alert_warning_arn]
+
+  metric_query {
+    id          = "q1"
+    expression  = <<-EOT
+      SELECT SUM(international_sms_sent)
+      FROM SCHEMA("NotificationCanadaCa", service_id)
+      GROUP BY service_id
+      ORDER BY SUM() DESC
+    EOT
+    period      = 86400
+    return_data = true
+    label       = "International SMS sent per service"
+  }
+}

--- a/aws/eks/cloudwatch_log.tf
+++ b/aws/eks/cloudwatch_log.tf
@@ -434,4 +434,3 @@ resource "aws_cloudwatch_log_metric_filter" "coredns-nxdomain-notification-filte
     value     = "1"
   }
 }
-

--- a/aws/eks/cloudwatch_queries.tf
+++ b/aws/eks/cloudwatch_queries.tf
@@ -768,8 +768,8 @@ resource "aws_cloudwatch_query_definition" "international-sms-by-service" {
 
   query_string = <<QUERY
 filter @message like "International text sent"
-| parse @message "service_id=* notification_id=*" as service_id, notification_id
-| stats count(*) as international_sms_count by service_id
+| parse @message "service_id=* notification_id=*" as @service_id, @notification_id
+| stats count(*) as international_sms_count by @service_id
 | sort international_sms_count desc
 QUERY
 }

--- a/aws/eks/cloudwatch_queries.tf
+++ b/aws/eks/cloudwatch_queries.tf
@@ -756,3 +756,20 @@ fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as
 | display @timestamp, @gunicorn_time
 QUERY
 }
+
+resource "aws_cloudwatch_query_definition" "international-sms-by-service" {
+  provider = aws.core_services
+  count    = var.cloudwatch_enabled ? 1 : 0
+  name     = "SMS / International SMS by service"
+
+  log_group_names = [
+    local.eks_application_log_group
+  ]
+
+  query_string = <<QUERY
+filter @message like "International text sent"
+| parse @message "service_id=* notification_id=*" as service_id, notification_id
+| stats count(*) as international_sms_count by service_id
+| sort international_sms_count desc
+QUERY
+}


### PR DESCRIPTION
# Summary
Adds alerting when any single service sends a high volume of international SMS messages, so we can proactively control costs.

## How it works
1. Emits a CloudWatch EMF metric (international_sms_sent) with service_id as a dimension each time an international SMS is sent
1. A Metrics Insights alarm with GROUP BY service_id evaluates all services independently — no service list to maintain
1. The alarm fires when any individual service sends ≥100 international SMS in a 1-hour window
1. A Logs Insights saved query is available for triage to see which services are sending international messages

## Changes
1. cloudwatch_alarms.tf — Metrics Insights query alarm with GROUP BY service_id
1. cloudwatch_queries.tf — Saved query "SMS / International SMS by service" for triage

## Threshold
The threshold of 100/hour is a starting point.

## Related PR:
https://github.com/cds-snc/notification-api/pull/3008
