### PR TITLE
Use unique tags for Terraform bootstrap images

### DIFF
--- a/.github/workflows/terragrunt_create_dev_environment.yml
+++ b/.github/workflows/terragrunt_create_dev_environment.yml
@@ -16,6 +16,7 @@ env:
   ENVIRONMENT: dev
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING }}
   WORKFLOW: true
+  BOOTSTRAP_IMAGE_TAG: bootstrap-${{ github.run_id }}
 
 permissions:
   id-token: write

--- a/aws/database-tools/blazer.tf
+++ b/aws/database-tools/blazer.tf
@@ -1,5 +1,5 @@
 locals {
-  image_tag = var.blazer_image_tag
+  image_tag = var.bootstrap ? var.bootstrap_image_tag : var.blazer_image_tag
 }
 
 resource "aws_ecs_cluster" "blazer" {

--- a/aws/database-tools/images.tf
+++ b/aws/database-tools/images.tf
@@ -23,7 +23,7 @@ resource "null_resource" "build_blazer_docker_image" {
 
 
   provisioner "local-exec" {
-    command = "cd /var/tmp/notification-lambdas/blazer/ && docker build -t ${aws_ecr_repository.blazer.repository_url}:bootstrap ."
+    command = "cd /var/tmp/notification-lambdas/blazer/ && docker build -t ${aws_ecr_repository.blazer.repository_url}:${var.bootstrap_image_tag} ."
   }
 
 }
@@ -33,7 +33,7 @@ resource "null_resource" "push_blazer_docker_image" {
   depends_on = [null_resource.build_blazer_docker_image]
 
   provisioner "local-exec" {
-    command = "docker push ${aws_ecr_repository.blazer.repository_url}:bootstrap"
+    command = "docker push ${aws_ecr_repository.blazer.repository_url}:${var.bootstrap_image_tag}"
   }
 
 }

--- a/aws/ecr-us-east/images.tf
+++ b/aws/ecr-us-east/images.tf
@@ -24,7 +24,7 @@ resource "null_resource" "build_ses_receiving_emails_docker_image" {
   ]
 
   provisioner "local-exec" {
-    command = "cd /var/tmp/notification-lambdas/sesreceivingemails && docker build -t ${aws_ecr_repository.ses_receiving_emails.repository_url}:bootstrap ."
+    command = "cd /var/tmp/notification-lambdas/sesreceivingemails && docker build -t ${aws_ecr_repository.ses_receiving_emails.repository_url}:${var.bootstrap_image_tag} ."
   }
 
 }
@@ -34,7 +34,7 @@ resource "null_resource" "push_ses_receiving_emails_docker_image" {
   depends_on = [null_resource.build_ses_receiving_emails_docker_image]
 
   provisioner "local-exec" {
-    command = "docker push ${aws_ecr_repository.ses_receiving_emails.repository_url}:bootstrap"
+    command = "docker push ${aws_ecr_repository.ses_receiving_emails.repository_url}:${var.bootstrap_image_tag}"
   }
 
 }

--- a/aws/ecr-us-west-2/images.tf
+++ b/aws/ecr-us-west-2/images.tf
@@ -24,7 +24,7 @@ resource "null_resource" "build_pinpoint_to_sqs_sms_callbacks_docker_image" {
   ]
 
   provisioner "local-exec" {
-    command = "cd /var/tmp/notification-lambdas/pinpointsmscallbacks && docker build -t ${aws_ecr_repository.pinpoint_to_sqs_sms_callbacks.repository_url}:bootstrap ."
+    command = "cd /var/tmp/notification-lambdas/pinpointsmscallbacks && docker build -t ${aws_ecr_repository.pinpoint_to_sqs_sms_callbacks.repository_url}:${var.bootstrap_image_tag} ."
   }
 
 }
