### PR TITLE
Add checks for blazer

### DIFF
--- a/aws/.checkov.yml
+++ b/aws/.checkov.yml
@@ -22,4 +22,5 @@ skip-check:
   - CKV2_AWS_8  # TODO: RDS investigate if Query Logging can be enabled
   - CKV2_AWS_27 # TODO: RDS investigate how to setup AWS Backup plan
   - CKV_TF_1 # You cannot reference commit hashes on terraform registry. 
-  - CKV2_AWS_57 
+  - CKV2_AWS_57
+  - CKV_AWS_337 # SSM SecureString default service key encryption is acceptable

--- a/aws/database-tools/blazer.tf
+++ b/aws/database-tools/blazer.tf
@@ -68,6 +68,9 @@ resource "aws_ecs_task_definition" "blazer" {
         "name" : "BLAZER_DATABASE_URL",
         "valueFrom" : "${aws_ssm_parameter.sqlalchemy_database_reader_uri.arn}"
         }, {
+        "name" : "BLAZER_CHECKS_DATABASE_URL",
+        "valueFrom" : "${aws_ssm_parameter.blazer_checks_database_url.arn}"
+        }, {
         "name" : "DATABASE_URL",
         "valueFrom" : "${aws_ssm_parameter.db_tools_environment_variables.arn}"
         }, {

--- a/aws/database-tools/blazer.tf
+++ b/aws/database-tools/blazer.tf
@@ -71,6 +71,9 @@ resource "aws_ecs_task_definition" "blazer" {
         "name" : "DATABASE_URL",
         "valueFrom" : "${aws_ssm_parameter.db_tools_environment_variables.arn}"
         }, {
+        "name" : "BLAZER_SLACK_WEBHOOK_URL",
+        "valueFrom" : "${aws_ssm_parameter.blazer_slack_webhook_general_topic.arn}"
+        }, {
         "name" : "GOOGLE_OAUTH_CLIENT_ID",
         "valueFrom" : "${aws_ssm_parameter.notify_o11y_google_oauth_client_id.arn}"
         }, {

--- a/aws/database-tools/check_schedules.tf
+++ b/aws/database-tools/check_schedules.tf
@@ -9,7 +9,7 @@ locals {
       schedule   = "1 hour"
     }
     "1-day" = {
-      expression = "cron(30 7 * * ? *)"
+      expression = "cron(0 14 * * ? *)" # 9am EST /10am EDT
       schedule   = "1 day"
     }
   } : {}

--- a/aws/database-tools/check_schedules.tf
+++ b/aws/database-tools/check_schedules.tf
@@ -1,0 +1,69 @@
+locals {
+  blazer_check_schedules = var.cloudwatch_enabled ? {
+    "5-minutes" = {
+      expression = "rate(5 minutes)"
+      schedule   = "5 minutes"
+    }
+    "1-hour" = {
+      expression = "rate(1 hour)"
+      schedule   = "1 hour"
+    }
+    "1-day" = {
+      expression = "cron(30 7 * * ? *)"
+      schedule   = "1 day"
+    }
+  } : {}
+}
+
+resource "aws_cloudwatch_event_rule" "blazer_run_checks" {
+  provider            = aws.core_services
+  for_each            = local.blazer_check_schedules
+  name                = "blazer-run-checks-${each.key}"
+  schedule_expression = each.value.expression
+
+  tags = {
+    Name                  = "blazer-run-checks-${each.key}"
+    (var.billing_tag_key) = var.billing_tag_value
+  }
+}
+
+resource "aws_cloudwatch_event_target" "blazer_run_checks" {
+  provider = aws.core_services
+  for_each = local.blazer_check_schedules
+
+  rule           = aws_cloudwatch_event_rule.blazer_run_checks[each.key].name
+  event_bus_name = aws_cloudwatch_event_rule.blazer_run_checks[each.key].event_bus_name
+  arn            = aws_ecs_cluster.blazer.arn
+  role_arn       = aws_iam_role.scheduled_task_blazer_event_role.arn
+
+  input = jsonencode({
+    containerOverrides = [
+      {
+        name    = "blazer"
+        command = ["bundle", "exec", "rake", "blazer:run_checks"]
+        environment = [
+          {
+            name  = "SCHEDULE"
+            value = each.value.schedule
+          }
+        ]
+      }
+    ]
+  })
+
+  ecs_target {
+    launch_type         = "FARGATE"
+    platform_version    = "1.4.0"
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.blazer.arn
+    network_configuration {
+      subnets          = var.vpc_private_subnets
+      security_groups  = [var.database-tools-securitygroup]
+      assign_public_ip = false
+    }
+
+    tags = {
+      (var.billing_tag_key) = var.billing_tag_value
+    }
+  }
+}

--- a/aws/database-tools/check_schedules_iam.tf
+++ b/aws/database-tools/check_schedules_iam.tf
@@ -1,0 +1,45 @@
+data "aws_iam_policy_document" "scheduled_task_blazer_event_role_assume_role_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      identifiers = ["events.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+data "aws_iam_policy_document" "scheduled_task_blazer_event_role_cloudwatch_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["ecs:RunTask"]
+    #checkov:skip=CKV_AWS_111:Required to run scheduled Blazer ECS tasks
+    resources = [aws_ecs_task_definition.blazer.arn]
+  }
+
+  statement {
+    effect  = "Allow"
+    actions = ["iam:PassRole"]
+    resources = [
+      aws_iam_role.blazer_ecs_task.arn,
+      aws_iam_role.blazer_execution_role.arn
+    ]
+  }
+}
+
+resource "aws_iam_role" "scheduled_task_blazer_event_role" {
+  provider           = aws.core_services
+  name               = "blazer-scheduled-task-role-${var.env}"
+  assume_role_policy = data.aws_iam_policy_document.scheduled_task_blazer_event_role_assume_role_policy.json
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+  }
+}
+
+resource "aws_iam_role_policy" "scheduled_task_blazer_event_role_cloudwatch_policy" {
+  provider = aws.core_services
+  name     = "${aws_ecs_cluster.blazer.name}-ecs-scheduled-policy-${var.env}"
+  role     = aws_iam_role.scheduled_task_blazer_event_role.id
+  policy   = data.aws_iam_policy_document.scheduled_task_blazer_event_role_cloudwatch_policy.json
+}

