### PR TITLE
anaomaly detection for international SMS

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -1535,3 +1535,35 @@ resource "aws_cloudwatch_metric_alarm" "international-sms-sent-critical" {
     label       = "International SMS sent per service"
   }
 }
+
+resource "aws_cloudwatch_metric_alarm" "international-sms-sent-anomaly" {
+  provider            = aws.core_services
+  count               = var.cloudwatch_enabled ? 1 : 0
+  alarm_name          = "international-sms-sent-anomaly"
+  alarm_description   = "Anomaly detected in the total volume of international SMS sent across all services in 10 minutes"
+  comparison_operator = "GreaterThanUpperThreshold"
+  evaluation_periods  = "2"
+  datapoints_to_alarm = "2"
+  threshold_metric_id = "e1"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [var.sns_alert_warning_arn]
+  ok_actions          = [var.sns_alert_ok_arn]
+
+  metric_query {
+    id          = "e1"
+    expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
+    label       = "International SMS sent (expected band)"
+    return_data = true
+  }
+
+  metric_query {
+    id          = "m1"
+    return_data = true
+    metric {
+      namespace   = "NotificationCanadaCa"
+      metric_name = "international_sms_sent"
+      period      = 600
+      stat        = "Sum"
+    }
+  }
+}


### PR DESCRIPTION
# Summary | Résumé

Adding an alarm that fires off if we have two anomalous periods of 10 minutes of SMS international sending

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/931

## Test instructions | Instructions pour tester la modification

TF Apply
Send some international texts and see if the alarm goes off
Verify that the alarm isn't too noisy

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
