### PR TITLE
Fix perf test waf secret

### DIFF
--- a/aws/performance-test/container_definitions/perf_test.json.tmpl
+++ b/aws/performance-test/container_definitions/perf_test.json.tmpl
@@ -65,7 +65,7 @@
         "valueFrom": "${DATABASE_READER_URI_ARN}"
       },
       {
-        "name": "WAF_SECRET",
+        "name": "PERF_TEST_WAF_SECRET",
         "valueFrom": "${PERF_TEST_WAF_SECRET_ARN}"
       }
     ]

--- a/aws/performance-test/container_definitions/perf_test_failure_scenarios.json.tmpl
+++ b/aws/performance-test/container_definitions/perf_test_failure_scenarios.json.tmpl
@@ -65,7 +65,7 @@
         "valueFrom": "${DATABASE_READER_URI_ARN}"
       },
       {
-        "name": "WAF_SECRET",
+        "name": "PERF_TEST_WAF_SECRET",
         "valueFrom": "${PERF_TEST_WAF_SECRET_ARN}"
       }
     ]


### PR DESCRIPTION
# Summary | Résumé

Perf test waf secret name fix

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/934

## Test instructions | Instructions pour tester la modification

TF Apply
Run perf test

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
