### PR TITLE
waf secret on perf test

### DIFF
--- a/aws/performance-test/container_definitions/perf_test.json.tmpl
+++ b/aws/performance-test/container_definitions/perf_test.json.tmpl
@@ -63,6 +63,10 @@
       {
         "name": "DATABASE_READER_URI",
         "valueFrom": "${DATABASE_READER_URI_ARN}"
+      },
+      {
+        "name": "WAF_SECRET",
+        "valueFrom": "${PERF_TEST_WAF_SECRET_ARN}"
       }
     ]
   }

--- a/aws/performance-test/container_definitions/perf_test_failure_scenarios.json.tmpl
+++ b/aws/performance-test/container_definitions/perf_test_failure_scenarios.json.tmpl
@@ -63,6 +63,10 @@
       {
         "name": "DATABASE_READER_URI",
         "valueFrom": "${DATABASE_READER_URI_ARN}"
+      },
+      {
+        "name": "WAF_SECRET",
+        "valueFrom": "${PERF_TEST_WAF_SECRET_ARN}"
       }
     ]
   }

--- a/aws/performance-test/container_execution_role.tf
+++ b/aws/performance-test/container_execution_role.tf
@@ -63,7 +63,8 @@ data "aws_iam_policy_document" "perf_test_secretsmanager" {
       var.env == "production" ? "" : aws_secretsmanager_secret_version.perf_test_domain[0].arn,
       var.env == "production" ? "" : aws_secretsmanager_secret_version.perf_test_api_key[0].arn,
       var.env == "production" ? "" : aws_secretsmanager_secret_version.perf_test_slack_webhook[0].arn,
-      var.env == "production" ? "" : aws_secretsmanager_secret_version.perf_test_database_uri[0].arn
+      var.env == "production" ? "" : aws_secretsmanager_secret_version.perf_test_database_uri[0].arn,
+      var.env == "production" ? "" : aws_secretsmanager_secret_version.perf_test_waf_secret[0].arn
     ]
   }
 }

--- a/aws/performance-test/ecs.tf
+++ b/aws/performance-test/ecs.tf
@@ -53,6 +53,7 @@ data "template_file" "perf_test_container_definition" {
     PERF_TEST_API_KEY_ARN       = var.env == "production" ? "" : aws_secretsmanager_secret_version.perf_test_api_key[0].arn
     PERF_TEST_SLACK_WEBHOOK_ARN = var.env == "production" ? "" : aws_secretsmanager_secret_version.perf_test_slack_webhook[0].arn
     DATABASE_READER_URI_ARN     = var.env == "production" ? "" : aws_secretsmanager_secret_version.perf_test_database_uri[0].arn
+    PERF_TEST_WAF_SECRET_ARN    = var.env == "production" ? "" : aws_secretsmanager_secret_version.perf_test_waf_secret[0].arn
   }
 }
 
@@ -91,6 +92,7 @@ data "template_file" "perf_test_failure_scenarios_container_definition" {
     PERF_TEST_API_KEY_ARN       = var.env == "production" ? "" : aws_secretsmanager_secret_version.perf_test_api_key[0].arn
     PERF_TEST_SLACK_WEBHOOK_ARN = var.env == "production" ? "" : aws_secretsmanager_secret_version.perf_test_slack_webhook[0].arn
     DATABASE_READER_URI_ARN     = var.env == "production" ? "" : aws_secretsmanager_secret_version.perf_test_database_uri[0].arn
+    PERF_TEST_WAF_SECRET_ARN    = var.env == "production" ? "" : aws_secretsmanager_secret_version.perf_test_waf_secret[0].arn
   }
 }
 

--- a/aws/performance-test/secrets.tf
+++ b/aws/performance-test/secrets.tf
@@ -117,3 +117,17 @@ resource "aws_secretsmanager_secret_version" "perf_test_database_uri" {
   secret_id     = aws_secretsmanager_secret.perf_test_database_uri[0].id
   secret_string = "postgresql://${var.app_db_user}:${var.app_db_user_password}@${var.database_read_only_proxy_endpoint}/${var.app_db_database_name}"
 }
+
+resource "aws_secretsmanager_secret" "perf_test_waf_secret" {
+  provider                = aws.core_services
+  count                   = var.env == "production" ? 0 : 1
+  name                    = "perf_test_waf_secret"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "perf_test_waf_secret" {
+  provider      = aws.core_services
+  count         = var.env == "production" ? 0 : 1
+  secret_id     = aws_secretsmanager_secret.perf_test_waf_secret[0].id
+  secret_string = var.waf_secret
+}

--- a/aws/performance-test/variables.tf
+++ b/aws/performance-test/variables.tf
@@ -28,3 +28,8 @@ variable "perf_test_security_group_id" {
   type        = string
   description = "performance test security group id"
 }
+
+variable "waf_secret" {
+  type      = string
+  sensitive = true
+}

--- a/aws/performance-test/variables.tf
+++ b/aws/performance-test/variables.tf
@@ -28,8 +28,3 @@ variable "perf_test_security_group_id" {
   type        = string
   description = "performance test security group id"
 }
-
-variable "waf_secret" {
-  type      = string
-  sensitive = true
-}


### PR DESCRIPTION
# Summary | Résumé

Not sure how this was not included... But the nightly perf test isn't sending the waf secret.

## Related Issues | Cartes liées

*  https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/875
* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/934

## Test instructions | Instructions pour tester la modification

TF Apply
Run staging perf test

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
