### PR TITLE
Enable new waf rule blocking in prod

### DIFF
--- a/aws/common/sql/waf_admin_geo_restriction_hits.sql.tmpl
+++ b/aws/common/sql/waf_admin_geo_restriction_hits.sql.tmpl
@@ -1,9 +1,8 @@
 -- WAF: AdminAuthenticatedPagesGeoRestriction hits (last 7 days)
--- Shows requests that matched the custom count-mode rule
--- AdminAuthenticatedPagesGeoRestriction (non-CA/US traffic on admin-authenticated
--- paths: /services/, /organisations/, /platform-admin/, /user-profile,
--- /find-users-by-email, /accounts).
--- final_action is the terminal action taken on the request.
+-- Shows requests blocked by AdminAuthenticatedPagesGeoRestriction (non-CA/US traffic
+-- on admin-authenticated paths: /services/, /organisations/, /platform-admin/,
+-- /user-profile, /find-users-by-email, /accounts).
+-- Rule is terminating (block), so matches appear in terminatingruleid not nonterminatingmatchingrules.
 
 SELECT
     from_unixtime(timestamp / 1000e0)    AS request_time,
@@ -12,11 +11,10 @@ SELECT
     httprequest.httpmethod                AS method,
     TRY(filter(httprequest.headers, h -> lower(h.name) = 'host')[1].value) AS host,
     httprequest.uri                       AS uri,
-    ja4fingerprint,
-    action                                AS final_action
+    ja4fingerprint
 FROM waf_logs
-CROSS JOIN UNNEST(nonterminatingmatchingrules) AS t(rule)
 WHERE from_unixtime(timestamp / 1000e0) >= NOW() - INTERVAL '7' DAY
-  AND rule.ruleid = 'AdminAuthenticatedPagesGeoRestriction'
+  AND terminatingruleid = 'AdminAuthenticatedPagesGeoRestriction'
+  AND action = 'BLOCK'
 ORDER BY request_time DESC
 LIMIT 200

--- a/aws/common/sql/waf_sqli_body_custom_hits.sql.tmpl
+++ b/aws/common/sql/waf_sqli_body_custom_hits.sql.tmpl
@@ -1,34 +1,29 @@
 -- WAF: BlockSQLi_Body_ExcludeContentPaths hits (last 7 days)
--- Shows requests that matched the custom count-mode rule
--- BlockSQLi_Body_ExcludeContentPaths (non-api, excludes /services/).
--- sqli_body and sqli_extended_body indicate which upstream managed SQLi label
--- triggered the custom rule. The custom rule matches on WAF labels emitted by
--- AWSManagedRulesSQLiRuleSet (see aws/eks/waf.tf), so we read those labels
--- from the top-level waf_logs.labels array rather than nonterminatingmatchingrules.
+-- Shows requests blocked by the custom label-match rule BlockSQLi_Body_ExcludeContentPaths
+-- (non-API, excludes /services/). Rule is terminating (block), so matches appear in
+-- terminatingruleid not nonterminatingmatchingrules.
+-- sqli_body and sqli_extended_body indicate which upstream managed SQLi label triggered
+-- the block, read from the top-level waf_logs.labels array.
 