@@ -34,7 +34,7 @@ resource "null_resource" "push_pinpoint_to_sqs_sms_callbacks_docker_image" {
   depends_on = [null_resource.build_pinpoint_to_sqs_sms_callbacks_docker_image]
 
   provisioner "local-exec" {
-    command = "docker push ${aws_ecr_repository.pinpoint_to_sqs_sms_callbacks.repository_url}:bootstrap"
+    command = "docker push ${aws_ecr_repository.pinpoint_to_sqs_sms_callbacks.repository_url}:${var.bootstrap_image_tag}"
   }
 
 }

--- a/aws/ecr/images.tf
+++ b/aws/ecr/images.tf
@@ -14,7 +14,7 @@ resource "null_resource" "build_lambda_log_extension_docker_image" {
   }
 
   provisioner "local-exec" {
-    command = "cd extension && docker build -t ${aws_ecr_repository.lambda_log_extension[0].repository_url}:latest ."
+    command = "cd extension && docker build -t ${aws_ecr_repository.lambda_log_extension[0].repository_url}:${var.bootstrap_image_tag} ."
   }
 
 }
@@ -30,7 +30,7 @@ resource "null_resource" "push_lambda_log_extension_docker_image" {
   ]
 
   provisioner "local-exec" {
-    command = "docker push ${aws_ecr_repository.lambda_log_extension[0].repository_url}:latest"
+    command = "docker push ${aws_ecr_repository.lambda_log_extension[0].repository_url}:${var.bootstrap_image_tag}"
   }
 
 }
@@ -60,7 +60,7 @@ resource "null_resource" "build_admin_docker_image" {
   ]
 
   provisioner "local-exec" {
-    command = "cd /var/tmp/notification-admin/ && docker build -t ${aws_ecr_repository.notify_admin[0].repository_url}:bootstrap -f /var/tmp/notification-admin/ci/Dockerfile.lambda ."
+    command = "cd /var/tmp/notification-admin/ && docker build -t ${aws_ecr_repository.notify_admin[0].repository_url}:${var.bootstrap_image_tag} -f /var/tmp/notification-admin/ci/Dockerfile.lambda ."
   }
 
 }
@@ -70,7 +70,7 @@ resource "null_resource" "push_admin_docker_image" {
   depends_on = [null_resource.build_admin_docker_image]
 
   provisioner "local-exec" {
-    command = "docker push ${aws_ecr_repository.notify_admin[0].repository_url}:bootstrap"
+    command = "docker push ${aws_ecr_repository.notify_admin[0].repository_url}:${var.bootstrap_image_tag}"
   }
 
 }
@@ -101,7 +101,7 @@ resource "null_resource" "build_heartbeat_docker_image" {
   ]
 
   provisioner "local-exec" {
-    command = "cd /var/tmp/notification-lambdas/heartbeat && docker build -t ${aws_ecr_repository.heartbeat.repository_url}:bootstrap ."
+    command = "cd /var/tmp/notification-lambdas/heartbeat && docker build -t ${aws_ecr_repository.heartbeat.repository_url}:${var.bootstrap_image_tag} ."
   }
 
 }
@@ -111,7 +111,7 @@ resource "null_resource" "push_heartbeat_docker_image" {
   depends_on = [null_resource.build_heartbeat_docker_image]
 
   provisioner "local-exec" {
-    command = "docker push ${aws_ecr_repository.heartbeat.repository_url}:bootstrap"
+    command = "docker push ${aws_ecr_repository.heartbeat.repository_url}:${var.bootstrap_image_tag}"
   }
 
 }
@@ -130,7 +130,7 @@ resource "null_resource" "build_google_cidr_docker_image" {
   ]
 
   provisioner "local-exec" {
-    command = "cd /var/tmp/notification-lambdas/google-cidr && docker build -t ${aws_ecr_repository.google-cidr.repository_url}:bootstrap ."
+    command = "cd /var/tmp/notification-lambdas/google-cidr && docker build -t ${aws_ecr_repository.google-cidr.repository_url}:${var.bootstrap_image_tag} ."
   }
 
 }
