### PR TITLE
Fix AMI Checking

### DIFF
--- a/.github/workflows/check_eks_ami_update.yml
+++ b/.github/workflows/check_eks_ami_update.yml
@@ -199,5 +199,5 @@ jobs:
       if: ${{ failure() }}
       #checkov:skip=CKV_GHA_3:This is an expected use of curl
       run: |
-        json='{"text":"<!here> Check for EKS AMI updates failed in <https://github.com/cds-snc/notification-terraform/actions/workflows/check_eks_ami_update.yml|notification-terraform> !"}'
+        json='{"text":"<!here> Check for EKS AMI updates failed: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run #${{ github.run_number }}>"}'
         curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.NOTIFY_DEV_SLACK_WEBHOOK }}

--- a/.github/workflows/check_eks_ami_update.yml
+++ b/.github/workflows/check_eks_ami_update.yml
@@ -193,4 +193,11 @@ jobs:
       #checkov:skip=CKV_GHA_3:This is an expected use of curl
       run: |
         json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":kubernetes: Kubernetes worker update available. Please review and merge the PRs: \n <${{steps.dev_staging_pr.outputs.pull-request-url}}|Staging PR> \n <${{steps.production_pr.outputs.pull-request-url}}|Production PR>"}}]}'
-        curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.NOTIFY_DEV_SLACK_WEBHOOK }} 
+        curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.NOTIFY_DEV_SLACK_WEBHOOK }}
+
+    - name: Notify Slack channel if this job failed
+      if: ${{ failure() }}
+      #checkov:skip=CKV_GHA_3:This is an expected use of curl
+      run: |
+        json='{"text":"<!here> Check for EKS AMI updates failed in <https://github.com/cds-snc/notification-terraform/actions/workflows/check_eks_ami_update.yml|notification-terraform> !"}'
+        curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.NOTIFY_DEV_SLACK_WEBHOOK }}

--- a/.github/workflows/check_eks_ami_update.yml
+++ b/.github/workflows/check_eks_ami_update.yml
@@ -90,6 +90,7 @@ jobs:
       if: steps.latest.outputs.ami != steps.current.outputs.ami
       with:
         token: ${{ steps.generate-token.outputs.token }}
+        sign-commits: true
         commit-message: Dev and Staging EKS AMI patch
         title: Dev and Staging EKS AMI patch
         branch: dev-staging-eks-ami-${{ steps.latest.outputs.ami }}-${{ github.run_id }}
@@ -154,6 +155,7 @@ jobs:
       uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
       with:
         token: ${{ steps.generate-token.outputs.token }}
+        sign-commits: true
         commit-message: Production EKS AMI patch
         title: Production EKS AMI patch
         branch: production-eks-ami-${{ steps.latest.outputs.ami }}-${{ github.run_id }}


### PR DESCRIPTION
# Summary | Résumé

The EKS ami checks have been failing since we enabled signed commits. I've added the ability to sign these commits and also a notification of failure so that we're aware of any subsequent failures for this workflow

## Related Issues | Cartes liées

Ad-hoc

## Test instructions | Instructions pour tester la modification

Run the action, verify the PR gets created succesfully.

## Release Instructions | Instructions pour le déploiement

None.

## Reviewer checklist | Liste de vérification du réviseur

* [ ] This PR does not break existing functionality.
* [ ] This PR does not violate GCNotify's privacy policies.
* [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [ ] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
