### PR TITLE
Use configured image tags for heartbeat Lambdas

### DIFF
--- a/aws/heartbeat/lambda.tf
+++ b/aws/heartbeat/lambda.tf
@@ -1,5 +1,5 @@
 locals {
-  image_tag = var.env == "production" ? var.heartbeat_docker_tag : (var.bootstrap == true ? "bootstrap" : "latest")
+  image_tag = var.heartbeat_docker_tag
 }
 
 module "heartbeat" {

--- a/aws/system_status/lambda.tf
+++ b/aws/system_status/lambda.tf
@@ -1,5 +1,5 @@
 locals {
-  image_tag = var.env == "production" ? var.system_status_docker_tag : (var.bootstrap == true ? "bootstrap" : "latest")
+  image_tag = var.system_status_docker_tag
 }
 
 module "system_status" {


### PR DESCRIPTION
## Summary

- Make the heartbeat Lambda use `var.heartbeat_docker_tag` in every environment.
- Make the system-status Lambda use `var.system_status_docker_tag` in every environment.
- Remove the implicit non-production `bootstrap`/`latest` fallback.

## Dev environment workflow review

The create-dev workflow was reviewed end to end. It applies ECR before heartbeat/system-status, and `env/dev_config.tfvars` explicitly sets the Lambda tags to `bootstrap` while `bootstrap = true`. The ECR bootstrap resources still publish those tags, so fresh dev-environment creation remains compatible with this change. No workflow dependency edge needed changing.

The manifests repository's `helmfile/overrides/dev.env` was also checked. It contains the four Kubernetes application tags, not the Lambda image tags consumed by Terraform, so it is not used as a Terraform Lambda tag source in this PR.

## Validation

- Repository commit hook: full Terraform formatting check passed.
- Create-dev workflow YAML parsed successfully.
- `terraform fmt -check` and `git diff --check` passed.
- Dev Terragrunt validation reached the dependency graph but could not complete locally because AWS backend/ECR output credentials were unavailable in the environment.