@@ -140,7 +140,7 @@ resource "null_resource" "push_google_cidr_docker_image" {
   depends_on = [null_resource.build_google_cidr_docker_image]
 
   provisioner "local-exec" {
-    command = "docker push ${aws_ecr_repository.google-cidr.repository_url}:bootstrap"
+    command = "docker push ${aws_ecr_repository.google-cidr.repository_url}:${var.bootstrap_image_tag}"
   }
 
 }
@@ -159,7 +159,7 @@ resource "null_resource" "build_ses_to_sqs_email_callbacks_docker_image" {
   ]
 
   provisioner "local-exec" {
-    command = "cd /var/tmp/notification-lambdas/sesemailcallbacks && docker build -t ${aws_ecr_repository.ses_to_sqs_email_callbacks.repository_url}:bootstrap ."
+    command = "cd /var/tmp/notification-lambdas/sesemailcallbacks && docker build -t ${aws_ecr_repository.ses_to_sqs_email_callbacks.repository_url}:${var.bootstrap_image_tag} ."
   }
 
 }
@@ -169,7 +169,7 @@ resource "null_resource" "push_ses_to_sqs_email_callbacks_docker_image" {
   depends_on = [null_resource.build_ses_to_sqs_email_callbacks_docker_image]
 
   provisioner "local-exec" {
-    command = "docker push ${aws_ecr_repository.ses_to_sqs_email_callbacks.repository_url}:bootstrap"
+    command = "docker push ${aws_ecr_repository.ses_to_sqs_email_callbacks.repository_url}:${var.bootstrap_image_tag}"
   }
 
 }
@@ -188,7 +188,7 @@ resource "null_resource" "build_sns_to_sqs_sms_callbacks_docker_image" {
   ]
 
   provisioner "local-exec" {
-    command = "cd /var/tmp/notification-lambdas/snssmscallbacks && docker build -t ${aws_ecr_repository.sns_to_sqs_sms_callbacks.repository_url}:bootstrap ."
+    command = "cd /var/tmp/notification-lambdas/snssmscallbacks && docker build -t ${aws_ecr_repository.sns_to_sqs_sms_callbacks.repository_url}:${var.bootstrap_image_tag} ."
   }
 
 }
@@ -198,7 +198,7 @@ resource "null_resource" "push_sns_to_sqs_sms_callbacks_docker_image" {
   depends_on = [null_resource.build_sns_to_sqs_sms_callbacks_docker_image]
 
   provisioner "local-exec" {
-    command = "docker push ${aws_ecr_repository.sns_to_sqs_sms_callbacks.repository_url}:bootstrap"
+    command = "docker push ${aws_ecr_repository.sns_to_sqs_sms_callbacks.repository_url}:${var.bootstrap_image_tag}"
   }
 
 }
@@ -217,7 +217,7 @@ resource "null_resource" "build_system_status_docker_image" {
   ]
 
   provisioner "local-exec" {
-    command = "cd /var/tmp/notification-lambdas/system_status && docker build -t ${aws_ecr_repository.system_status.repository_url}:bootstrap ."
+    command = "cd /var/tmp/notification-lambdas/system_status && docker build -t ${aws_ecr_repository.system_status.repository_url}:${var.bootstrap_image_tag} ."
   }
 }
 
@@ -226,7 +226,7 @@ resource "null_resource" "push_system_status_docker_image" {
   depends_on = [null_resource.build_system_status_docker_image]
 
   provisioner "local-exec" {
-    command = "docker push ${aws_ecr_repository.system_status.repository_url}:bootstrap"
+    command = "docker push ${aws_ecr_repository.system_status.repository_url}:${var.bootstrap_image_tag}"
   }
 
 }
@@ -245,7 +245,7 @@ resource "null_resource" "build_pinpoint_to_sqs_sms_callbacks_docker_image" {
   ]
 
   provisioner "local-exec" {
-    command = "cd /var/tmp/notification-lambdas/pinpointsmscallbacks && docker build -t ${aws_ecr_repository.pinpoint_to_sqs_sms_callbacks.repository_url}:bootstrap ."
+    command = "cd /var/tmp/notification-lambdas/pinpointsmscallbacks && docker build -t ${aws_ecr_repository.pinpoint_to_sqs_sms_callbacks.repository_url}:${var.bootstrap_image_tag} ."
   }
 }
 