-WITH sqli_hits AS (
-    SELECT
-        from_unixtime(timestamp / 1000e0)    AS request_time,
-        httprequest.clientip                  AS client_ip,
-        httprequest.country                   AS country,
-        httprequest.httpmethod                AS method,
-        TRY(filter(httprequest.headers, h -> lower(h.name) = 'host')[1].value) AS host,
-        httprequest.uri                       AS uri,
-        ja4fingerprint,
-        cardinality(filter(
-            labels,
-            l -> l.name = 'awswaf:managed:aws:sql-database:SQLi_Body'
-        )) > 0                               AS sqli_body,
-        cardinality(filter(
-            labels,
-            l -> l.name = 'awswaf:managed:aws:sql-database:SQLiExtendedPatterns_Body'
-        )) > 0                               AS sqli_extended_body
-    FROM waf_logs
-    CROSS JOIN UNNEST(nonterminatingmatchingrules) AS t(rule)
-    WHERE from_unixtime(timestamp / 1000e0) >= NOW() - INTERVAL '7' DAY
-      AND rule.ruleid = 'BlockSQLi_Body_ExcludeContentPaths'
-)
-SELECT request_time, client_ip, country, method, host, uri, ja4fingerprint, sqli_body, sqli_extended_body
-FROM sqli_hits
+SELECT
+    from_unixtime(timestamp / 1000e0)    AS request_time,
+    httprequest.clientip                  AS client_ip,
+    httprequest.country                   AS country,
+    httprequest.httpmethod                AS method,
+    TRY(filter(httprequest.headers, h -> lower(h.name) = 'host')[1].value) AS host,
+    httprequest.uri                       AS uri,
+    ja4fingerprint,
+    cardinality(filter(
+        labels,
+        l -> l.name = 'awswaf:managed:aws:sql-database:SQLi_Body'
+    )) > 0                               AS sqli_body,
+    cardinality(filter(
+        labels,
+        l -> l.name = 'awswaf:managed:aws:sql-database:SQLiExtendedPatterns_Body'
+    )) > 0                               AS sqli_extended_body
+FROM waf_logs
+WHERE from_unixtime(timestamp / 1000e0) >= NOW() - INTERVAL '7' DAY
+  AND terminatingruleid = 'BlockSQLi_Body_ExcludeContentPaths'
+  AND action = 'BLOCK'
 ORDER BY request_time DESC
 LIMIT 200

--- a/aws/common/sql/waf_sqli_body_managed_hits.sql.tmpl
+++ b/aws/common/sql/waf_sqli_body_managed_hits.sql.tmpl
@@ -6,7 +6,8 @@
 -- aws/eks/waf.tf; the *_RC_COUNT variants are shipped in count mode by AWS.
 -- Excludes api.* hosts because the downstream custom rule
 -- BlockSQLi_Body_ExcludeContentPaths scopes to non-api.
