### PR TITLE
remove api large request waf rule

### DIFF
--- a/aws/common/athena_queries_support.tf
+++ b/aws/common/athena_queries_support.tf
@@ -138,7 +138,7 @@ resource "aws_athena_named_query" "waf_admin_geo_restriction_hits" {
 
 resource "aws_athena_named_query" "waf_size_restrictions_body_hits" {
   name        = "WAF: SizeRestrictions body hits"
-  description = "Managed SizeRestrictions_BODY hits (~8 KB threshold), excluding api.* which is guarded by the 7 MB BlockLargeRequests_Body_Api rule."
+  description = "Managed SizeRestrictions_BODY hits (~8 KB threshold), excluding api.* hosts (API body size is enforced at the application layer)."
   workgroup   = aws_athena_workgroup.support.name
   database    = aws_athena_database.notification_athena.name
   query       = templatefile("${path.module}/sql/waf_size_restrictions_body_hits.sql.tmpl", {})

--- a/aws/common/sql/waf_size_restrictions_body_hits.sql.tmpl
+++ b/aws/common/sql/waf_size_restrictions_body_hits.sql.tmpl
@@ -1,8 +1,7 @@
 -- WAF: SizeRestrictions_BODY hits (last 7 days)
 -- Shows requests that matched the managed CRS sub-rule SizeRestrictions_BODY (~8 KB threshold).
--- Excludes api.* hosts because BlockLargeRequests_Body_Api (priority 4) is the intended
--- body-size guard on api (7 MB); the CRS sub-rule fires at ~8 KB regardless of host,
--- so api hits here are noise.
+-- Excludes api.* hosts: the CRS fires at ~8 KB regardless of host, so api hits are noise
+-- (API body size is enforced at the application layer, not WAF).
 -- Downstream custom rule BlockSizeRestrictions_Body_ExcludeUploadPaths is non-api scoped
 -- and additionally excludes /v2/notifications/bulk, /services/, /letters on non-api hosts.
 -- content_length_bytes is taken from the Content-Length header (best proxy for body size

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -10,7 +10,6 @@
 #   1 |    ~1 | ip_blocklist                                | BLOCK
 #   2 |   ~10 | BlockLargeRequests_CookiesAndHeaders        | count → BLOCK
 #   3 |   ~20 | BlockLargeRequests_Body_Admin               | count → BLOCK (non-API, 8 KB, excl. /otlp-proxy/)
-#   4 |   ~15 | BlockLargeRequests_Body_Api                 | count → BLOCK (API, 7 MB)
 #   5 |   ~20 | BlockFFUFUserAgent                          | BLOCK
 #   6 |   ~20 | SigninRateLimitRule                         | BLOCK (rate, IP)
 #   7 |   ~22 | SigninRateLimitRule_JA4                     | count → BLOCK (rate, JA4)
@@ -646,7 +645,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
   }
 
   # ~20 WCU - Block oversized bodies on admin/documentation hosts (8 KB limit).
-  # API body size is handled separately by BlockLargeRequests_Body_Api (priority 4) with a 7 MB limit.
+  # API body size cannot be enforced at the WAF level; enforce via application MAX_CONTENT_LENGTH.
   rule {
     name     = "BlockLargeRequests_Body_Admin"
     priority = 3
@@ -777,59 +776,6 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     visibility_config {
       cloudwatch_metrics_enabled = true
       metric_name                = "BlockLargeRequests_Body_Admin"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  # ~15 WCU - Block oversized bodies on the API host (7 MB limit).
-  # Higher limit than admin to accommodate large JSON notification payloads.
-  rule {
-    name     = "BlockLargeRequests_Body_Api"
-    priority = 4
-
-    action {
-      count {}
-    }
-
-    statement {
-      and_statement {
-        # Scope to API host only
-        statement {
-          byte_match_statement {
-            field_to_match {
-              single_header {
-                name = "host"
-              }
-            }
-            positional_constraint = "STARTS_WITH"
-            search_string         = "api"
-            text_transformation {
-              priority = 0
-              type     = "LOWERCASE"
-            }
-          }
-        }
-        statement {
-          size_constraint_statement {
-            field_to_match {
-              body {
-                oversize_handling = "CONTINUE"
-              }
-            }
-            comparison_operator = "GT"
-            size                = 7340032
-            text_transformation {
-              priority = 0
-              type     = "NONE"
-            }
-          }
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "BlockLargeRequests_Body_Api"
       sampled_requests_enabled   = true
     }
   }
@@ -1492,9 +1438,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
   }
 
   # ~6 WCU - Block oversized bodies on non-API hosts, except on bulk-send and file upload endpoints.
-  # API hosts are excluded here because BlockLargeRequests_Body_Api (priority 4) enforces the
-  # correct 7 MB limit for api; the CRS SizeRestrictions_BODY label fires at ~8 KB regardless
-  # of host, which is the admin threshold and would incorrectly block legitimate api traffic.
+  # API hosts excluded: AWSManagedRulesCommonRuleSet is scoped to non-API, so this label never fires for API.
   rule {
     name     = "BlockSizeRestrictions_Body_ExcludeUploadPaths"
     priority = 23
@@ -1511,7 +1455,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
             key   = "awswaf:managed:aws:core-rule-set:SizeRestrictions_BODY"
           }
         }
-        # Exclude API host: body size on api is enforced by BlockLargeRequests_Body_Api (7 MB)
+        # Exclude API host: CommonRuleSet scope-down means this label is never set for API traffic
         statement {
           not_statement {
             statement {

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -1438,7 +1438,6 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
   }
 
   # ~6 WCU - Block oversized bodies on non-API hosts, except on bulk-send and file upload endpoints.
-  # API hosts excluded: AWSManagedRulesCommonRuleSet is scoped to non-API, so this label never fires for API.
   rule {
     name     = "BlockSizeRestrictions_Body_ExcludeUploadPaths"
     priority = 23
@@ -1455,7 +1454,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
             key   = "awswaf:managed:aws:core-rule-set:SizeRestrictions_BODY"
           }
         }
-        # Exclude API host: CommonRuleSet scope-down means this label is never set for API traffic
+        # SizeRestrictions_BODY fires at ~8 KB which is the admin threshold and would incorrectly flag large API payloads
         statement {
           not_statement {
             statement {


### PR DESCRIPTION
# Summary | Résumé

Removing the API WAF rule for governing the maximum request size. It will not work on the WAF:

After reviewing, we can't block large requests for the API at the WAF level. AWS WAF only reads the first 8kb of the body, and anything after that would automatically trip it to "too large" and block the request. Thus there's no way to differentiate between 9kb and 7MB. They suggest doing this at the ALB level, but we can't do that either because we don't use nginx (we use AWS ALB Controller). The last suggestion was to do it at the flask level, but I'm not sure if that's worth it.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/875

## Test instructions | Instructions pour tester la modification

TF Apply

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
