### PR TITLE
set new waf rules to block in staging and dev

### DIFF
--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -591,7 +591,14 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 2
 
     action {
-      count {}
+      dynamic "block" {
+        for_each = var.env != "production" ? [1] : []
+        content {}
+      }
+      dynamic "count" {
+        for_each = var.env == "production" ? [1] : []
+        content {}
+      }
     }
 
     statement {
@@ -651,7 +658,14 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 3
 
     action {
-      count {}
+      dynamic "block" {
+        for_each = var.env != "production" ? [1] : []
+        content {}
+      }
+      dynamic "count" {
+        for_each = var.env == "production" ? [1] : []
+        content {}
+      }
     }
 
     statement {
@@ -787,7 +801,14 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 7
 
     action {
-      count {}
+      dynamic "block" {
+        for_each = var.env != "production" ? [1] : []
+        content {}
+      }
+      dynamic "count" {
+        for_each = var.env == "production" ? [1] : []
+        content {}
+      }
     }
 
     visibility_config {
@@ -872,7 +893,14 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 8
 
     action {
-      count {}
+      dynamic "block" {
+        for_each = var.env != "production" ? [1] : []
+        content {}
+      }
+      dynamic "count" {
+        for_each = var.env == "production" ? [1] : []
+        content {}
+      }
     }
 
     visibility_config {
@@ -943,7 +971,14 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 10
 
     action {
-      count {}
+      dynamic "block" {
+        for_each = var.env != "production" ? [1] : []
+        content {}
+      }
+      dynamic "count" {
+        for_each = var.env == "production" ? [1] : []
+        content {}
+      }
     }
 
     visibility_config {
@@ -1021,7 +1056,14 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 11
 
     action {
-      count {}
+      dynamic "block" {
+        for_each = var.env != "production" ? [1] : []
+        content {}
+      }
+      dynamic "count" {
+        for_each = var.env == "production" ? [1] : []
+        content {}
+      }
     }
 
     visibility_config {
@@ -1127,7 +1169,14 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 16
 
     action {
-      count {}
+      dynamic "block" {
+        for_each = var.env != "production" ? [1] : []
+        content {}
+      }
+      dynamic "count" {
+        for_each = var.env == "production" ? [1] : []
+        content {}
+      }
     }
 
     statement {
@@ -1377,7 +1426,14 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 22
 
     action {
-      count {}
+      dynamic "block" {
+        for_each = var.env != "production" ? [1] : []
+        content {}
+      }
+      dynamic "count" {
+        for_each = var.env == "production" ? [1] : []
+        content {}
+      }
     }
 
     statement {
@@ -1443,7 +1499,14 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 23
 
     action {
-      count {}
+      dynamic "block" {
+        for_each = var.env != "production" ? [1] : []
+        content {}
+      }
+      dynamic "count" {
+        for_each = var.env == "production" ? [1] : []
+        content {}
+      }
     }
 
     statement {
@@ -1542,7 +1605,14 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 24
 
     action {
-      count {}
+      dynamic "block" {
+        for_each = var.env != "production" ? [1] : []
+        content {}
+      }
+      dynamic "count" {
+        for_each = var.env == "production" ? [1] : []
+        content {}
+      }
     }
 
     statement {
@@ -1631,7 +1701,14 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 25
 
     action {
-      count {}
+      dynamic "block" {
+        for_each = var.env != "production" ? [1] : []
+        content {}
+      }
+      dynamic "count" {
+        for_each = var.env == "production" ? [1] : []
+        content {}
+      }
     }
 
     statement {
@@ -1804,7 +1881,14 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 27
 
     action {
-      count {}
+      dynamic "block" {
+        for_each = var.env != "production" ? [1] : []
+        content {}
+      }
+      dynamic "count" {
+        for_each = var.env == "production" ? [1] : []
+        content {}
+      }
     }
 
     statement {


### PR DESCRIPTION
# Summary | Résumé

Setting the new WAF rules to block in dev and staging. We can let it sit like this for a week or so.

## Related Issues | Cartes liées

*  https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/875

## Test instructions | Instructions pour tester la modification

Validate that we don't get weird errors on our ci/cd and regular usage of staging

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