--- a/aws/database-tools/check_schedules_iam.tf
+++ b/aws/database-tools/check_schedules_iam.tf
@@ -6,6 +6,23 @@ data "aws_iam_policy_document" "scheduled_task_blazer_event_role_assume_role_pol
       identifiers = ["events.amazonaws.com"]
       type        = "Service"
     }
+
+    # Prevent a confused-deputy: only allow our own account's EventBridge rules to assume this role.
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [var.account_id]
+    }
+
+    # Skipped when no schedules exist (cloudwatch_enabled = false) since the condition values can't be empty.
+    dynamic "condition" {
+      for_each = length(aws_cloudwatch_event_rule.blazer_run_checks) > 0 ? [1] : []
+      content {
+        test     = "ArnLike"
+        variable = "aws:SourceArn"
+        values   = [for rule in aws_cloudwatch_event_rule.blazer_run_checks : rule.arn]
+      }
+    }
   }
 }
 

--- a/aws/database-tools/check_schedules_iam.tf
+++ b/aws/database-tools/check_schedules_iam.tf
@@ -19,10 +19,11 @@ data "aws_iam_policy_document" "scheduled_task_blazer_event_role_cloudwatch_poli
 
   # Required because the ecs_target in check_schedules.tf sets task tags, which makes
   # ECS require ecs:TagResource on the caller for every RunTask invocation.
+  # Scoped to the task ARN (not the task-definition ARN) since RunTask tags the launched task.
   statement {
     effect    = "Allow"
     actions   = ["ecs:TagResource"]
-    resources = [aws_ecs_task_definition.blazer.arn]
+    resources = ["arn:aws:ecs:${var.region}:${var.account_id}:task/${aws_ecs_cluster.blazer.name}/*"]
   }
 
   statement {

--- a/aws/database-tools/check_schedules_iam.tf
+++ b/aws/database-tools/check_schedules_iam.tf
@@ -17,6 +17,14 @@ data "aws_iam_policy_document" "scheduled_task_blazer_event_role_cloudwatch_poli
     resources = [aws_ecs_task_definition.blazer.arn]
   }
 