@@ -254,6 +254,6 @@ resource "null_resource" "push_pinpoint_to_sqs_sms_callbacks_docker_image" {
   depends_on = [null_resource.build_pinpoint_to_sqs_sms_callbacks_docker_image]
 
   provisioner "local-exec" {
-    command = "docker push ${aws_ecr_repository.pinpoint_to_sqs_sms_callbacks.repository_url}:bootstrap"
+    command = "docker push ${aws_ecr_repository.pinpoint_to_sqs_sms_callbacks.repository_url}:${var.bootstrap_image_tag}"
   }
 }

--- a/aws/heartbeat/lambda.tf
+++ b/aws/heartbeat/lambda.tf
@@ -1,5 +1,5 @@
 locals {
-  image_tag = var.env == "production" ? var.heartbeat_docker_tag : (var.bootstrap == true ? "bootstrap" : "latest")
+  image_tag = var.heartbeat_docker_tag
 }
 
 module "heartbeat" {

--- a/aws/heartbeat/lambda.tf
+++ b/aws/heartbeat/lambda.tf
@@ -1,5 +1,5 @@
 locals {
-  image_tag = var.heartbeat_docker_tag
+  image_tag = var.bootstrap ? var.bootstrap_image_tag : var.heartbeat_docker_tag
 }
 
 module "heartbeat" {

--- a/aws/lambda-google-cidr/lambda.tf
+++ b/aws/lambda-google-cidr/lambda.tf
@@ -1,10 +1,14 @@
+locals {
+  image_tag = var.bootstrap ? var.bootstrap_image_tag : var.google_cidr_docker_tag
+}
+
 module "lambda-google-cidr" {
   source                 = "github.com/cds-snc/terraform-modules//lambda?ref=94729229cfcb754146c82a566227e55df6612228" # v11.3.5
   name                   = "google-cidr"
   billing_tag_value      = var.billing_tag_value
   ecr_arn                = var.google_cidr_ecr_arn
   enable_lambda_insights = true
-  image_uri              = "${var.google_cidr_ecr_repository_url}:${var.google_cidr_docker_tag}"
+  image_uri              = "${var.google_cidr_ecr_repository_url}:${local.image_tag}"
   timeout                = 60
   memory                 = 1024
 

--- a/aws/pinpoint_to_sqs_sms_callbacks/lambda.tf
+++ b/aws/pinpoint_to_sqs_sms_callbacks/lambda.tf
@@ -1,10 +1,14 @@
+locals {
+  image_tag = var.bootstrap ? var.bootstrap_image_tag : var.pinpoint_to_sqs_sms_callbacks_docker_tag
+}
+
 module "pinpoint_to_sqs_sms_callbacks" {
   source                     = "github.com/cds-snc/terraform-modules//lambda?ref=94729229cfcb754146c82a566227e55df6612228" # v11.3.5
   name                       = "pinpoint_to_sqs_sms_callbacks"
   billing_tag_value          = var.billing_tag_value
   ecr_arn                    = var.pinpoint_to_sqs_sms_callbacks_ecr_arn
   enable_lambda_insights     = true
-  image_uri                  = "${var.pinpoint_to_sqs_sms_callbacks_ecr_repository_url}:${var.pinpoint_to_sqs_sms_callbacks_docker_tag}"
+  image_uri                  = "${var.pinpoint_to_sqs_sms_callbacks_ecr_repository_url}:${local.image_tag}"
   timeout                    = 60
   memory                     = 1024
   log_group_retention_period = var.sensitive_log_retention_period_days
@@ -71,7 +75,7 @@ module "pinpoint_to_sqs_sms_callbacks_us_west_2" {
   billing_tag_value          = var.billing_tag_value
   ecr_arn                    = var.pinpoint_to_sqs_sms_callbacks_us_west_2_ecr_arn
   enable_lambda_insights     = true
-  image_uri                  = "${var.pinpoint_to_sqs_sms_callbacks_us_west_2_ecr_repository_url}:${var.pinpoint_to_sqs_sms_callbacks_docker_tag}"
+  image_uri                  = "${var.pinpoint_to_sqs_sms_callbacks_us_west_2_ecr_repository_url}:${local.image_tag}"
   timeout                    = 60
   memory                     = 1024
   log_group_retention_period = var.sensitive_log_retention_period_days

--- a/aws/ses_receiving_emails/lambda.tf
+++ b/aws/ses_receiving_emails/lambda.tf
@@ -1,3 +1,7 @@
+locals {
+  image_tag = var.bootstrap ? var.bootstrap_image_tag : var.ses_receiving_emails_docker_tag
+}
+
 module "ses_receiving_emails" {
 
   providers = {
@@ -9,7 +13,7 @@ module "ses_receiving_emails" {
   billing_tag_value          = var.billing_tag_value
   ecr_arn                    = var.ses_receiving_emails_ecr_arn
   enable_lambda_insights     = true
-  image_uri                  = "${var.ses_receiving_emails_ecr_repository_url}:${var.ses_receiving_emails_docker_tag}"
+  image_uri                  = "${var.ses_receiving_emails_ecr_repository_url}:${local.image_tag}"
   timeout                    = 60
   memory                     = 1024
   log_group_retention_period = var.sensitive_log_retention_period_days

--- a/aws/ses_to_sqs_email_callbacks/lambda.tf
+++ b/aws/ses_to_sqs_email_callbacks/lambda.tf
@@ -1,10 +1,14 @@
+locals {
+  image_tag = var.bootstrap ? var.bootstrap_image_tag : var.ses_to_sqs_callbacks_docker_tag
+}
+
 module "ses_to_sqs_email_callbacks" {
   source                     = "github.com/cds-snc/terraform-modules//lambda?ref=94729229cfcb754146c82a566227e55df6612228" # v11.3.5
   name                       = "ses_to_sqs_email_callbacks"
   billing_tag_value          = var.billing_tag_value
   ecr_arn                    = var.ses_to_sqs_email_callbacks_ecr_arn
   enable_lambda_insights     = true
-  image_uri                  = "${var.ses_to_sqs_email_callbacks_ecr_repository_url}:${var.ses_to_sqs_callbacks_docker_tag}"
+  image_uri                  = "${var.ses_to_sqs_email_callbacks_ecr_repository_url}:${local.image_tag}"
   timeout                    = 60
   memory                     = 1024
   log_group_retention_period = var.sensitive_log_retention_period_days

--- a/aws/sns_to_sqs_sms_callbacks/lambda.tf
+++ b/aws/sns_to_sqs_sms_callbacks/lambda.tf
@@ -1,10 +1,14 @@
+locals {
+  image_tag = var.bootstrap ? var.bootstrap_image_tag : var.sns_to_sqs_sms_callbacks_docker_tag
+}
+
 module "sns_to_sqs_sms_callbacks" {
   source                     = "github.com/cds-snc/terraform-modules//lambda?ref=94729229cfcb754146c82a566227e55df6612228" # v11.3.5
   name                       = "sns_to_sqs_sms_callbacks"
   billing_tag_value          = var.billing_tag_value
   ecr_arn                    = var.sns_to_sqs_sms_callbacks_ecr_arn
   enable_lambda_insights     = true
-  image_uri                  = "${var.sns_to_sqs_sms_callbacks_ecr_repository_url}:${var.sns_to_sqs_sms_callbacks_docker_tag}"
+  image_uri                  = "${var.sns_to_sqs_sms_callbacks_ecr_repository_url}:${local.image_tag}"
   timeout                    = 60
   memory                     = 1024
   log_group_retention_period = var.sensitive_log_retention_period_days

--- a/aws/system_status/lambda.tf
+++ b/aws/system_status/lambda.tf
@@ -1,5 +1,5 @@
 locals {
-  image_tag = var.system_status_docker_tag
+  image_tag = var.bootstrap ? var.bootstrap_image_tag : var.system_status_docker_tag
 }
 
 module "system_status" {

--- a/aws/system_status/lambda.tf
+++ b/aws/system_status/lambda.tf
@@ -1,5 +1,5 @@
 locals {
-  image_tag = var.env == "production" ? var.system_status_docker_tag : (var.bootstrap == true ? "bootstrap" : "latest")
+  image_tag = var.system_status_docker_tag
 }
 
 module "system_status" {

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -6,6 +6,8 @@ locals {
 inputs = merge(
   local.secret_inputs,local.config_inputs,
   {
+    bootstrap_image_tag = get_env("BOOTSTRAP_IMAGE_TAG", try(local.config_inputs.bootstrap_image_tag, "bootstrap"))
+    bootstrap_image_tag = get_env("BOOTSTRAP_IMAGE_TAG", try(local.config_inputs.bootstrap_image_tag, "bootstrap"))
     elb_account_ids = {
       "${local.config_inputs.region}" = "${local.secret_inputs.elb_account_id}"
     }
@@ -138,7 +140,7 @@ provider "aws" {
 # Production uses the DNS from the Production account, but also has a 
 # different name :/  So we need to handle that here with if Logic
 
-%{ if local.config_inputs.env != "production" && local.config_inputs.env != "staging" }
+%{if local.config_inputs.env != "production" && local.config_inputs.env != "staging"}
 provider "aws" {
   alias  = "dns"
   region = "ca-central-1"
@@ -154,8 +156,8 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.secret_inputs.staging_account_id}:role/${local.config_inputs.env}_dns_manager_role"
   }
 }
-%{ endif }
-%{ if local.config_inputs.env == "staging" }
+%{endif}
+%{if local.config_inputs.env == "staging"}
 provider "aws" {
   alias  = "dns"
   region = "ca-central-1"
@@ -173,8 +175,8 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.secret_inputs.staging_account_id}:role/${local.config_inputs.env}_dns_manager_role"
   }
 }
-%{ endif }
-%{ if local.config_inputs.env == "production" }
+%{endif}
+%{if local.config_inputs.env == "production"}
 provider "aws" {
   alias  = "dns"
   region = "ca-central-1"
@@ -190,7 +192,7 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.secret_inputs.dns_account_id}:role/notify_prod_dns_manager"
   }
 }
-%{ endif }
+%{endif}
 
 provider "github" {
   owner = "cds-snc"

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -6,7 +6,7 @@ locals {
 inputs = merge(
   local.secret_inputs,local.config_inputs,
   {
-    bootstrap_image_tag = get_env("BOOTSTRAP_IMAGE_TAG", try(local.config_inputs.bootstrap_image_tag, "bootstrap"))
+    bootstrap_image_tag = get_env("BOOTSTRAP_IMAGE_TAG", try(local.config_inputs.bootstrap_image_tag, ""))
     elb_account_ids = {
       "${local.config_inputs.region}" = "${local.secret_inputs.elb_account_id}"
     }

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -7,7 +7,6 @@ inputs = merge(
   local.secret_inputs,local.config_inputs,
   {
     bootstrap_image_tag = get_env("BOOTSTRAP_IMAGE_TAG", try(local.config_inputs.bootstrap_image_tag, "bootstrap"))
-    bootstrap_image_tag = get_env("BOOTSTRAP_IMAGE_TAG", try(local.config_inputs.bootstrap_image_tag, "bootstrap"))
     elb_account_ids = {
       "${local.config_inputs.region}" = "${local.secret_inputs.elb_account_id}"
     }
@@ -140,7 +139,7 @@ provider "aws" {
 # Production uses the DNS from the Production account, but also has a 
 # different name :/  So we need to handle that here with if Logic
 
-%{if local.config_inputs.env != "production" && local.config_inputs.env != "staging"}
+%{ if local.config_inputs.env != "production" && local.config_inputs.env != "staging" }
 provider "aws" {
   alias  = "dns"
   region = "ca-central-1"
@@ -156,8 +155,8 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.secret_inputs.staging_account_id}:role/${local.config_inputs.env}_dns_manager_role"
   }
 }
-%{endif}
-%{if local.config_inputs.env == "staging"}
+%{ endif }
+%{ if local.config_inputs.env == "staging" }
 provider "aws" {
   alias  = "dns"
   region = "ca-central-1"
@@ -175,8 +174,8 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.secret_inputs.staging_account_id}:role/${local.config_inputs.env}_dns_manager_role"
   }
 }
-%{endif}
-%{if local.config_inputs.env == "production"}
+%{ endif }
+%{ if local.config_inputs.env == "production" }
 provider "aws" {
   alias  = "dns"
   region = "ca-central-1"
@@ -192,7 +191,7 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.secret_inputs.dns_account_id}:role/notify_prod_dns_manager"
   }
 }
-%{endif}
+%{ endif }
 
 provider "github" {
   owner = "cds-snc"

--- a/env/variables.tf
+++ b/env/variables.tf
@@ -99,7 +99,12 @@ variable "bootstrap" {
 
 variable "bootstrap_image_tag" {
   type    = string
-  default = "bootstrap"
+  default = ""
+
+  validation {
+    condition     = !var.bootstrap || (var.bootstrap_image_tag != "" && var.bootstrap_image_tag != "bootstrap" && var.bootstrap_image_tag != "latest")
+    error_message = "bootstrap_image_tag must be an explicit immutable tag when bootstrap is enabled; bootstrap and latest are not allowed."
+  }
 }
 
 variable "enable_sentinel_forwarding" {

--- a/env/variables.tf
+++ b/env/variables.tf
@@ -97,6 +97,11 @@ variable "bootstrap" {
   type = bool
 }
 
+variable "bootstrap_image_tag" {
+  type    = string
+  default = "bootstrap"
+}
+
 variable "enable_sentinel_forwarding" {
   type = bool
 }


### PR DESCRIPTION
## Summary

This Terraform-side change makes the environment bootstrap/recovery image path use one immutable, workflow-scoped tag instead of overwriting `:bootstrap` and `:latest`.

- Create-dev defines `BOOTSTRAP_IMAGE_TAG=bootstrap-${{ github.run_id }}` once for the entire workflow.
- Root Terragrunt injects that same value into every component, with a backward-compatible local fallback.
- All Terraform-owned bootstrap builders use `var.bootstrap_image_tag`, including Lambda images, Blazer, Notify Admin, SES receiving emails, Pinpoint in both regions, and the dev log extension.
- All Terraform-managed image consumers use that tag only when `bootstrap=true`; non-bootstrap environments continue using their configured image tags.

## Why this is safe

The create-dev dependency graph applies ECR before the Lambda consumers. The builders and consumers receive the same workflow tag, so a fresh environment does not try to consume an image before it exists and does not rely on a mutable `bootstrap`/`latest` pointer.

This PR is intentionally limited to the Terraform-owned bootstrap/recovery path. Normal staging/production images are built by `notification-lambdas` and deployed/selected by `notification-manifests`; their mutable-tag migration is a separate coordinated change.

## Validation

- Repository commit hook passed the full Terraform formatting check across all modules.
- Focused `terraform fmt -check` passed for every edited Terraform file.
- `git diff --check` passed.
- Create-dev workflow YAML parsed successfully.
- Live dev ECR inspection confirmed the previous images were all published under the old mutable `bootstrap` tag; this PR changes the next create-dev run to publish and consume a unique tag.

## Operational note

Existing `bootstrap` images are not deleted by this PR. They remain available for rollback/forensics; cleanup should follow after a successful create-dev run and verification that no environment references them.