### PR TITLE
switch of callback paging

### DIFF
--- a/aws/eks/cloudwatch_alarms.tf
+++ b/aws/eks/cloudwatch_alarms.tf
@@ -1327,26 +1327,11 @@ resource "aws_cloudwatch_metric_alarm" "aggregating-queues-not-active-5-minutes-
   ok_actions          = [var.sns_alert_ok_arn]
 }
 
+
 resource "aws_cloudwatch_metric_alarm" "service-callback-too-many-failures-warning" {
   provider            = aws.core_services
   count               = var.cloudwatch_enabled ? 1 : 0
   alarm_name          = "service-callback-too-many-failures-warning"
-  alarm_description   = "Service reached the max number of callback retries 25 times in 5 minutes"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.callback-request-failures[0].metric_transformation[0].name
-  namespace           = aws_cloudwatch_log_metric_filter.callback-request-failures[0].metric_transformation[0].namespace
-  period              = 60 * 5
-  statistic           = "Sum"
-  threshold           = 25
-  treat_missing_data  = "notBreaching"
-  alarm_actions       = [var.sns_alert_warning_arn]
-}
-
-resource "aws_cloudwatch_metric_alarm" "service-callback-too-many-failures-critical" {
-  provider            = aws.core_services
-  count               = var.cloudwatch_enabled ? 1 : 0
-  alarm_name          = "service-callback-too-many-failures-critical"
   alarm_description   = "Service reached the max number of callback retries 100 times in 10 minutes"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -1356,7 +1341,7 @@ resource "aws_cloudwatch_metric_alarm" "service-callback-too-many-failures-criti
   statistic           = "Sum"
   threshold           = 100
   treat_missing_data  = "notBreaching"
-  alarm_actions       = [var.sns_alert_critical_arn]
+  alarm_actions       = [var.sns_alert_warning_arn]
   ok_actions          = [var.sns_alert_ok_arn]
 }
 


### PR DESCRIPTION
# Summary | Résumé

Keeping the alarm for visibility. We switch of callbacks and email clients automatically.