--- blocked_by_label_rule indicates whether the downstream label rule also fired.
+-- blocked_by_label_rule is true when BlockSQLi_Body_ExcludeContentPaths fired:
+--   either as terminating (block) in terminatingruleid, or non-terminating (count).
 
 WITH sqli_hits AS (
     SELECT
@@ -19,7 +20,9 @@ WITH sqli_hits AS (
         ja4fingerprint,
         rg_rule.ruleid                                AS matched_rule,
         TRY(rg_rule.rulematchdetails[1].matcheddata)  AS matched_data,
-        cardinality(filter(
+        -- check both block (terminatingruleid) and count (nonterminatingmatchingrules)
+        terminatingruleid = 'BlockSQLi_Body_ExcludeContentPaths'
+        OR cardinality(filter(
             nonterminatingmatchingrules,
             r -> r.ruleid = 'BlockSQLi_Body_ExcludeContentPaths'
         )) > 0                                        AS blocked_by_label_rule

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -591,14 +591,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 2
 
     action {
-      dynamic "block" {
-        for_each = var.env != "production" ? [1] : []
-        content {}
-      }
-      dynamic "count" {
-        for_each = var.env == "production" ? [1] : []
-        content {}
-      }
+      block {}
     }
 
     statement {
@@ -658,14 +651,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 3
 
     action {
-      dynamic "block" {
-        for_each = var.env != "production" ? [1] : []
-        content {}
-      }
-      dynamic "count" {
-        for_each = var.env == "production" ? [1] : []
-        content {}
-      }
+      block {}
     }
 
     statement {
@@ -801,14 +787,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 7
 
     action {
-      dynamic "block" {
-        for_each = var.env != "production" ? [1] : []
-        content {}
-      }
-      dynamic "count" {
-        for_each = var.env == "production" ? [1] : []
-        content {}
-      }
+      block {}
     }
 
     visibility_config {
@@ -893,14 +872,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 8
 
     action {
-      dynamic "block" {
-        for_each = var.env != "production" ? [1] : []
-        content {}
-      }
-      dynamic "count" {
-        for_each = var.env == "production" ? [1] : []
-        content {}
-      }
+      block {}
     }
 
     visibility_config {
@@ -971,14 +943,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 10
 
     action {
-      dynamic "block" {
-        for_each = var.env != "production" ? [1] : []
-        content {}
-      }
-      dynamic "count" {
-        for_each = var.env == "production" ? [1] : []
-        content {}
-      }
+      block {}
     }
 
     visibility_config {
@@ -1056,14 +1021,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 11
 
     action {
-      dynamic "block" {
-        for_each = var.env != "production" ? [1] : []
-        content {}
-      }
-      dynamic "count" {
-        for_each = var.env == "production" ? [1] : []
-        content {}
-      }
+      block {}
     }
 
     visibility_config {
@@ -1169,14 +1127,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 16
 
     action {
-      dynamic "block" {
-        for_each = var.env != "production" ? [1] : []
-        content {}
-      }
-      dynamic "count" {
-        for_each = var.env == "production" ? [1] : []
-        content {}
-      }
+      block {}
     }
 
     statement {
@@ -1426,14 +1377,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 22
 
     action {
-      dynamic "block" {
-        for_each = var.env != "production" ? [1] : []
-        content {}
-      }
-      dynamic "count" {
-        for_each = var.env == "production" ? [1] : []
-        content {}
-      }
+      block {}
     }
 
     statement {
@@ -1499,14 +1443,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 23
 
     action {
-      dynamic "block" {
-        for_each = var.env != "production" ? [1] : []
-        content {}
-      }
-      dynamic "count" {
-        for_each = var.env == "production" ? [1] : []
-        content {}
-      }
+      block {}
     }
 
     statement {
@@ -1605,14 +1542,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 24
 
     action {
-      dynamic "block" {
-        for_each = var.env != "production" ? [1] : []
-        content {}
-      }
-      dynamic "count" {
-        for_each = var.env == "production" ? [1] : []
-        content {}
-      }
+      block {}
     }
 
     statement {
@@ -1701,14 +1631,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 25
 
     action {
-      dynamic "block" {
-        for_each = var.env != "production" ? [1] : []
-        content {}
-      }
-      dynamic "count" {
-        for_each = var.env == "production" ? [1] : []
-        content {}
-      }
+      block {}
     }
 
     statement {
@@ -1881,14 +1804,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 27
 
     action {
-      dynamic "block" {
-        for_each = var.env != "production" ? [1] : []
-        content {}
-      }
-      dynamic "count" {
-        for_each = var.env == "production" ? [1] : []
-        content {}
-      }
+      block {}
     }
 
     statement {

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -8,31 +8,31 @@
 # Pri | WCU   | Name                                        | Action
 # ----|-------|---------------------------------------------|----------------------------
 #   1 |    ~1 | ip_blocklist                                | BLOCK
-#   2 |   ~10 | BlockLargeRequests_CookiesAndHeaders        | count → BLOCK
-#   3 |   ~20 | BlockLargeRequests_Body_Admin               | count → BLOCK (non-API, 8 KB, excl. /otlp-proxy/)
+#   2 |   ~10 | BlockLargeRequests_CookiesAndHeaders        | BLOCK
+#   3 |   ~20 | BlockLargeRequests_Body_Admin               | BLOCK (non-API, 8 KB, excl. /otlp-proxy/)
 #   5 |   ~20 | BlockFFUFUserAgent                          | BLOCK
 #   6 |   ~20 | SigninRateLimitRule                         | BLOCK (rate, IP)
-#   7 |   ~22 | SigninRateLimitRule_JA4                     | count → BLOCK (rate, JA4)
-#   8 |   ~22 | ApiRateLimit_JA4                            | count → BLOCK (rate, JA4)
+#   7 |   ~22 | SigninRateLimitRule_JA4                     | BLOCK (rate, JA4)
+#   8 |   ~22 | ApiRateLimit_JA4                            | BLOCK (rate, JA4)
 #   9 |   ~23 | CanadaUSOnlyGeoRestriction                  | BLOCK (API host, non-CA/US)
-#  10 |   ~24 | MutatingApiRateLimit                        | count → BLOCK (rate, IP)
-#  11 |   ~24 | MutatingApiRateLimit_JA4                    | count → BLOCK (rate, JA4)
+#  10 |   ~24 | MutatingApiRateLimit                        | BLOCK (rate, IP)
+#  11 |   ~24 | MutatingApiRateLimit_JA4                    | BLOCK (rate, JA4)
 #  12 |   ~25 | PreventHostInjections                       | BLOCK
 #  13 |    25 | AWSManagedRulesAmazonIpReputationList        | BLOCK (managed)
 #  14 |   ~26 | rate_limit_all_except_api                   | BLOCK (rate, IP)
 #  15 |   ~26 | ApiRateLimit                                | BLOCK (rate, IP)
-#  16 |   ~30 | AdminAuthenticatedPagesGeoRestriction        | count → BLOCK (non-CA)
+#  16 |   ~30 | AdminAuthenticatedPagesGeoRestriction        | BLOCK (non-CA/US)
 #  17 |    50 | AWSManagedRulesAnonymousIpList               | BLOCK (managed)
 #  18 |   157 | valid_paths                                 | BLOCK
 #  19 |   200 | AWSManagedRulesKnownBadInputsRuleSet         | BLOCK (managed)
 #  20 |   200 | AWSManagedRulesLinuxRuleSet                  | BLOCK (managed)
-#  21 |   700 | AWSManagedRulesCommonRuleSet                 | BLOCK (managed, sets labels)
-#  22 |    ~8 | BlockLabeled_SSRF_NoUserAgent_NonCA          | count → BLOCK (label, after 21, non-API)
-#  23 |    ~6 | BlockSizeRestrictions_Body_ExcludeUploadPaths| count → BLOCK (label, after 21, non-API)
-#  24 |    ~6 | BlockLFI_Body_ExcludeTemplatePaths           | count → BLOCK (label, after 21)
-#  25 |    ~8 | BlockXSS_Body_ExcludeContentPaths            | count → BLOCK (label, after 21, excl. /services/)
+#  21 |   700 | AWSManagedRulesCommonRuleSet                 | BLOCK (managed, sets labels, non-API only)
+#  22 |    ~8 | BlockLabeled_SSRF_NoUserAgent_NonCA          | BLOCK (label, after 21, non-API)
+#  23 |    ~6 | BlockSizeRestrictions_Body_ExcludeUploadPaths| BLOCK (label, after 21, non-API)
+#  24 |    ~6 | BlockLFI_Body_ExcludeTemplatePaths           | BLOCK (label, after 21)
+#  25 |    ~8 | BlockXSS_Body_ExcludeContentPaths            | BLOCK (label, after 21, excl. /services/)
 #  26 |   200 | AWSManagedRulesSQLiRuleSet                   | BLOCK (managed, sets labels, excl. /services/)
-#  27 |    ~8 | BlockSQLi_Body_ExcludeContentPaths           | count → BLOCK (label, after 26, non-API, excl. /services/)
+#  27 |    ~8 | BlockSQLi_Body_ExcludeContentPaths           | BLOCK (label, after 26, non-API, excl. /services/)
 #  28 |    ?? | AWSManagedRulesAntiDDoSRuleSet               | count (managed, non-API only)
 # =============================================================================
 
@@ -781,7 +781,6 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
   }
 
   # ~22 WCU - JA4 fingerprint rate limit on sign-in paths; catches credential-stuffing tools that rotate IPs
-  # Count-only until baseline is established.
   rule {
     name     = "SigninRateLimitRule_JA4"
     priority = 7
@@ -866,7 +865,6 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
   }
 
   # ~22 WCU - JA4 fingerprint rate limit on the API host; catches API abuse tools that rotate IPs
-  # Count-only until baseline is established.
   rule {
     name     = "ApiRateLimit_JA4"
     priority = 8
@@ -937,7 +935,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
   }
 
   # ~24 WCU - IP rate limit on mutating methods (POST/PUT/PATCH/DELETE) to the API host.
-  # Lower threshold than ApiRateLimit to catch write-heavy abuse. Count-only until baseline established.
+  # Lower threshold than ApiRateLimit to catch write-heavy abuse.
   rule {
     name     = "MutatingApiRateLimit"
     priority = 10
@@ -1015,7 +1013,6 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
   }
 
   # ~24 WCU - JA4 rate limit on mutating methods; catches write-abuse tools that rotate IPs.
-  # Count-only until baseline established.
   rule {
     name     = "MutatingApiRateLimit_JA4"
     priority = 11
@@ -1798,7 +1795,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
   }
 
   # ~6 WCU - Block SQLi in body except on paths where user-supplied content is expected.
-  # Count-only until baseline established. Must run after AWSManagedRulesSQLiRuleSet (priority 26).
+  # Must run after AWSManagedRulesSQLiRuleSet (priority 26).
   rule {
     name     = "BlockSQLi_Body_ExcludeContentPaths"
     priority = 27

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -1362,24 +1362,6 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
 
         # Exclude API host: API clients legitimately omit User-Agent and send user content
         # that trips body-inspection rules (SSRF, XSS, LFI, RFI).
-        scope_down_statement {
-          not_statement {
-            statement {
-              byte_match_statement {
-                field_to_match {
-                  single_header {
-                    name = "host"
-                  }
-                }
-                positional_constraint = "STARTS_WITH"
-                search_string         = "api"
-                text_transformation {
-                  priority = 0
-                  type     = "LOWERCASE"
-                }
-              }
-            }
-          }
         }
       }
     }

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -1307,6 +1307,9 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
   }
 
   # 700 WCU
+  # Scoped to non-API hosts: body-inspection sub-rules (NoUserAgent_HEADER, EC2MetaDataSSRF_BODY,
+  # CrossSiteScripting_BODY, GenericLFI_BODY, GenericRFI_BODY) generate false positives on API traffic
+  # because API clients legitimately omit User-Agent and send user-supplied content in request bodies.
   rule {
     name     = "AWSManagedRulesCommonRuleSet"
     priority = 21
@@ -1354,6 +1357,28 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
           name = "GenericRFI_BODY"
           action_to_use {
             count {}
+          }
+        }
+
+        # Exclude API host: API clients legitimately omit User-Agent and send user content
+        # that trips body-inspection rules (SSRF, XSS, LFI, RFI).
+        scope_down_statement {
+          not_statement {
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  single_header {
+                    name = "host"
+                  }
+                }
+                positional_constraint = "STARTS_WITH"
+                search_string         = "api"
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
# Summary | Résumé

These are the new waf rules for prod. They've been in count for 2 weeks, and in block in staging for 1 week. Time to give them a go.

Rule Descriptions:

BlockLargeRequests_CookiesAndHeaders (priority 2)
- Blocks requests where cookies or headers exceed 8 KB
- Applies to all hosts

BlockLargeRequests_Body_Admin (priority 3)
- Blocks requests where body exceeds 8 KB on non-API hosts
- Excludes: /services/, /email-branding/, /platform-admin/letter-validation-preview, /letters, /otlp-proxy/

SigninRateLimitRule_JA4 (priority 7)
- Blocks repeated sign-in/register/forgot-password attempts from the same JA4 fingerprint
- Catches credential stuffing tools that rotate IPs

ApiRateLimit_JA4 (priority 8)
- Blocks high-rate API requests from the same JA4 fingerprint
- Catches API abuse tools that rotate IPs

MutatingApiRateLimit (priority 10)
- Blocks high-rate POST/PUT/PATCH/DELETE requests to the API by IP
- Lower threshold than the general API rate limit

MutatingApiRateLimit_JA4 (priority 11)
- Same as above but keyed on JA4 fingerprint instead of IP

AdminAuthenticatedPagesGeoRestriction (priority 16)
- Blocks non-CA/US access to authenticated admin paths
- (/services/, /organisations/, /platform-admin/, /user-profile, /find-users-by-email, /accounts)

BlockLabeled_SSRF_NoUserAgent_NonCA (priority 22)
- Blocks non-CA/US requests on non-API hosts labeled by EC2MetaDataSSRF_BODY or NoUserAgent_HEADER
- Depends on AWSManagedRulesCommonRuleSet labels (runs after priority 21)

BlockSizeRestrictions_Body_ExcludeUploadPaths (priority 23)
- Blocks requests labeled SizeRestrictions_BODY on non-API hosts
- Excludes: /v2/notifications/bulk, /services/, /letters

BlockLFI_Body_ExcludeTemplatePaths (priority 24)
- Blocks requests labeled GenericLFI_BODY
- Excludes: /v2/notifications, /templates, /personalise, /services/

BlockXSS_Body_ExcludeContentPaths (priority 25)
- Blocks requests labeled CrossSiteScripting_BODY
- Excludes: /v2/notifications, /templates, /personalise, /_email, /_letter, /services/

BlockSQLi_Body_ExcludeContentPaths (priority 27)
- Blocks requests labeled SQLi_Body or SQLiExtendedPatterns_Body on non-API hosts
- Excludes: /v2/notifications, /templates, /personalise, /services/
- Depends on AWSManagedRulesSQLiRuleSet labels (runs after priority 26)

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/875

## Test instructions | Instructions pour tester la modification

TF Apply / Release

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
