### PR TITLE
Add PR check to enforce SHA-pinned GitHub Actions

### DIFF
--- a/.github/workflows/check_pinned_actions.yml
+++ b/.github/workflows/check_pinned_actions.yml
@@ -1,0 +1,54 @@
+name: "Check pinned GitHub Actions"
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+
+permissions: {}
+
+jobs:
+  check-pinned-actions:
+    name: "Scan for unpinned actions"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
+      # Only fails on unpinned-uses: zizmor's other audits are out of scope for this check.
+      - name: "Scan for unpinned actions"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          uvx "zizmor@1.29.0" --format=json-v1 --no-exit-codes .github/workflows .github/actions > zizmor-results.json
+
+          UNPINNED=$(jq '[.[] | select(.ident == "unpinned-uses")]' zizmor-results.json)
+          COUNT=$(echo "$UNPINNED" | jq 'length')
+
+          if [ "$COUNT" -gt 0 ]; then
+            echo "::error::Found $COUNT unpinned GitHub Action reference(s). All actions must be pinned to a full 40-character commit SHA."
+            echo "$UNPINNED" | jq -r '.[] | "  - \(.locations[0].symbolic.key.Local.verbatim_path): \(.desc)"'
+            echo ""
+            echo "To fix: replace the tag/branch with the action's full commit SHA and add a '# vX.Y.Z' comment, e.g."
+            echo "    uses: owner/repo@<40-char-sha> # v1.2.3"
+            echo ""
+            echo "If a version genuinely cannot be pinned to a SHA, add an inline exception with justification:"
+            echo "    uses: owner/repo@ref # zizmor: ignore[unpinned-uses] <reason>"
+            exit 1
+          fi
+
+          echo "No unpinned GitHub Actions found."

--- a/.github/workflows/check_pinned_actions.yml
+++ b/.github/workflows/check_pinned_actions.yml
@@ -41,7 +41,7 @@ jobs:
 
           if [ "$COUNT" -gt 0 ]; then
             echo "::error::Found $COUNT unpinned GitHub Action reference(s). All actions must be pinned to a full 40-character commit SHA."
-            echo "$UNPINNED" | jq -r '.[] | "  - \(.locations[0].symbolic.key.Local.verbatim_path): \(.desc)"'
+            echo "$UNPINNED" | jq -r '.[] | "  - \(.locations[0].symbolic.key.Local.verbatim_path // .locations[0].concrete.feature // "unknown location"): \(.desc)"'
             echo ""
             echo "To fix: replace the tag/branch with the action's full commit SHA and add a '# vX.Y.Z' comment, e.g."
             echo "    uses: owner/repo@<40-char-sha> # v1.2.3"

--- a/.github/workflows/check_pinned_actions.yml
+++ b/.github/workflows/check_pinned_actions.yml
@@ -34,7 +34,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          uvx "zizmor@1.29.0" --format=json-v1 --no-exit-codes .github/workflows .github/actions > zizmor-results.json
+          TARGETS=".github/workflows"
+          [ -d ".github/actions" ] && TARGETS="$TARGETS .github/actions"
+
+          uvx "zizmor@1.29.0" --format=json-v1 --no-exit-codes $TARGETS > zizmor-results.json
 
           UNPINNED=$(jq '[.[] | select(.ident == "unpinned-uses")]' zizmor-results.json)
           COUNT=$(echo "$UNPINNED" | jq 'length')

--- a/.github/workflows/check_pinned_actions.yml
+++ b/.github/workflows/check_pinned_actions.yml
@@ -44,7 +44,11 @@ jobs:
 
           if [ "$COUNT" -gt 0 ]; then
             echo "::error::Found $COUNT unpinned GitHub Action reference(s). All actions must be pinned to a full 40-character commit SHA."
-            echo "$UNPINNED" | jq -r '.[] | "  - \(.locations[0].symbolic.key.Local.verbatim_path // .locations[0].concrete.feature // "unknown location"): \(.desc)"'
+            echo "$UNPINNED" | jq -r '
+              .[] as $finding |
+              (($finding.locations[] | select(.symbolic.kind == "Primary")) // $finding.locations[0]) as $loc |
+              "  - \($loc.symbolic.key.Local.verbatim_path // $loc.concrete.feature // "unknown location"):\(($loc.concrete.location.start_point.row // 0) + 1): \($finding.desc)"
+            '
             echo ""
             echo "To fix: replace the tag/branch with the action's full commit SHA and add a '# vX.Y.Z' comment, e.g."
             echo "    uses: owner/repo@<40-char-sha> # v1.2.3"


### PR DESCRIPTION
## Description

Follow-up to the GH Actions SHA-pinning remediation ([#2732](https://github.com/cds-snc/notification-terraform/pull/2732)): adds a mandatory PR check that automatically fails if a workflow or composite action references a third-party action by a mutable tag/branch instead of a full 40-character commit SHA. Same implementation as [cds-snc/notification-manifests#5133](https://github.com/cds-snc/notification-manifests/pull/5133).

## Why not Renovate or the existing OSSF Scorecard job?

- **Renovate** already auto-proposes PRs to keep pins updated, but it's a remediation bot — it can't block a human PR that introduces a new unpinned action.
- **Scorecard**'s `Pinned-Dependencies` check only runs weekly/on push to `main` as a scoring job — it never runs on `pull_request` and doesn't fail the build.

Neither currently blocks a PR, which is the actual gap this closes.

## What this does

- New workflow: `.github/workflows/check_pinned_actions.yml`, triggered on `pull_request`/`push:main` when `.github/workflows/**` or `.github/actions/**` change (this repo also has composite actions under `.github/actions/`, so both are scanned).
- Runs [`zizmor`](https://docs.zizmor.sh) and filters its results down to just the `unpinned-uses` finding, so it stays scoped to SHA-pinning only (zizmor's other audits, e.g. `template-injection`, are a separate concern, out of scope here).
- Fails the check with actionable output (file + finding) and remediation guidance in the logs if any unpinned action is found.
- **Exception mechanism**: an inline `# zizmor: ignore[unpinned-uses] <reason>` comment skips the check for that line, if a genuinely unpinnable reference is ever needed (none currently exist in this repo).
- Note: used `.yml` (not `.yaml`) for the new file to match this repo's existing workflow-file convention and because this repo's `.gitignore` has a blanket `*.yaml` rule (used for Terraform-related YAML) that would otherwise silently exclude it.

## To make this a real merge gate

Branch protection on `main` needs "Scan for unpinned actions" added as a required status check (not done in this PR — repo settings, not code).

## Testing

Ran `zizmor` locally against this repo's `.github/workflows` and `.github/actions`: 0 `unpinned-uses` findings already, confirmed the CI script correctly fails against a deliberately unpinned test workflow.
