### PR TITLE
Put admin authenticated pages geo restriction back to count

### DIFF
--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -1117,7 +1117,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     }
   }
 
-  # ~30 WCU - Block non- US or CA access to authenticated admin pages.
+  # ~30 WCU - Count non- US or CA access to authenticated admin pages.
   # Public pages (sign-in, register, auth flows, GCA content, contact, newsletter, /_status) remain accessible worldwide.
   rule {
     name     = "AdminAuthenticatedPagesGeoRestriction"

--- a/aws/eks/waf.tf
+++ b/aws/eks/waf.tf
@@ -21,7 +21,7 @@
 #  13 |    25 | AWSManagedRulesAmazonIpReputationList        | BLOCK (managed)
 #  14 |   ~26 | rate_limit_all_except_api                   | BLOCK (rate, IP)
 #  15 |   ~26 | ApiRateLimit                                | BLOCK (rate, IP)
-#  16 |   ~30 | AdminAuthenticatedPagesGeoRestriction        | BLOCK (non-CA/US)
+#  16 |   ~30 | AdminAuthenticatedPagesGeoRestriction        | count (non-CA/US)
 #  17 |    50 | AWSManagedRulesAnonymousIpList               | BLOCK (managed)
 #  18 |   157 | valid_paths                                 | BLOCK
 #  19 |   200 | AWSManagedRulesKnownBadInputsRuleSet         | BLOCK (managed)
@@ -1124,7 +1124,7 @@ resource "aws_wafv2_web_acl" "notification-canada-ca" {
     priority = 16
 
     action {
-      block {}
+      count {}
     }
 
     statement {


### PR DESCRIPTION
# Summary | Résumé

Putting this back to count as there was some legitimate traffic that was going through this. 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/875

## Test instructions | Instructions pour tester la modification

TF Apply

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