+  # Required because the ecs_target in check_schedules.tf sets task tags, which makes
+  # ECS require ecs:TagResource on the caller for every RunTask invocation.
+  statement {
+    effect    = "Allow"
+    actions   = ["ecs:TagResource"]
+    resources = [aws_ecs_task_definition.blazer.arn]
+  }
+
   statement {
     effect  = "Allow"
     actions = ["iam:PassRole"]
@@ -24,6 +32,12 @@ data "aws_iam_policy_document" "scheduled_task_blazer_event_role_cloudwatch_poli
       aws_iam_role.blazer_ecs_task.arn,
       aws_iam_role.blazer_execution_role.arn
     ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["ecs-tasks.amazonaws.com"]
+    }
   }
 }
 

--- a/aws/database-tools/container_execution_role.tf
+++ b/aws/database-tools/container_execution_role.tf
@@ -76,6 +76,7 @@ data "aws_iam_policy_document" "blazer_exection_role_parameter_policy_actions" {
     resources = [
       aws_ssm_parameter.sqlalchemy_database_reader_uri.arn,
       aws_ssm_parameter.db_tools_environment_variables.arn,
+      aws_ssm_parameter.blazer_slack_webhook_general_topic.arn,
       aws_ssm_parameter.notify_o11y_google_oauth_client_id.arn,
       aws_ssm_parameter.notify_o11y_google_oauth_client_secret.arn
     ]

--- a/aws/database-tools/container_execution_role.tf
+++ b/aws/database-tools/container_execution_role.tf
@@ -76,6 +76,7 @@ data "aws_iam_policy_document" "blazer_exection_role_parameter_policy_actions" {
     resources = [
       aws_ssm_parameter.sqlalchemy_database_reader_uri.arn,
       aws_ssm_parameter.db_tools_environment_variables.arn,
+      aws_ssm_parameter.blazer_checks_database_url.arn,
       aws_ssm_parameter.blazer_slack_webhook_general_topic.arn,
       aws_ssm_parameter.notify_o11y_google_oauth_client_id.arn,
       aws_ssm_parameter.notify_o11y_google_oauth_client_secret.arn

--- a/aws/database-tools/parameterstore.tf
+++ b/aws/database-tools/parameterstore.tf
@@ -38,6 +38,18 @@ resource "aws_ssm_parameter" "notify_o11y_google_oauth_client_secret" {
   }
 }
 
+resource "aws_ssm_parameter" "blazer_slack_webhook_general_topic" {
+  provider = aws.core_services
+  name     = "blazer_slack_webhook_general_topic"
+  type     = "SecureString"
+  value    = var.blazer_slack_webhook_general_topic
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}
+
 resource "aws_ssm_parameter" "sqlalchemy_database_reader_uri" {
   provider = aws.core_services
   name     = "sqlalchemy_database_reader_uri"

--- a/aws/database-tools/parameterstore.tf
+++ b/aws/database-tools/parameterstore.tf
@@ -50,6 +50,18 @@ resource "aws_ssm_parameter" "blazer_slack_webhook_general_topic" {
   }
 }
 
+resource "aws_ssm_parameter" "blazer_checks_database_url" {
+  provider = aws.core_services
+  name     = "blazer_checks_database_url"
+  type     = "SecureString"
+  value    = var.blazer_checks_database_url
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}
+
 resource "aws_ssm_parameter" "sqlalchemy_database_reader_uri" {
   provider = aws.core_services
   name     = "sqlalchemy_database_reader_uri"

--- a/aws/database-tools/parameterstore.tf
+++ b/aws/database-tools/parameterstore.tf
@@ -54,7 +54,7 @@ resource "aws_ssm_parameter" "blazer_checks_database_url" {
   provider = aws.core_services
   name     = "blazer_checks_database_url"
   type     = "SecureString"
-  value    = "postgresql://${var.blazer_checks_db_user}:${var.blazer_checks_db_password}@${var.database_read_only_proxy_endpoint}/NotificationCanadaCa${var.env}"
+  value    = "postgresql://someuser:${var.blazer_checks_db_password}@${var.database_read_only_proxy_endpoint}/NotificationCanadaCa${var.env}"
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value

--- a/aws/database-tools/parameterstore.tf
+++ b/aws/database-tools/parameterstore.tf
@@ -54,7 +54,7 @@ resource "aws_ssm_parameter" "blazer_checks_database_url" {
   provider = aws.core_services
   name     = "blazer_checks_database_url"
   type     = "SecureString"
-  value    = var.blazer_checks_database_url
+  value    = "postgresql://${var.blazer_checks_db_user}:${var.blazer_checks_db_password}@${var.database_read_only_proxy_endpoint}/NotificationCanadaCa${var.env}"
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value

--- a/aws/database-tools/parameterstore.tf
+++ b/aws/database-tools/parameterstore.tf
@@ -54,7 +54,7 @@ resource "aws_ssm_parameter" "blazer_checks_database_url" {
   provider = aws.core_services
   name     = "blazer_checks_database_url"
   type     = "SecureString"
-  value    = "postgresql://someuser:${var.blazer_checks_db_password}@${var.database_read_only_proxy_endpoint}/NotificationCanadaCa${var.env}"
+  value    = "postgresql://blazer_checks_db_user:${var.blazer_checks_db_password}@${var.database_read_only_proxy_endpoint}/NotificationCanadaCa${var.env}"
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value

--- a/aws/database-tools/parameterstore.tf
+++ b/aws/database-tools/parameterstore.tf
@@ -54,7 +54,7 @@ resource "aws_ssm_parameter" "blazer_checks_database_url" {
   provider = aws.core_services
   name     = "blazer_checks_database_url"
   type     = "SecureString"
-  value    = "postgresql://blazer_checks_db_user:${var.blazer_checks_db_password}@${var.database_read_only_proxy_endpoint}/NotificationCanadaCa${var.env}"
+  value    = "postgresql://blazer_checks_db_user:${var.blazer_checks_db_user_password}@${var.database_read_only_proxy_endpoint}/NotificationCanadaCa${var.env}"
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value

--- a/aws/database-tools/task_role.tf
+++ b/aws/database-tools/task_role.tf
@@ -61,6 +61,7 @@ data "aws_iam_policy_document" "blazer_task_role_actions" {
     resources = [
       aws_ssm_parameter.sqlalchemy_database_reader_uri.arn,
       aws_ssm_parameter.db_tools_environment_variables.arn,
+      aws_ssm_parameter.blazer_checks_database_url.arn,
       aws_ssm_parameter.blazer_slack_webhook_general_topic.arn,
       aws_ssm_parameter.notify_o11y_google_oauth_client_id.arn,
       aws_ssm_parameter.notify_o11y_google_oauth_client_secret.arn

--- a/aws/database-tools/task_role.tf
+++ b/aws/database-tools/task_role.tf
@@ -61,6 +61,7 @@ data "aws_iam_policy_document" "blazer_task_role_actions" {
     resources = [
       aws_ssm_parameter.sqlalchemy_database_reader_uri.arn,
       aws_ssm_parameter.db_tools_environment_variables.arn,
+      aws_ssm_parameter.blazer_slack_webhook_general_topic.arn,
       aws_ssm_parameter.notify_o11y_google_oauth_client_id.arn,
       aws_ssm_parameter.notify_o11y_google_oauth_client_secret.arn
     ]

--- a/aws/database-tools/variables.tf
+++ b/aws/database-tools/variables.tf
@@ -28,8 +28,3 @@ variable "sns_alert_warning_arn" {
   description = "value of the sns alert warning arn"
   type        = string
 }
-
-variable "blazer_checks_database_url" {
-  description = "Database URL used by Blazer checks-only datasource"
-  type        = string
-}

--- a/aws/database-tools/variables.tf
+++ b/aws/database-tools/variables.tf
@@ -28,3 +28,8 @@ variable "sns_alert_warning_arn" {
   description = "value of the sns alert warning arn"
   type        = string
 }
+
+variable "blazer_checks_database_url" {
+  description = "Database URL used by Blazer checks-only datasource"
+  type        = string
+}

--- a/env/variables.tf
+++ b/env/variables.tf
@@ -315,6 +315,11 @@ variable "blazer_slack_webhook_general_topic" {
   sensitive = true
 }
 
+variable "blazer_checks_database_url" {
+  type      = string
+  sensitive = true
+}
+
 variable "cloudwatch_slack_webhook_warning_topic" {
   type      = string
   sensitive = true

--- a/env/variables.tf
+++ b/env/variables.tf
@@ -315,6 +315,11 @@ variable "blazer_slack_webhook_general_topic" {
   sensitive = true
 }
 
+variable "blazer_checks_db_password" {
+  type      = string
+  sensitive = true
+}
+
 variable "cloudwatch_slack_webhook_warning_topic" {
   type      = string
   sensitive = true

--- a/env/variables.tf
+++ b/env/variables.tf
@@ -315,7 +315,7 @@ variable "blazer_slack_webhook_general_topic" {
   sensitive = true
 }
 
-variable "blazer_checks_db_password" {
+variable "blazer_checks_db_user_password" {
   type      = string
   sensitive = true
 }

--- a/env/variables.tf
+++ b/env/variables.tf
@@ -315,11 +315,6 @@ variable "blazer_slack_webhook_general_topic" {
   sensitive = true
 }
 
-variable "blazer_checks_database_url" {
-  type      = string
-  sensitive = true
-}
-
 variable "cloudwatch_slack_webhook_warning_topic" {
   type      = string
   sensitive = true


### PR DESCRIPTION
## Summary
This PR enables automated Blazer check execution and wires Blazer check notifications to Slack for the database-tools deployment.

## Why
Blazer had check schedules configured in app settings, but infrastructure did not run the checks on a schedule and did not pass a Slack webhook into the running task. This meant checks were not consistently executed and Slack notifications were not fully wired.

## New user as well
This Terraform PR introduces a separate connection path for Blazer checks so checks can run with a restricted database user while normal Blazer querying remains unchanged: it adds a new sensitive input variable and SecureString parameter for blazer_checks_database_url in variables.tf and parameterstore.tf, injects that value into the Blazer ECS task as BLAZER_CHECKS_DATABASE_URL in blazer.tf, and updates both execution and task IAM policies to allow reading the new parameter in container_execution_role.tf and task_role.tf

## How eventbridge reaches out to blazer
1. Scheduled rules are created in check_schedules.tf:18 with cron/rate expressions at check_schedules.tf:22.
1 .Each rule targets the Blazer ECS cluster ARN, not an HTTP endpoint, at check_schedules.tf:30 and check_schedules.tf:36.
1. EventBridge assumes a role at check_schedules.tf:37, where trust allows events.amazonaws.com in check_schedules_iam.tf:6, and permissions allow ecs:RunTask and iam:PassRole at check_schedules_iam.tf:15 and check_schedules_iam.tf:22.
1. EventBridge starts a one-off Fargate task from the Blazer task definition at check_schedules.tf:58, overriding the container command to run blazer:run_checks at check_schedules.tf:40.
1. That task runs inside private subnets with no public IP at check_schedules.tf:62, using the same VPC network model as the Blazer service at blazer.tf:22 and blazer.tf:24.

## What changed
1. Inject Blazer Slack webhook into the ECS task definition:
2. Create a secure SSM parameter for the Blazer Slack webhook:
3. Allow Blazer task and execution roles to read the new webhook parameter:
4. Add scheduled EventBridge rules to run Blazer checks as one-off ECS tasks:
- every 5 minutes with SCHEDULE=5 minutes
- every 1 hour with SCHEDULE=1 hour
- daily at 9am est/10am edt with SCHEDULE=1 day
`check_schedules.tf`

5. Add IAM role and policy for EventBridge to run ECS tasks and pass required roles:
`check_schedules_iam.tf`

Behavior notes
- Schedules are only created when cloudwatch_enabled is true.
- Scheduled runs use the existing Blazer ECS task definition and private subnet networking.

Testing

1. Trigger one rule manually and confirm:
- ECS task starts successfully
- Blazer checks execute
- Slack notification is received for failing/passing checks as configured

Risk and rollback
- Risk is low and scoped to database-tools Blazer scheduling and secret wiring.
- Rollback is straightforward by reverting this PR, which removes schedules and Slack webhook injection.
