### PR TITLE
Remove manifest_ prefix from Manifest repository secret variables and secret names

### DIFF
--- a/aws/common/cloudwatch_events.tf
+++ b/aws/common/cloudwatch_events.tf
@@ -58,7 +58,7 @@ resource "aws_cloudwatch_event_connection" "guardduty_scan_verdict_callback" {
   auth_parameters {
     api_key {
       key   = "X-Scan-Callback-Token"
-      value = var.manifest_scan_verdict_callback_token
+      value = var.scan_verdict_callback_token
     }
   }
 }

--- a/aws/github/api-secrets.tf
+++ b/aws/github/api-secrets.tf
@@ -9,7 +9,7 @@ resource "github_actions_secret" "api_cypress_user_pw_secret" {
   count            = var.env == "staging" ? 1 : 0
   repository       = data.github_repository.notification_api.name
   secret_name      = "CYPRESS_USER_PW_SECRET"
-  plaintext_value  = var.manifest_cypress_user_pw_secret
+  plaintext_value  = var.cypress_user_pw_secret
   destroy_on_drift = false
 }
 

--- a/aws/github/manifest-secrets.tf
+++ b/aws/github/manifest-secrets.tf
@@ -31,7 +31,7 @@ resource "github_actions_secret" "manifests_notify_dev_slack_webhook" {
 resource "github_actions_secret" "manifests_cache_clear_client_secret" {
   repository       = data.github_repository.notification_manifests.name
   secret_name      = "${upper(var.env)}_CACHE_CLEAR_CLIENT_SECRET"
-  plaintext_value  = var.manifest_cache_clear_client_secret
+  plaintext_value  = var.cache_clear_client_secret
   destroy_on_drift = false
 }
 
@@ -39,7 +39,7 @@ resource "github_actions_secret" "smoke_admin_client_secret" {
   count            = var.env == "production" || var.env == "staging" ? 1 : 0
   repository       = data.github_repository.notification_manifests.name
   secret_name      = "${upper(var.env)}_SMOKE_ADMIN_CLIENT_SECRET"
-  plaintext_value  = var.manifest_smoke_admin_client_secret
+  plaintext_value  = var.smoke_admin_client_secret
   destroy_on_drift = false
 }
 
@@ -47,7 +47,7 @@ resource "github_actions_secret" "smoke_api_key" {
   count            = var.env == "production" || var.env == "staging" ? 1 : 0
   repository       = data.github_repository.notification_manifests.name
   secret_name      = "${upper(var.env)}_SMOKE_API_KEY"
-  plaintext_value  = var.manifest_smoke_api_key
+  plaintext_value  = var.smoke_api_key
   destroy_on_drift = false
 }
 
@@ -55,7 +55,7 @@ resource "github_actions_secret" "pr_bot_github_token" {
   count            = var.env == "staging" ? 1 : 0
   repository       = data.github_repository.notification_manifests.name
   secret_name      = "PR_BOT_GITHUB_TOKEN"
-  plaintext_value  = var.manifest_pr_bot_github_token
+  plaintext_value  = var.pr_bot_github_token
   destroy_on_drift = false
 }
 

--- a/aws/manifest_secrets/secrets.tf
+++ b/aws/manifest_secrets/secrets.tf
@@ -1,3 +1,11 @@
+# ---------------------------------------------------------------------------
+# LEGACY: MANIFEST_-prefixed secrets. Duplicated below under de-prefixed
+# names (see "_unprefixed" resources at the end of this file) as part of the
+# migration away from the manifest_ prefix. DO NOT delete these until the
+# Helm/ExternalSecret rollout in notification-manifests has been verified to
+# read the new de-prefixed names in every environment. Tracking: PR #2787.
+# ---------------------------------------------------------------------------
+
 resource "aws_secretsmanager_secret" "manifest_admin_client_secret" {
   provider                = aws.core_services
   name                    = "MANIFEST_ADMIN_CLIENT_SECRET"
@@ -536,5 +544,548 @@ resource "aws_secretsmanager_secret" "manifest_scan_verdict_callback_token" {
 resource "aws_secretsmanager_secret_version" "manifest_scan_verdict_callback_token" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_scan_verdict_callback_token.id
+  secret_string = var.scan_verdict_callback_token
+}
+
+# ---------------------------------------------------------------------------
+# NEW: de-prefixed duplicates of every secret above, added so the migration
+# is additive-only (nothing above is destroyed by this change). Once the
+# Helm/ExternalSecret rollout is verified against these names, delete the
+# LEGACY MANIFEST_-prefixed block above and drop the "_unprefixed" suffix
+# from the resource labels below. Tracking: PR #2787.
+# ---------------------------------------------------------------------------
+resource "aws_secretsmanager_secret" "manifest_admin_client_secret_unprefixed" {
+  provider                = aws.core_services
+  name                    = "ADMIN_CLIENT_SECRET"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_admin_client_secret_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_admin_client_secret_unprefixed.id
+  secret_string = var.admin_client_secret
+}
+
+resource "aws_secretsmanager_secret" "manifest_auth_tokens_unprefixed" {
+  provider                = aws.core_services
+  name                    = "AUTH_TOKENS"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_auth_tokens_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_auth_tokens_unprefixed.id
+  secret_string = var.auth_tokens
+}
+
+resource "aws_secretsmanager_secret" "manifest_airtable_api_key_unprefixed" {
+  provider                = aws.core_services
+  name                    = "AIRTABLE_API_KEY"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_airtable_api_key_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_airtable_api_key_unprefixed.id
+  secret_string = var.airtable_api_key
+}
+
+resource "aws_secretsmanager_secret" "manifest_document_download_api_key_unprefixed" {
+  provider                = aws.core_services
+  name                    = "DOCUMENT_DOWNLOAD_API_KEY"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_document_download_api_key_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_document_download_api_key_unprefixed.id
+  secret_string = var.auth_tokens
+}
+
+resource "aws_secretsmanager_secret" "manifest_aws_route53_zone_unprefixed" {
+  provider                = aws.core_services
+  name                    = "AWS_ROUTE53_ZONE"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_aws_route53_zone_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_aws_route53_zone_unprefixed.id
+  secret_string = var.aws_route53_zone
+}
+
+resource "aws_secretsmanager_secret" "manifest_aws_ses_access_key_unprefixed" {
+  provider                = aws.core_services
+  name                    = "AWS_SES_ACCESS_KEY"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_aws_ses_access_key_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_aws_ses_access_key_unprefixed.id
+  secret_string = var.aws_ses_access_key
+}
+
+resource "aws_secretsmanager_secret" "manifest_aws_ses_secret_key_unprefixed" {
+  provider                = aws.core_services
+  name                    = "AWS_SES_SECRET_KEY"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_aws_ses_secret_key_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_aws_ses_secret_key_unprefixed.id
+  secret_string = var.aws_ses_secret_key
+}
+
+resource "aws_secretsmanager_secret" "manifest_dangerous_salt_unprefixed" {
+  provider                = aws.core_services
+  name                    = "DANGEROUS_SALT"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_dangerous_salt_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_dangerous_salt_unprefixed.id
+  secret_string = var.dangerous_salt
+}
+
+resource "aws_secretsmanager_secret" "manifest_debug_key_unprefixed" {
+  provider                = aws.core_services
+  name                    = "DEBUG_KEY"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_debug_key_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_debug_key_unprefixed.id
+  secret_string = var.debug_key
+}
+
+resource "aws_secretsmanager_secret" "manifest_fresh_desk_product_id_unprefixed" {
+  provider                = aws.core_services
+  name                    = "FRESH_DESK_PRODUCT_ID"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_fresh_desk_product_id_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_fresh_desk_product_id_unprefixed.id
+  secret_string = var.fresh_desk_product_id
+}
+
+resource "aws_secretsmanager_secret" "manifest_fresh_desk_api_key_unprefixed" {
+  provider                = aws.core_services
+  name                    = "FRESH_DESK_API_KEY"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_fresh_desk_api_key_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_fresh_desk_api_key_unprefixed.id
+  secret_string = var.fresh_desk_api_key
+}
+
+resource "aws_secretsmanager_secret" "manifest_gc_articles_api_auth_username_unprefixed" {
+  provider                = aws.core_services
+  name                    = "GC_ARTICLES_API_AUTH_USERNAME"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_gc_articles_api_auth_username_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_gc_articles_api_auth_username_unprefixed.id
+  secret_string = var.gc_articles_api_auth_username
+}
+
+resource "aws_secretsmanager_secret" "manifest_gc_articles_api_auth_password_unprefixed" {
+  provider                = aws.core_services
+  name                    = "GC_ARTICLES_API_AUTH_PASSWORD"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_gc_articles_api_auth_password_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_gc_articles_api_auth_password_unprefixed.id
+  secret_string = var.gc_articles_api_auth_password
+}
+
+resource "aws_secretsmanager_secret" "manifest_gc_articles_waf_rate_bypass_secret_unprefixed" {
+  provider                = aws.core_services
+  name                    = "GC_ARTICLES_WAF_RATE_BYPASS_SECRET"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_gc_articles_waf_rate_bypass_secret_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_gc_articles_waf_rate_bypass_secret_unprefixed.id
+  secret_string = var.gc_articles_waf_rate_bypass_secret
+}
+
+resource "aws_secretsmanager_secret" "manifest_mixpanel_project_token_unprefixed" {
+  provider                = aws.core_services
+  name                    = "MIXPANEL_PROJECT_TOKEN"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_mixpanel_project_token_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_mixpanel_project_token_unprefixed.id
+  secret_string = var.mixpanel_project_token
+}
+
+resource "aws_secretsmanager_secret" "manifest_crm_github_personal_access_token_unprefixed" {
+  provider                = aws.core_services
+  name                    = "CRM_GITHUB_PERSONAL_ACCESS_TOKEN"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_crm_github_personal_access_token_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_crm_github_personal_access_token_unprefixed.id
+  secret_string = var.crm_github_personal_access_token
+}
+
+resource "aws_secretsmanager_secret" "manifest_secret_key_unprefixed" {
+  provider                = aws.core_services
+  name                    = "SECRET_KEY"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_secret_key_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_secret_key_unprefixed.id
+  secret_string = var.secret_key
+}
+
+resource "aws_secretsmanager_secret" "manifest_sendgrid_api_key_unprefixed" {
+  provider                = aws.core_services
+  name                    = "SENDGRID_API_KEY"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_sendgrid_api_key_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_sendgrid_api_key_unprefixed.id
+  secret_string = var.sendgrid_api_key
+}
+
+resource "aws_secretsmanager_secret" "manifest_waf_secret_unprefixed" {
+  provider                = aws.core_services
+  name                    = "WAF_SECRET"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_waf_secret_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_waf_secret_unprefixed.id
+  secret_string = var.waf_secret
+}
+
+resource "aws_secretsmanager_secret" "manifest_zendesk_api_key_unprefixed" {
+  provider                = aws.core_services
+  name                    = "ZENDESK_API_KEY"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_zendesk_api_key_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_zendesk_api_key_unprefixed.id
+  secret_string = var.zendesk_api_key
+}
+
+resource "aws_secretsmanager_secret" "manifest_zendesk_sell_api_key_unprefixed" {
+  provider                = aws.core_services
+  name                    = "ZENDESK_SELL_API_KEY"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_zendesk_sell_api_key_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_zendesk_sell_api_key_unprefixed.id
+  secret_string = var.zendesk_sell_api_key
+}
+
+resource "aws_secretsmanager_secret" "manifest_sre_client_secret_unprefixed" {
+  provider                = aws.core_services
+  name                    = "SRE_CLIENT_SECRET"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_sre_client_secret_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_sre_client_secret_unprefixed.id
+  secret_string = var.sre_client_secret
+}
+
+resource "aws_secretsmanager_secret" "manifest_cache_clear_client_secret_unprefixed" {
+  provider                = aws.core_services
+  name                    = "CACHE_CLEAR_CLIENT_SECRET"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_cache_clear_client_secret_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_cache_clear_client_secret_unprefixed.id
+  secret_string = var.cache_clear_client_secret
+}
+
+resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_sc_pool_id_unprefixed" {
+  provider                = aws.core_services
+  name                    = "AWS_PINPOINT_SC_POOL_ID"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_sc_pool_id_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_aws_pinpoint_sc_pool_id_unprefixed.id
+  secret_string = var.aws_pinpoint_sc_pool_id
+}
+
+resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_sc_template_ids_unprefixed" {
+  provider                = aws.core_services
+  name                    = "AWS_PINPOINT_SC_TEMPLATE_IDS"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_sc_template_ids_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_aws_pinpoint_sc_template_ids_unprefixed.id
+  secret_string = var.aws_pinpoint_sc_template_ids
+}
+
+resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_default_pool_id_unprefixed" {
+  provider                = aws.core_services
+  name                    = "AWS_PINPOINT_DEFAULT_POOL_ID"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_default_pool_id_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_aws_pinpoint_default_pool_id_unprefixed.id
+  secret_string = var.aws_pinpoint_default_pool_id
+}
+
+resource "aws_secretsmanager_secret" "manifest_sqlalachemy_database_uri_unprefixed" {
+  provider                = aws.core_services
+  name                    = "SQLALCHEMY_DATABASE_URI"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_sqlalachemy_database_uri_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_sqlalachemy_database_uri_unprefixed.id
+  secret_string = "postgresql://${var.app_db_user}:${var.app_db_user_password}@${var.database_read_write_proxy_endpoint}/${var.app_db_database_name}"
+}
+
+resource "aws_secretsmanager_secret" "manifest_sqlalachemy_database_reader_uri_unprefixed" {
+  provider                = aws.core_services
+  name                    = "SQLALCHEMY_DATABASE_READER_URI"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_sqlalachemy_database_reader_uri_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_sqlalachemy_database_reader_uri_unprefixed.id
+  secret_string = "postgresql://${var.app_db_user}:${var.app_db_user_password}@${var.database_read_only_proxy_endpoint}/${var.app_db_database_name}"
+}
+
+resource "aws_secretsmanager_secret" "manifest_postgres_host_unprefixed" {
+  provider                = aws.core_services
+  name                    = "POSTGRES_HOST"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_postgres_host_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_postgres_host_unprefixed.id
+  secret_string = var.postgres_cluster_endpoint
+}
+
+resource "aws_secretsmanager_secret" "manifest_postgres_sql_unprefixed" {
+  provider                = aws.core_services
+  name                    = "POSTGRES_SQL"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_postgres_sql_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_postgres_sql_unprefixed.id
+  secret_string = "postgresql://${var.app_db_user}:${var.app_db_user_password}@${var.database_read_write_proxy_endpoint}/${var.app_db_database_name}"
+}
+
+resource "aws_secretsmanager_secret" "manifest_cache_ops_url_unprefixed" {
+  provider                = aws.core_services
+  name                    = "CACHE_OPS_URL"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_cache_ops_url_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_cache_ops_url_unprefixed.id
+  secret_string = "redis://${var.elasticache_queue_cache_primary_endpoint_address}"
+}
+
+resource "aws_secretsmanager_secret" "manifest_redis_publish_url_unprefixed" {
+  provider                = aws.core_services
+  name                    = "REDIS_PUBLISH_URL"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_redis_publish_url_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_redis_publish_url_unprefixed.id
+  secret_string = var.env != "production" ? "redis://${var.elasticache_queue_cache_primary_endpoint_address}" : "redis://${var.redis_primary_endpoint_address}"
+}
+
+resource "aws_secretsmanager_secret" "manifest_redis_url_unprefixed" {
+  provider                = aws.core_services
+  name                    = "REDIS_URL"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_redis_url_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_redis_url_unprefixed.id
+  secret_string = "redis://${var.redis_primary_endpoint_address}"
+}
+
+resource "aws_secretsmanager_secret" "manifest_cypress_user_pw_secret_unprefixed" {
+  provider                = aws.core_services
+  name                    = "CYPRESS_USER_PW_SECRET"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_cypress_user_pw_secret_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_cypress_user_pw_secret_unprefixed.id
+  secret_string = var.cypress_user_pw_secret
+}
+
+resource "aws_secretsmanager_secret" "manifest_cypress_auth_client_secret_unprefixed" {
+  provider                = aws.core_services
+  name                    = "CYPRESS_AUTH_CLIENT_SECRET"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_cypress_auth_client_secret_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_cypress_auth_client_secret_unprefixed.id
+  secret_string = var.cypress_auth_client_secret
+}
+
+resource "aws_secretsmanager_secret" "manifest_docker_hub_username_unprefixed" {
+  provider                = aws.core_services
+  name                    = "DOCKER_HUB_USERNAME"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_docker_hub_username_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_docker_hub_username_unprefixed.id
+  secret_string = var.docker_hub_username
+}
+
+resource "aws_secretsmanager_secret" "manifest_docker_hub_pat_unprefixed" {
+  provider                = aws.core_services
+  name                    = "DOCKER_HUB_PAT"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_docker_hub_pat_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_docker_hub_pat_unprefixed.id
+  secret_string = var.docker_hub_pat
+}
+
+resource "aws_secretsmanager_secret" "manifest_signoz_smtp_username_unprefixed" {
+  provider                = aws.core_services
+  count                   = var.enable_signoz ? 1 : 0
+  name                    = "SIGNOZ_SMTP_USERNAME"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_signoz_smtp_username_unprefixed" {
+  provider      = aws.core_services
+  count         = var.enable_signoz ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.manifest_signoz_smtp_username_unprefixed[0].id
+  secret_string = var.signoz_smtp_username
+}
+
+resource "aws_secretsmanager_secret" "manifest_signoz_smtp_password_unprefixed" {
+  provider                = aws.core_services
+  count                   = var.enable_signoz ? 1 : 0
+  name                    = "SIGNOZ_SMTP_PASSWORD"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_signoz_smtp_password_unprefixed" {
+  provider      = aws.core_services
+  count         = var.enable_signoz ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.manifest_signoz_smtp_password_unprefixed[0].id
+  secret_string = var.signoz_smtp_password
+}
+
+resource "aws_secretsmanager_secret" "manifest_signoz_dashboard_api_key_unprefixed" {
+  provider                = aws.core_services
+  count                   = var.enable_signoz ? 1 : 0
+  name                    = "SIGNOZ_DASHBOARD_API_KEY"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_signoz_dashboard_api_key_unprefixed" {
+  provider      = aws.core_services
+  count         = var.enable_signoz ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.manifest_signoz_dashboard_api_key_unprefixed[0].id
+  secret_string = var.signoz_dashboard_api_key
+}
+
+resource "aws_secretsmanager_secret" "manifest_signoz_postgres_password_unprefixed" {
+  provider                = aws.core_services
+  count                   = var.enable_signoz ? 1 : 0
+  name                    = "SIGNOZ_POSTGRES_PASSWORD"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_signoz_postgres_password_unprefixed" {
+  provider      = aws.core_services
+  count         = var.enable_signoz ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.manifest_signoz_postgres_password_unprefixed[0].id
+  secret_string = var.signoz_postgres_password
+}
+
+resource "aws_secretsmanager_secret" "manifest_falco_credentials_unprefixed" {
+  provider                = aws.core_services
+  name                    = "FALCO_CREDENTIALS"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_falco_credentials_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_falco_credentials_unprefixed.id
+  secret_string = var.falco_credentials
+}
+
+resource "aws_secretsmanager_secret" "manifest_falco_slack_webhook_url_unprefixed" {
+  provider                = aws.core_services
+  name                    = "FALCO_SLACK_WEBHOOK_URL"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_falco_slack_webhook_url_version_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_falco_slack_webhook_url_unprefixed.id
+  secret_string = var.falco_slack_webhook_url
+}
+
+resource "aws_secretsmanager_secret" "manifest_scan_verdict_callback_token_unprefixed" {
+  provider                = aws.core_services
+  name                    = "SCAN_VERDICT_CALLBACK_TOKEN"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "manifest_scan_verdict_callback_token_unprefixed" {
+  provider      = aws.core_services
+  secret_id     = aws_secretsmanager_secret.manifest_scan_verdict_callback_token_unprefixed.id
   secret_string = var.scan_verdict_callback_token
 }

--- a/aws/manifest_secrets/secrets.tf
+++ b/aws/manifest_secrets/secrets.tf
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------------
 # LEGACY: MANIFEST_-prefixed secrets. Duplicated below under de-prefixed
-# names (see "_unprefixed" resources at the end of this file) as part of the
-# migration away from the manifest_ prefix. DO NOT delete these until the
+# names, matching the variable names, as part of the migration away from the
+# manifest_ prefix. DO NOT delete these until the
 # Helm/ExternalSecret rollout in notification-manifests has been verified to
 # read the new de-prefixed names in every environment. Tracking: PR #2787.
 # ---------------------------------------------------------------------------
@@ -571,541 +571,540 @@ resource "aws_secretsmanager_secret_version" "manifest_scan_verdict_callback_tok
 # NEW: de-prefixed duplicates of every secret above, added so the migration
 # is additive-only (nothing above is destroyed by this change). Once the
 # Helm/ExternalSecret rollout is verified against these names, delete the
-# LEGACY MANIFEST_-prefixed block above and drop the "_unprefixed" suffix
-# from the resource labels below. Tracking: PR #2787.
+# LEGACY MANIFEST_-prefixed block above. Tracking: PR #2787.
 # ---------------------------------------------------------------------------
-resource "aws_secretsmanager_secret" "manifest_admin_client_secret_unprefixed" {
+resource "aws_secretsmanager_secret" "admin_client_secret" {
   provider                = aws.core_services
   name                    = "ADMIN_CLIENT_SECRET"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_admin_client_secret_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "admin_client_secret_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_admin_client_secret_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.admin_client_secret.id
   secret_string = var.admin_client_secret
 }
 
-resource "aws_secretsmanager_secret" "manifest_auth_tokens_unprefixed" {
+resource "aws_secretsmanager_secret" "auth_tokens" {
   provider                = aws.core_services
   name                    = "AUTH_TOKENS"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_auth_tokens_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "auth_tokens_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_auth_tokens_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.auth_tokens.id
   secret_string = var.auth_tokens
 }
 
-resource "aws_secretsmanager_secret" "manifest_airtable_api_key_unprefixed" {
+resource "aws_secretsmanager_secret" "airtable_api_key" {
   provider                = aws.core_services
   name                    = "AIRTABLE_API_KEY"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_airtable_api_key_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "airtable_api_key_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_airtable_api_key_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.airtable_api_key.id
   secret_string = var.airtable_api_key
 }
 
-resource "aws_secretsmanager_secret" "manifest_document_download_api_key_unprefixed" {
+resource "aws_secretsmanager_secret" "document_download_api_key" {
   provider                = aws.core_services
   name                    = "DOCUMENT_DOWNLOAD_API_KEY"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_document_download_api_key_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "document_download_api_key_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_document_download_api_key_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.document_download_api_key.id
   secret_string = var.auth_tokens
 }
 
-resource "aws_secretsmanager_secret" "manifest_aws_route53_zone_unprefixed" {
+resource "aws_secretsmanager_secret" "aws_route53_zone" {
   provider                = aws.core_services
   name                    = "AWS_ROUTE53_ZONE"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_aws_route53_zone_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "aws_route53_zone_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_aws_route53_zone_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.aws_route53_zone.id
   secret_string = var.aws_route53_zone
 }
 
-resource "aws_secretsmanager_secret" "manifest_aws_ses_access_key_unprefixed" {
+resource "aws_secretsmanager_secret" "aws_ses_access_key" {
   provider                = aws.core_services
   name                    = "AWS_SES_ACCESS_KEY"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_aws_ses_access_key_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "aws_ses_access_key_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_aws_ses_access_key_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.aws_ses_access_key.id
   secret_string = var.aws_ses_access_key
 }
 
-resource "aws_secretsmanager_secret" "manifest_aws_ses_secret_key_unprefixed" {
+resource "aws_secretsmanager_secret" "aws_ses_secret_key" {
   provider                = aws.core_services
   name                    = "AWS_SES_SECRET_KEY"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_aws_ses_secret_key_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "aws_ses_secret_key_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_aws_ses_secret_key_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.aws_ses_secret_key.id
   secret_string = var.aws_ses_secret_key
 }
 
-resource "aws_secretsmanager_secret" "manifest_dangerous_salt_unprefixed" {
+resource "aws_secretsmanager_secret" "dangerous_salt" {
   provider                = aws.core_services
   name                    = "DANGEROUS_SALT"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_dangerous_salt_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "dangerous_salt_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_dangerous_salt_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.dangerous_salt.id
   secret_string = var.dangerous_salt
 }
 
-resource "aws_secretsmanager_secret" "manifest_debug_key_unprefixed" {
+resource "aws_secretsmanager_secret" "debug_key" {
   provider                = aws.core_services
   name                    = "DEBUG_KEY"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_debug_key_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "debug_key_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_debug_key_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.debug_key.id
   secret_string = var.debug_key
 }
 
-resource "aws_secretsmanager_secret" "manifest_fresh_desk_product_id_unprefixed" {
+resource "aws_secretsmanager_secret" "fresh_desk_product_id" {
   provider                = aws.core_services
   name                    = "FRESH_DESK_PRODUCT_ID"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_fresh_desk_product_id_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "fresh_desk_product_id_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_fresh_desk_product_id_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.fresh_desk_product_id.id
   secret_string = var.fresh_desk_product_id
 }
 
-resource "aws_secretsmanager_secret" "manifest_fresh_desk_api_key_unprefixed" {
+resource "aws_secretsmanager_secret" "fresh_desk_api_key" {
   provider                = aws.core_services
   name                    = "FRESH_DESK_API_KEY"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_fresh_desk_api_key_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "fresh_desk_api_key_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_fresh_desk_api_key_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.fresh_desk_api_key.id
   secret_string = var.fresh_desk_api_key
 }
 
-resource "aws_secretsmanager_secret" "manifest_gc_articles_api_auth_username_unprefixed" {
+resource "aws_secretsmanager_secret" "gc_articles_api_auth_username" {
   provider                = aws.core_services
   name                    = "GC_ARTICLES_API_AUTH_USERNAME"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_gc_articles_api_auth_username_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "gc_articles_api_auth_username_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_gc_articles_api_auth_username_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.gc_articles_api_auth_username.id
   secret_string = var.gc_articles_api_auth_username
 }
 
-resource "aws_secretsmanager_secret" "manifest_gc_articles_api_auth_password_unprefixed" {
+resource "aws_secretsmanager_secret" "gc_articles_api_auth_password" {
   provider                = aws.core_services
   name                    = "GC_ARTICLES_API_AUTH_PASSWORD"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_gc_articles_api_auth_password_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "gc_articles_api_auth_password_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_gc_articles_api_auth_password_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.gc_articles_api_auth_password.id
   secret_string = var.gc_articles_api_auth_password
 }
 
-resource "aws_secretsmanager_secret" "manifest_gc_articles_waf_rate_bypass_secret_unprefixed" {
+resource "aws_secretsmanager_secret" "gc_articles_waf_rate_bypass_secret" {
   provider                = aws.core_services
   name                    = "GC_ARTICLES_WAF_RATE_BYPASS_SECRET"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_gc_articles_waf_rate_bypass_secret_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "gc_articles_waf_rate_bypass_secret_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_gc_articles_waf_rate_bypass_secret_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.gc_articles_waf_rate_bypass_secret.id
   secret_string = var.gc_articles_waf_rate_bypass_secret
 }
 
-resource "aws_secretsmanager_secret" "manifest_mixpanel_project_token_unprefixed" {
+resource "aws_secretsmanager_secret" "mixpanel_project_token" {
   provider                = aws.core_services
   name                    = "MIXPANEL_PROJECT_TOKEN"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_mixpanel_project_token_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "mixpanel_project_token_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_mixpanel_project_token_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.mixpanel_project_token.id
   secret_string = var.mixpanel_project_token
 }
 
-resource "aws_secretsmanager_secret" "manifest_crm_github_personal_access_token_unprefixed" {
+resource "aws_secretsmanager_secret" "crm_github_personal_access_token" {
   provider                = aws.core_services
   name                    = "CRM_GITHUB_PERSONAL_ACCESS_TOKEN"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_crm_github_personal_access_token_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "crm_github_personal_access_token_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_crm_github_personal_access_token_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.crm_github_personal_access_token.id
   secret_string = var.crm_github_personal_access_token
 }
 
-resource "aws_secretsmanager_secret" "manifest_secret_key_unprefixed" {
+resource "aws_secretsmanager_secret" "secret_key" {
   provider                = aws.core_services
   name                    = "SECRET_KEY"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_secret_key_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "secret_key_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_secret_key_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.secret_key.id
   secret_string = var.secret_key
 }
 
-resource "aws_secretsmanager_secret" "manifest_sendgrid_api_key_unprefixed" {
+resource "aws_secretsmanager_secret" "sendgrid_api_key" {
   provider                = aws.core_services
   name                    = "SENDGRID_API_KEY"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_sendgrid_api_key_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "sendgrid_api_key_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_sendgrid_api_key_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.sendgrid_api_key.id
   secret_string = var.sendgrid_api_key
 }
 
-resource "aws_secretsmanager_secret" "manifest_waf_secret_unprefixed" {
+resource "aws_secretsmanager_secret" "waf_secret" {
   provider                = aws.core_services
   name                    = "WAF_SECRET"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_waf_secret_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "waf_secret_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_waf_secret_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.waf_secret.id
   secret_string = var.waf_secret
 }
 
-resource "aws_secretsmanager_secret" "manifest_zendesk_api_key_unprefixed" {
+resource "aws_secretsmanager_secret" "zendesk_api_key" {
   provider                = aws.core_services
   name                    = "ZENDESK_API_KEY"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_zendesk_api_key_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "zendesk_api_key_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_zendesk_api_key_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.zendesk_api_key.id
   secret_string = var.zendesk_api_key
 }
 
-resource "aws_secretsmanager_secret" "manifest_zendesk_sell_api_key_unprefixed" {
+resource "aws_secretsmanager_secret" "zendesk_sell_api_key" {
   provider                = aws.core_services
   name                    = "ZENDESK_SELL_API_KEY"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_zendesk_sell_api_key_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "zendesk_sell_api_key_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_zendesk_sell_api_key_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.zendesk_sell_api_key.id
   secret_string = var.zendesk_sell_api_key
 }
 
-resource "aws_secretsmanager_secret" "manifest_sre_client_secret_unprefixed" {
+resource "aws_secretsmanager_secret" "sre_client_secret" {
   provider                = aws.core_services
   name                    = "SRE_CLIENT_SECRET"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_sre_client_secret_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "sre_client_secret_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_sre_client_secret_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.sre_client_secret.id
   secret_string = var.sre_client_secret
 }
 
-resource "aws_secretsmanager_secret" "manifest_cache_clear_client_secret_unprefixed" {
+resource "aws_secretsmanager_secret" "cache_clear_client_secret" {
   provider                = aws.core_services
   name                    = "CACHE_CLEAR_CLIENT_SECRET"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_cache_clear_client_secret_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "cache_clear_client_secret_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_cache_clear_client_secret_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.cache_clear_client_secret.id
   secret_string = var.cache_clear_client_secret
 }
 
-resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_sc_pool_id_unprefixed" {
+resource "aws_secretsmanager_secret" "aws_pinpoint_sc_pool_id" {
   provider                = aws.core_services
   name                    = "AWS_PINPOINT_SC_POOL_ID"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_sc_pool_id_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "aws_pinpoint_sc_pool_id_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_aws_pinpoint_sc_pool_id_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.aws_pinpoint_sc_pool_id.id
   secret_string = var.aws_pinpoint_sc_pool_id
 }
 
-resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_sc_template_ids_unprefixed" {
+resource "aws_secretsmanager_secret" "aws_pinpoint_sc_template_ids" {
   provider                = aws.core_services
   name                    = "AWS_PINPOINT_SC_TEMPLATE_IDS"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_sc_template_ids_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "aws_pinpoint_sc_template_ids_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_aws_pinpoint_sc_template_ids_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.aws_pinpoint_sc_template_ids.id
   secret_string = var.aws_pinpoint_sc_template_ids
 }
 
-resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_default_pool_id_unprefixed" {
+resource "aws_secretsmanager_secret" "aws_pinpoint_default_pool_id" {
   provider                = aws.core_services
   name                    = "AWS_PINPOINT_DEFAULT_POOL_ID"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_default_pool_id_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "aws_pinpoint_default_pool_id_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_aws_pinpoint_default_pool_id_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.aws_pinpoint_default_pool_id.id
   secret_string = var.aws_pinpoint_default_pool_id
 }
 
-resource "aws_secretsmanager_secret" "manifest_sqlalchemy_database_uri_unprefixed" {
+resource "aws_secretsmanager_secret" "sqlalchemy_database_uri" {
   provider                = aws.core_services
   name                    = "SQLALCHEMY_DATABASE_URI"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_sqlalchemy_database_uri_unprefixed" {
+resource "aws_secretsmanager_secret_version" "sqlalchemy_database_uri_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_sqlalchemy_database_uri_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.sqlalchemy_database_uri.id
   secret_string = "postgresql://${var.app_db_user}:${var.app_db_user_password}@${var.database_read_write_proxy_endpoint}/${var.app_db_database_name}"
 }
 
-resource "aws_secretsmanager_secret" "manifest_sqlalchemy_database_reader_uri_unprefixed" {
+resource "aws_secretsmanager_secret" "sqlalchemy_database_reader_uri" {
   provider                = aws.core_services
   name                    = "SQLALCHEMY_DATABASE_READER_URI"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_sqlalchemy_database_reader_uri_unprefixed" {
+resource "aws_secretsmanager_secret_version" "sqlalchemy_database_reader_uri_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_sqlalchemy_database_reader_uri_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.sqlalchemy_database_reader_uri.id
   secret_string = "postgresql://${var.app_db_user}:${var.app_db_user_password}@${var.database_read_only_proxy_endpoint}/${var.app_db_database_name}"
 }
 
-resource "aws_secretsmanager_secret" "manifest_postgres_host_unprefixed" {
+resource "aws_secretsmanager_secret" "postgres_host" {
   provider                = aws.core_services
   name                    = "POSTGRES_HOST"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_postgres_host_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "postgres_host_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_postgres_host_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.postgres_host.id
   secret_string = var.postgres_cluster_endpoint
 }
 
-resource "aws_secretsmanager_secret" "manifest_postgres_sql_unprefixed" {
+resource "aws_secretsmanager_secret" "postgres_sql" {
   provider                = aws.core_services
   name                    = "POSTGRES_SQL"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_postgres_sql_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "postgres_sql_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_postgres_sql_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.postgres_sql.id
   secret_string = "postgresql://${var.app_db_user}:${var.app_db_user_password}@${var.database_read_write_proxy_endpoint}/${var.app_db_database_name}"
 }
 
-resource "aws_secretsmanager_secret" "manifest_cache_ops_url_unprefixed" {
+resource "aws_secretsmanager_secret" "cache_ops_url" {
   provider                = aws.core_services
   name                    = "CACHE_OPS_URL"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_cache_ops_url_unprefixed" {
+resource "aws_secretsmanager_secret_version" "cache_ops_url_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_cache_ops_url_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.cache_ops_url.id
   secret_string = "redis://${var.elasticache_queue_cache_primary_endpoint_address}"
 }
 
-resource "aws_secretsmanager_secret" "manifest_redis_publish_url_unprefixed" {
+resource "aws_secretsmanager_secret" "redis_publish_url" {
   provider                = aws.core_services
   name                    = "REDIS_PUBLISH_URL"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_redis_publish_url_unprefixed" {
+resource "aws_secretsmanager_secret_version" "redis_publish_url_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_redis_publish_url_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.redis_publish_url.id
   secret_string = var.env != "production" ? "redis://${var.elasticache_queue_cache_primary_endpoint_address}" : "redis://${var.redis_primary_endpoint_address}"
 }
 
-resource "aws_secretsmanager_secret" "manifest_redis_url_unprefixed" {
+resource "aws_secretsmanager_secret" "redis_url" {
   provider                = aws.core_services
   name                    = "REDIS_URL"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_redis_url_unprefixed" {
+resource "aws_secretsmanager_secret_version" "redis_url_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_redis_url_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.redis_url.id
   secret_string = "redis://${var.redis_primary_endpoint_address}"
 }
 
-resource "aws_secretsmanager_secret" "manifest_cypress_user_pw_secret_unprefixed" {
+resource "aws_secretsmanager_secret" "cypress_user_pw_secret" {
   provider                = aws.core_services
   name                    = "CYPRESS_USER_PW_SECRET"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_cypress_user_pw_secret_unprefixed" {
+resource "aws_secretsmanager_secret_version" "cypress_user_pw_secret_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_cypress_user_pw_secret_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.cypress_user_pw_secret.id
   secret_string = var.cypress_user_pw_secret
 }
 
-resource "aws_secretsmanager_secret" "manifest_cypress_auth_client_secret_unprefixed" {
+resource "aws_secretsmanager_secret" "cypress_auth_client_secret" {
   provider                = aws.core_services
   name                    = "CYPRESS_AUTH_CLIENT_SECRET"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_cypress_auth_client_secret_unprefixed" {
+resource "aws_secretsmanager_secret_version" "cypress_auth_client_secret_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_cypress_auth_client_secret_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.cypress_auth_client_secret.id
   secret_string = var.cypress_auth_client_secret
 }
 
-resource "aws_secretsmanager_secret" "manifest_docker_hub_username_unprefixed" {
+resource "aws_secretsmanager_secret" "docker_hub_username" {
   provider                = aws.core_services
   name                    = "DOCKER_HUB_USERNAME"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_docker_hub_username_unprefixed" {
+resource "aws_secretsmanager_secret_version" "docker_hub_username_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_docker_hub_username_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.docker_hub_username.id
   secret_string = var.docker_hub_username
 }
 
-resource "aws_secretsmanager_secret" "manifest_docker_hub_pat_unprefixed" {
+resource "aws_secretsmanager_secret" "docker_hub_pat" {
   provider                = aws.core_services
   name                    = "DOCKER_HUB_PAT"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_docker_hub_pat_unprefixed" {
+resource "aws_secretsmanager_secret_version" "docker_hub_pat_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_docker_hub_pat_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.docker_hub_pat.id
   secret_string = var.docker_hub_pat
 }
 
-resource "aws_secretsmanager_secret" "manifest_signoz_smtp_username_unprefixed" {
+resource "aws_secretsmanager_secret" "signoz_smtp_username" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
   name                    = "SIGNOZ_SMTP_USERNAME"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_signoz_smtp_username_unprefixed" {
+resource "aws_secretsmanager_secret_version" "signoz_smtp_username_version" {
   provider      = aws.core_services
   count         = var.enable_signoz ? 1 : 0
-  secret_id     = aws_secretsmanager_secret.manifest_signoz_smtp_username_unprefixed[0].id
+  secret_id     = aws_secretsmanager_secret.signoz_smtp_username[0].id
   secret_string = var.signoz_smtp_username
 }
 
-resource "aws_secretsmanager_secret" "manifest_signoz_smtp_password_unprefixed" {
+resource "aws_secretsmanager_secret" "signoz_smtp_password" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
   name                    = "SIGNOZ_SMTP_PASSWORD"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_signoz_smtp_password_unprefixed" {
+resource "aws_secretsmanager_secret_version" "signoz_smtp_password_version" {
   provider      = aws.core_services
   count         = var.enable_signoz ? 1 : 0
-  secret_id     = aws_secretsmanager_secret.manifest_signoz_smtp_password_unprefixed[0].id
+  secret_id     = aws_secretsmanager_secret.signoz_smtp_password[0].id
   secret_string = var.signoz_smtp_password
 }
 
-resource "aws_secretsmanager_secret" "manifest_signoz_dashboard_api_key_unprefixed" {
+resource "aws_secretsmanager_secret" "signoz_dashboard_api_key" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
   name                    = "SIGNOZ_DASHBOARD_API_KEY"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_signoz_dashboard_api_key_unprefixed" {
+resource "aws_secretsmanager_secret_version" "signoz_dashboard_api_key_version" {
   provider      = aws.core_services
   count         = var.enable_signoz ? 1 : 0
-  secret_id     = aws_secretsmanager_secret.manifest_signoz_dashboard_api_key_unprefixed[0].id
+  secret_id     = aws_secretsmanager_secret.signoz_dashboard_api_key[0].id
   secret_string = var.signoz_dashboard_api_key
 }
 
-resource "aws_secretsmanager_secret" "manifest_signoz_postgres_password_unprefixed" {
+resource "aws_secretsmanager_secret" "signoz_postgres_password" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
   name                    = "SIGNOZ_POSTGRES_PASSWORD"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_signoz_postgres_password_unprefixed" {
+resource "aws_secretsmanager_secret_version" "signoz_postgres_password_version" {
   provider      = aws.core_services
   count         = var.enable_signoz ? 1 : 0
-  secret_id     = aws_secretsmanager_secret.manifest_signoz_postgres_password_unprefixed[0].id
+  secret_id     = aws_secretsmanager_secret.signoz_postgres_password[0].id
   secret_string = var.signoz_postgres_password
 }
 
-resource "aws_secretsmanager_secret" "manifest_falco_credentials_unprefixed" {
+resource "aws_secretsmanager_secret" "falco_credentials" {
   provider                = aws.core_services
   name                    = "FALCO_CREDENTIALS"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_falco_credentials_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "falco_credentials_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_falco_credentials_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.falco_credentials.id
   secret_string = var.falco_credentials
 }
 
-resource "aws_secretsmanager_secret" "manifest_falco_slack_webhook_url_unprefixed" {
+resource "aws_secretsmanager_secret" "falco_slack_webhook_url" {
   provider                = aws.core_services
   name                    = "FALCO_SLACK_WEBHOOK_URL"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_falco_slack_webhook_url_version_unprefixed" {
+resource "aws_secretsmanager_secret_version" "falco_slack_webhook_url_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_falco_slack_webhook_url_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.falco_slack_webhook_url.id
   secret_string = var.falco_slack_webhook_url
 }
 
-resource "aws_secretsmanager_secret" "manifest_scan_verdict_callback_token_unprefixed" {
+resource "aws_secretsmanager_secret" "scan_verdict_callback_token" {
   provider                = aws.core_services
   name                    = "SCAN_VERDICT_CALLBACK_TOKEN"
   recovery_window_in_days = 7
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_scan_verdict_callback_token_unprefixed" {
+resource "aws_secretsmanager_secret_version" "scan_verdict_callback_token_version" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_scan_verdict_callback_token_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.scan_verdict_callback_token.id
   secret_string = var.scan_verdict_callback_token
 }

--- a/aws/manifest_secrets/secrets.tf
+++ b/aws/manifest_secrets/secrets.tf
@@ -9,7 +9,7 @@
 resource "aws_secretsmanager_secret" "manifest_admin_client_secret" {
   provider                = aws.core_services
   name                    = "MANIFEST_ADMIN_CLIENT_SECRET"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_admin_client_secret_version" {
@@ -21,7 +21,7 @@ resource "aws_secretsmanager_secret_version" "manifest_admin_client_secret_versi
 resource "aws_secretsmanager_secret" "manifest_auth_tokens" {
   provider                = aws.core_services
   name                    = "MANIFEST_AUTH_TOKENS"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_auth_tokens_version" {
@@ -33,7 +33,7 @@ resource "aws_secretsmanager_secret_version" "manifest_auth_tokens_version" {
 resource "aws_secretsmanager_secret" "manifest_airtable_api_key" {
   provider                = aws.core_services
   name                    = "MANIFEST_AIRTABLE_API_KEY"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_airtable_api_key_version" {
@@ -45,7 +45,7 @@ resource "aws_secretsmanager_secret_version" "manifest_airtable_api_key_version"
 resource "aws_secretsmanager_secret" "manifest_document_download_api_key" {
   provider                = aws.core_services
   name                    = "MANIFEST_DOCUMENT_DOWNLOAD_API_KEY"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_document_download_api_key_version" {
@@ -57,7 +57,7 @@ resource "aws_secretsmanager_secret_version" "manifest_document_download_api_key
 resource "aws_secretsmanager_secret" "manifest_aws_route53_zone" {
   provider                = aws.core_services
   name                    = "MANIFEST_AWS_ROUTE53_ZONE"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_aws_route53_zone_version" {
@@ -69,7 +69,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_route53_zone_version"
 resource "aws_secretsmanager_secret" "manifest_aws_ses_access_key" {
   provider                = aws.core_services
   name                    = "MANIFEST_AWS_SES_ACCESS_KEY"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_aws_ses_access_key_version" {
@@ -81,7 +81,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_ses_access_key_versio
 resource "aws_secretsmanager_secret" "manifest_aws_ses_secret_key" {
   provider                = aws.core_services
   name                    = "MANIFEST_AWS_SES_SECRET_KEY"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_aws_ses_secret_key_version" {
@@ -93,7 +93,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_ses_secret_key_versio
 resource "aws_secretsmanager_secret" "manifest_dangerous_salt" {
   provider                = aws.core_services
   name                    = "MANIFEST_DANGEROUS_SALT"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_dangerous_salt_version" {
@@ -105,7 +105,7 @@ resource "aws_secretsmanager_secret_version" "manifest_dangerous_salt_version" {
 resource "aws_secretsmanager_secret" "manifest_debug_key" {
   provider                = aws.core_services
   name                    = "MANIFEST_DEBUG_KEY"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_debug_key_version" {
@@ -117,7 +117,7 @@ resource "aws_secretsmanager_secret_version" "manifest_debug_key_version" {
 resource "aws_secretsmanager_secret" "manifest_fresh_desk_product_id" {
   provider                = aws.core_services
   name                    = "MANIFEST_FRESH_DESK_PRODUCT_ID"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_fresh_desk_product_id_version" {
@@ -129,7 +129,7 @@ resource "aws_secretsmanager_secret_version" "manifest_fresh_desk_product_id_ver
 resource "aws_secretsmanager_secret" "manifest_fresh_desk_api_key" {
   provider                = aws.core_services
   name                    = "MANIFEST_FRESH_DESK_API_KEY"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_fresh_desk_api_key_version" {
@@ -141,7 +141,7 @@ resource "aws_secretsmanager_secret_version" "manifest_fresh_desk_api_key_versio
 resource "aws_secretsmanager_secret" "manifest_gc_articles_api_auth_username" {
   provider                = aws.core_services
   name                    = "MANIFEST_GC_ARTICLES_API_AUTH_USERNAME"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_gc_articles_api_auth_username_version" {
@@ -153,7 +153,7 @@ resource "aws_secretsmanager_secret_version" "manifest_gc_articles_api_auth_user
 resource "aws_secretsmanager_secret" "manifest_gc_articles_api_auth_password" {
   provider                = aws.core_services
   name                    = "MANIFEST_GC_ARTICLES_API_AUTH_PASSWORD"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_gc_articles_api_auth_password_version" {
@@ -165,7 +165,7 @@ resource "aws_secretsmanager_secret_version" "manifest_gc_articles_api_auth_pass
 resource "aws_secretsmanager_secret" "manifest_gc_articles_waf_rate_bypass_secret" {
   provider                = aws.core_services
   name                    = "MANIFEST_GC_ARTICLES_WAF_RATE_BYPASS_SECRET"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_gc_articles_waf_rate_bypass_secret_version" {
@@ -177,7 +177,7 @@ resource "aws_secretsmanager_secret_version" "manifest_gc_articles_waf_rate_bypa
 resource "aws_secretsmanager_secret" "manifest_mixpanel_project_token" {
   provider                = aws.core_services
   name                    = "MANIFEST_MIXPANEL_PROJECT_TOKEN"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_mixpanel_project_token_version" {
@@ -189,7 +189,7 @@ resource "aws_secretsmanager_secret_version" "manifest_mixpanel_project_token_ve
 resource "aws_secretsmanager_secret" "manifest_crm_github_personal_access_token" {
   provider                = aws.core_services
   name                    = "MANIFEST_CRM_GITHUB_PERSONAL_ACCESS_TOKEN"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_crm_github_personal_access_token_version" {
@@ -201,7 +201,7 @@ resource "aws_secretsmanager_secret_version" "manifest_crm_github_personal_acces
 resource "aws_secretsmanager_secret" "manifest_secret_key" {
   provider                = aws.core_services
   name                    = "MANIFEST_SECRET_KEY"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_secret_key_version" {
@@ -213,7 +213,7 @@ resource "aws_secretsmanager_secret_version" "manifest_secret_key_version" {
 resource "aws_secretsmanager_secret" "manifest_sendgrid_api_key" {
   provider                = aws.core_services
   name                    = "MANIFEST_SENDGRID_API_KEY"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_sendgrid_api_key_version" {
@@ -225,7 +225,7 @@ resource "aws_secretsmanager_secret_version" "manifest_sendgrid_api_key_version"
 resource "aws_secretsmanager_secret" "manifest_waf_secret" {
   provider                = aws.core_services
   name                    = "MANIFEST_WAF_SECRET"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_waf_secret_version" {
@@ -237,7 +237,7 @@ resource "aws_secretsmanager_secret_version" "manifest_waf_secret_version" {
 resource "aws_secretsmanager_secret" "manifest_zendesk_api_key" {
   provider                = aws.core_services
   name                    = "MANIFEST_ZENDESK_API_KEY"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_zendesk_api_key_version" {
@@ -249,7 +249,7 @@ resource "aws_secretsmanager_secret_version" "manifest_zendesk_api_key_version" 
 resource "aws_secretsmanager_secret" "manifest_zendesk_sell_api_key" {
   provider                = aws.core_services
   name                    = "MANIFEST_ZENDESK_SELL_API_KEY"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_zendesk_sell_api_key_version" {
@@ -261,7 +261,7 @@ resource "aws_secretsmanager_secret_version" "manifest_zendesk_sell_api_key_vers
 resource "aws_secretsmanager_secret" "manifest_sre_client_secret" {
   provider                = aws.core_services
   name                    = "MANIFEST_SRE_CLIENT_SECRET"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_sre_client_secret_version" {
@@ -273,7 +273,7 @@ resource "aws_secretsmanager_secret_version" "manifest_sre_client_secret_version
 resource "aws_secretsmanager_secret" "manifest_cache_clear_client_secret" {
   provider                = aws.core_services
   name                    = "MANIFEST_CACHE_CLEAR_CLIENT_SECRET"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_cache_clear_client_secret_version" {
@@ -285,7 +285,7 @@ resource "aws_secretsmanager_secret_version" "manifest_cache_clear_client_secret
 resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_sc_pool_id" {
   provider                = aws.core_services
   name                    = "MANIFEST_AWS_PINPOINT_SC_POOL_ID"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_sc_pool_id_version" {
@@ -297,7 +297,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_sc_pool_id_v
 resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_sc_template_ids" {
   provider                = aws.core_services
   name                    = "MANIFEST_AWS_PINPOINT_SC_TEMPLATE_IDS"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_sc_template_ids_version" {
@@ -309,7 +309,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_sc_template_
 resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_default_pool_id" {
   provider                = aws.core_services
   name                    = "MANIFEST_AWS_PINPOINT_DEFAULT_POOL_ID"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_default_pool_id_version" {
@@ -341,7 +341,7 @@ moved {
 resource "aws_secretsmanager_secret" "manifest_sqlalchemy_database_uri" {
   provider                = aws.core_services
   name                    = "MANIFEST_SQLALCHEMY_DATABASE_URI"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 # THESE BELOW ARE DEPENDENT ON DYNAMICALLY GENERATED AWS INFORMATION
@@ -355,7 +355,7 @@ resource "aws_secretsmanager_secret_version" "manifest_sqlalchemy_database_uri" 
 resource "aws_secretsmanager_secret" "manifest_sqlalchemy_database_reader_uri" {
   provider                = aws.core_services
   name                    = "MANIFEST_SQLALCHEMY_DATABASE_READER_URI"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_sqlalchemy_database_reader_uri" {
@@ -367,7 +367,7 @@ resource "aws_secretsmanager_secret_version" "manifest_sqlalchemy_database_reade
 resource "aws_secretsmanager_secret" "manifest_postgres_host" {
   provider                = aws.core_services
   name                    = "MANIFEST_POSTGRES_HOST"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_postgres_host_version" {
@@ -379,7 +379,7 @@ resource "aws_secretsmanager_secret_version" "manifest_postgres_host_version" {
 resource "aws_secretsmanager_secret" "manifest_postgres_sql" {
   provider                = aws.core_services
   name                    = "MANIFEST_POSTGRES_SQL"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_postgres_sql_version" {
@@ -391,7 +391,7 @@ resource "aws_secretsmanager_secret_version" "manifest_postgres_sql_version" {
 resource "aws_secretsmanager_secret" "manifest_cache_ops_url" {
   provider                = aws.core_services
   name                    = "MANIFEST_CACHE_OPS_URL"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_cache_ops_url" {
@@ -403,7 +403,7 @@ resource "aws_secretsmanager_secret_version" "manifest_cache_ops_url" {
 resource "aws_secretsmanager_secret" "manifest_redis_publish_url" {
   provider                = aws.core_services
   name                    = "MANIFEST_REDIS_PUBLISH_URL"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_redis_publish_url" {
@@ -416,7 +416,7 @@ resource "aws_secretsmanager_secret_version" "manifest_redis_publish_url" {
 resource "aws_secretsmanager_secret" "manifest_redis_url" {
   provider                = aws.core_services
   name                    = "MANIFEST_REDIS_URL"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_redis_url" {
@@ -428,7 +428,7 @@ resource "aws_secretsmanager_secret_version" "manifest_redis_url" {
 resource "aws_secretsmanager_secret" "manifest_cypress_user_pw_secret" {
   provider                = aws.core_services
   name                    = "MANIFEST_CYPRESS_USER_PW_SECRET"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_cypress_user_pw_secret" {
@@ -440,7 +440,7 @@ resource "aws_secretsmanager_secret_version" "manifest_cypress_user_pw_secret" {
 resource "aws_secretsmanager_secret" "manifest_cypress_auth_client_secret" {
   provider                = aws.core_services
   name                    = "MANIFEST_CYPRESS_AUTH_CLIENT_SECRET"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_cypress_auth_client_secret" {
@@ -452,7 +452,7 @@ resource "aws_secretsmanager_secret_version" "manifest_cypress_auth_client_secre
 resource "aws_secretsmanager_secret" "manifest_docker_hub_username" {
   provider                = aws.core_services
   name                    = "MANIFEST_DOCKER_HUB_USERNAME"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_docker_hub_username" {
@@ -464,7 +464,7 @@ resource "aws_secretsmanager_secret_version" "manifest_docker_hub_username" {
 resource "aws_secretsmanager_secret" "manifest_docker_hub_pat" {
   provider                = aws.core_services
   name                    = "MANIFEST_DOCKER_HUB_PAT"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_docker_hub_pat" {
@@ -477,7 +477,7 @@ resource "aws_secretsmanager_secret" "manifest_signoz_smtp_username" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
   name                    = "MANIFEST_SIGNOZ_SMTP_USERNAME"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_signoz_smtp_username" {
@@ -491,7 +491,7 @@ resource "aws_secretsmanager_secret" "manifest_signoz_smtp_password" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
   name                    = "MANIFEST_SIGNOZ_SMTP_PASSWORD"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_signoz_smtp_password" {
@@ -505,7 +505,7 @@ resource "aws_secretsmanager_secret" "manifest_signoz_dashboard_api_key" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
   name                    = "MANIFEST_SIGNOZ_DASHBOARD_API_KEY"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_signoz_dashboard_api_key" {
@@ -519,7 +519,7 @@ resource "aws_secretsmanager_secret" "manifest_signoz_postgres_password" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
   name                    = "MANIFEST_SIGNOZ_POSTGRES_PASSWORD"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_signoz_postgres_password" {
@@ -534,7 +534,7 @@ resource "aws_secretsmanager_secret_version" "manifest_signoz_postgres_password"
 resource "aws_secretsmanager_secret" "manifest_falco_credentials" {
   provider                = aws.core_services
   name                    = "MANIFEST_FALCO_CREDENTIALS"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_falco_credentials_version" {
@@ -546,7 +546,7 @@ resource "aws_secretsmanager_secret_version" "manifest_falco_credentials_version
 resource "aws_secretsmanager_secret" "manifest_falco_slack_webhook_url" {
   provider                = aws.core_services
   name                    = "MANIFEST_FALCO_SLACK_WEBHOOK_URL"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_falco_slack_webhook_url_version" {
@@ -558,7 +558,7 @@ resource "aws_secretsmanager_secret_version" "manifest_falco_slack_webhook_url_v
 resource "aws_secretsmanager_secret" "manifest_scan_verdict_callback_token" {
   provider                = aws.core_services
   name                    = "MANIFEST_SCAN_VERDICT_CALLBACK_TOKEN"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_scan_verdict_callback_token" {

--- a/aws/manifest_secrets/secrets.tf
+++ b/aws/manifest_secrets/secrets.tf
@@ -7,7 +7,7 @@ resource "aws_secretsmanager_secret" "manifest_admin_client_secret" {
 resource "aws_secretsmanager_secret_version" "manifest_admin_client_secret_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_admin_client_secret.id
-  secret_string = var.manifest_admin_client_secret
+  secret_string = var.admin_client_secret
 }
 
 resource "aws_secretsmanager_secret" "manifest_auth_tokens" {
@@ -19,7 +19,7 @@ resource "aws_secretsmanager_secret" "manifest_auth_tokens" {
 resource "aws_secretsmanager_secret_version" "manifest_auth_tokens_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_auth_tokens.id
-  secret_string = var.manifest_auth_tokens
+  secret_string = var.auth_tokens
 }
 
 resource "aws_secretsmanager_secret" "manifest_airtable_api_key" {
@@ -31,7 +31,7 @@ resource "aws_secretsmanager_secret" "manifest_airtable_api_key" {
 resource "aws_secretsmanager_secret_version" "manifest_airtable_api_key_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_airtable_api_key.id
-  secret_string = var.manifest_airtable_api_key
+  secret_string = var.airtable_api_key
 }
 
 resource "aws_secretsmanager_secret" "manifest_document_download_api_key" {
@@ -43,7 +43,7 @@ resource "aws_secretsmanager_secret" "manifest_document_download_api_key" {
 resource "aws_secretsmanager_secret_version" "manifest_document_download_api_key_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_document_download_api_key.id
-  secret_string = var.manifest_document_download_api_key
+  secret_string = var.auth_tokens
 }
 
 resource "aws_secretsmanager_secret" "manifest_aws_route53_zone" {
@@ -55,7 +55,7 @@ resource "aws_secretsmanager_secret" "manifest_aws_route53_zone" {
 resource "aws_secretsmanager_secret_version" "manifest_aws_route53_zone_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_aws_route53_zone.id
-  secret_string = var.manifest_aws_route53_zone
+  secret_string = var.aws_route53_zone
 }
 
 resource "aws_secretsmanager_secret" "manifest_aws_ses_access_key" {
@@ -67,7 +67,7 @@ resource "aws_secretsmanager_secret" "manifest_aws_ses_access_key" {
 resource "aws_secretsmanager_secret_version" "manifest_aws_ses_access_key_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_aws_ses_access_key.id
-  secret_string = var.manifest_aws_ses_access_key
+  secret_string = var.aws_ses_access_key
 }
 
 resource "aws_secretsmanager_secret" "manifest_aws_ses_secret_key" {
@@ -79,7 +79,7 @@ resource "aws_secretsmanager_secret" "manifest_aws_ses_secret_key" {
 resource "aws_secretsmanager_secret_version" "manifest_aws_ses_secret_key_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_aws_ses_secret_key.id
-  secret_string = var.manifest_aws_ses_secret_key
+  secret_string = var.aws_ses_secret_key
 }
 
 resource "aws_secretsmanager_secret" "manifest_dangerous_salt" {
@@ -91,7 +91,7 @@ resource "aws_secretsmanager_secret" "manifest_dangerous_salt" {
 resource "aws_secretsmanager_secret_version" "manifest_dangerous_salt_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_dangerous_salt.id
-  secret_string = var.manifest_dangerous_salt
+  secret_string = var.dangerous_salt
 }
 
 resource "aws_secretsmanager_secret" "manifest_debug_key" {
@@ -103,7 +103,7 @@ resource "aws_secretsmanager_secret" "manifest_debug_key" {
 resource "aws_secretsmanager_secret_version" "manifest_debug_key_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_debug_key.id
-  secret_string = var.manifest_debug_key
+  secret_string = var.debug_key
 }
 
 resource "aws_secretsmanager_secret" "manifest_fresh_desk_product_id" {
@@ -115,7 +115,7 @@ resource "aws_secretsmanager_secret" "manifest_fresh_desk_product_id" {
 resource "aws_secretsmanager_secret_version" "manifest_fresh_desk_product_id_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_fresh_desk_product_id.id
-  secret_string = var.manifest_fresh_desk_product_id
+  secret_string = var.fresh_desk_product_id
 }
 
 resource "aws_secretsmanager_secret" "manifest_fresh_desk_api_key" {
@@ -127,7 +127,7 @@ resource "aws_secretsmanager_secret" "manifest_fresh_desk_api_key" {
 resource "aws_secretsmanager_secret_version" "manifest_fresh_desk_api_key_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_fresh_desk_api_key.id
-  secret_string = var.manifest_fresh_desk_api_key
+  secret_string = var.fresh_desk_api_key
 }
 
 resource "aws_secretsmanager_secret" "manifest_gc_articles_api_auth_username" {
@@ -139,7 +139,7 @@ resource "aws_secretsmanager_secret" "manifest_gc_articles_api_auth_username" {
 resource "aws_secretsmanager_secret_version" "manifest_gc_articles_api_auth_username_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_gc_articles_api_auth_username.id
-  secret_string = var.manifest_gc_articles_api_auth_username
+  secret_string = var.gc_articles_api_auth_username
 }
 
 resource "aws_secretsmanager_secret" "manifest_gc_articles_api_auth_password" {
@@ -151,7 +151,7 @@ resource "aws_secretsmanager_secret" "manifest_gc_articles_api_auth_password" {
 resource "aws_secretsmanager_secret_version" "manifest_gc_articles_api_auth_password_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_gc_articles_api_auth_password.id
-  secret_string = var.manifest_gc_articles_api_auth_password
+  secret_string = var.gc_articles_api_auth_password
 }
 
 resource "aws_secretsmanager_secret" "manifest_gc_articles_waf_rate_bypass_secret" {
@@ -163,7 +163,7 @@ resource "aws_secretsmanager_secret" "manifest_gc_articles_waf_rate_bypass_secre
 resource "aws_secretsmanager_secret_version" "manifest_gc_articles_waf_rate_bypass_secret_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_gc_articles_waf_rate_bypass_secret.id
-  secret_string = var.manifest_gc_articles_waf_rate_bypass_secret
+  secret_string = var.gc_articles_waf_rate_bypass_secret
 }
 
 resource "aws_secretsmanager_secret" "manifest_mixpanel_project_token" {
@@ -175,7 +175,7 @@ resource "aws_secretsmanager_secret" "manifest_mixpanel_project_token" {
 resource "aws_secretsmanager_secret_version" "manifest_mixpanel_project_token_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_mixpanel_project_token.id
-  secret_string = var.manifest_mixpanel_project_token
+  secret_string = var.mixpanel_project_token
 }
 
 resource "aws_secretsmanager_secret" "manifest_crm_github_personal_access_token" {
@@ -187,7 +187,7 @@ resource "aws_secretsmanager_secret" "manifest_crm_github_personal_access_token"
 resource "aws_secretsmanager_secret_version" "manifest_crm_github_personal_access_token_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_crm_github_personal_access_token.id
-  secret_string = var.manifest_crm_github_personal_access_token
+  secret_string = var.crm_github_personal_access_token
 }
 
 resource "aws_secretsmanager_secret" "manifest_secret_key" {
@@ -199,7 +199,7 @@ resource "aws_secretsmanager_secret" "manifest_secret_key" {
 resource "aws_secretsmanager_secret_version" "manifest_secret_key_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_secret_key.id
-  secret_string = var.manifest_secret_key
+  secret_string = var.secret_key
 }
 
 resource "aws_secretsmanager_secret" "manifest_sendgrid_api_key" {
@@ -211,7 +211,7 @@ resource "aws_secretsmanager_secret" "manifest_sendgrid_api_key" {
 resource "aws_secretsmanager_secret_version" "manifest_sendgrid_api_key_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_sendgrid_api_key.id
-  secret_string = var.manifest_sendgrid_api_key
+  secret_string = var.sendgrid_api_key
 }
 
 resource "aws_secretsmanager_secret" "manifest_waf_secret" {
@@ -223,7 +223,7 @@ resource "aws_secretsmanager_secret" "manifest_waf_secret" {
 resource "aws_secretsmanager_secret_version" "manifest_waf_secret_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_waf_secret.id
-  secret_string = var.manifest_waf_secret
+  secret_string = var.waf_secret
 }
 
 resource "aws_secretsmanager_secret" "manifest_zendesk_api_key" {
@@ -235,7 +235,7 @@ resource "aws_secretsmanager_secret" "manifest_zendesk_api_key" {
 resource "aws_secretsmanager_secret_version" "manifest_zendesk_api_key_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_zendesk_api_key.id
-  secret_string = var.manifest_zendesk_api_key
+  secret_string = var.zendesk_api_key
 }
 
 resource "aws_secretsmanager_secret" "manifest_zendesk_sell_api_key" {
@@ -247,7 +247,7 @@ resource "aws_secretsmanager_secret" "manifest_zendesk_sell_api_key" {
 resource "aws_secretsmanager_secret_version" "manifest_zendesk_sell_api_key_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_zendesk_sell_api_key.id
-  secret_string = var.manifest_zendesk_sell_api_key
+  secret_string = var.zendesk_sell_api_key
 }
 
 resource "aws_secretsmanager_secret" "manifest_sre_client_secret" {
@@ -259,7 +259,7 @@ resource "aws_secretsmanager_secret" "manifest_sre_client_secret" {
 resource "aws_secretsmanager_secret_version" "manifest_sre_client_secret_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_sre_client_secret.id
-  secret_string = var.manifest_sre_client_secret
+  secret_string = var.sre_client_secret
 }
 
 resource "aws_secretsmanager_secret" "manifest_cache_clear_client_secret" {
@@ -271,7 +271,7 @@ resource "aws_secretsmanager_secret" "manifest_cache_clear_client_secret" {
 resource "aws_secretsmanager_secret_version" "manifest_cache_clear_client_secret_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_cache_clear_client_secret.id
-  secret_string = var.manifest_cache_clear_client_secret
+  secret_string = var.cache_clear_client_secret
 }
 
 resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_sc_pool_id" {
@@ -283,7 +283,7 @@ resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_sc_pool_id" {
 resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_sc_pool_id_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_aws_pinpoint_sc_pool_id.id
-  secret_string = var.manifest_aws_pinpoint_sc_pool_id
+  secret_string = var.aws_pinpoint_sc_pool_id
 }
 
 resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_sc_template_ids" {
@@ -295,7 +295,7 @@ resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_sc_template_ids" {
 resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_sc_template_ids_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_aws_pinpoint_sc_template_ids.id
-  secret_string = var.manifest_aws_pinpoint_sc_template_ids
+  secret_string = var.aws_pinpoint_sc_template_ids
 }
 
 resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_default_pool_id" {
@@ -307,7 +307,7 @@ resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_default_pool_id" {
 resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_default_pool_id_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_aws_pinpoint_default_pool_id.id
-  secret_string = var.manifest_aws_pinpoint_default_pool_id
+  secret_string = var.aws_pinpoint_default_pool_id
 }
 
 resource "aws_secretsmanager_secret" "manifest_sqlalachemy_database_uri" {
@@ -406,7 +406,7 @@ resource "aws_secretsmanager_secret" "manifest_cypress_user_pw_secret" {
 resource "aws_secretsmanager_secret_version" "manifest_cypress_user_pw_secret" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_cypress_user_pw_secret.id
-  secret_string = var.manifest_cypress_user_pw_secret
+  secret_string = var.cypress_user_pw_secret
 }
 
 resource "aws_secretsmanager_secret" "manifest_cypress_auth_client_secret" {
@@ -418,7 +418,7 @@ resource "aws_secretsmanager_secret" "manifest_cypress_auth_client_secret" {
 resource "aws_secretsmanager_secret_version" "manifest_cypress_auth_client_secret" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_cypress_auth_client_secret.id
-  secret_string = var.manifest_cypress_auth_client_secret
+  secret_string = var.cypress_auth_client_secret
 }
 
 resource "aws_secretsmanager_secret" "manifest_docker_hub_username" {
@@ -430,7 +430,7 @@ resource "aws_secretsmanager_secret" "manifest_docker_hub_username" {
 resource "aws_secretsmanager_secret_version" "manifest_docker_hub_username" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_docker_hub_username.id
-  secret_string = var.manifest_docker_hub_username
+  secret_string = var.docker_hub_username
 }
 
 resource "aws_secretsmanager_secret" "manifest_docker_hub_pat" {
@@ -442,7 +442,7 @@ resource "aws_secretsmanager_secret" "manifest_docker_hub_pat" {
 resource "aws_secretsmanager_secret_version" "manifest_docker_hub_pat" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_docker_hub_pat.id
-  secret_string = var.manifest_docker_hub_pat
+  secret_string = var.docker_hub_pat
 }
 
 resource "aws_secretsmanager_secret" "manifest_signoz_smtp_username" {
@@ -484,7 +484,7 @@ resource "aws_secretsmanager_secret_version" "manifest_signoz_dashboard_api_key"
   provider      = aws.core_services
   count         = var.enable_signoz ? 1 : 0
   secret_id     = aws_secretsmanager_secret.manifest_signoz_dashboard_api_key[0].id
-  secret_string = var.manifest_signoz_dashboard_api_key
+  secret_string = var.signoz_dashboard_api_key
 }
 
 resource "aws_secretsmanager_secret" "manifest_signoz_postgres_password" {
@@ -498,7 +498,7 @@ resource "aws_secretsmanager_secret_version" "manifest_signoz_postgres_password"
   provider      = aws.core_services
   count         = var.enable_signoz ? 1 : 0
   secret_id     = aws_secretsmanager_secret.manifest_signoz_postgres_password[0].id
-  secret_string = var.manifest_signoz_postgres_password
+  secret_string = var.signoz_postgres_password
 }
 
 ### Falco
@@ -512,7 +512,7 @@ resource "aws_secretsmanager_secret" "manifest_falco_credentials" {
 resource "aws_secretsmanager_secret_version" "manifest_falco_credentials_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_falco_credentials.id
-  secret_string = var.manifest_falco_credentials
+  secret_string = var.falco_credentials
 }
 
 resource "aws_secretsmanager_secret" "manifest_falco_slack_webhook_url" {
@@ -524,7 +524,7 @@ resource "aws_secretsmanager_secret" "manifest_falco_slack_webhook_url" {
 resource "aws_secretsmanager_secret_version" "manifest_falco_slack_webhook_url_version" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_falco_slack_webhook_url.id
-  secret_string = var.manifest_falco_slack_webhook_url
+  secret_string = var.falco_slack_webhook_url
 }
 
 resource "aws_secretsmanager_secret" "manifest_scan_verdict_callback_token" {
@@ -536,5 +536,5 @@ resource "aws_secretsmanager_secret" "manifest_scan_verdict_callback_token" {
 resource "aws_secretsmanager_secret_version" "manifest_scan_verdict_callback_token" {
   provider      = aws.core_services
   secret_id     = aws_secretsmanager_secret.manifest_scan_verdict_callback_token.id
-  secret_string = var.manifest_scan_verdict_callback_token
+  secret_string = var.scan_verdict_callback_token
 }

--- a/aws/manifest_secrets/secrets.tf
+++ b/aws/manifest_secrets/secrets.tf
@@ -318,7 +318,27 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_default_pool
   secret_string = var.aws_pinpoint_default_pool_id
 }
 
-resource "aws_secretsmanager_secret" "manifest_sqlalachemy_database_uri" {
+moved {
+  from = aws_secretsmanager_secret.manifest_sqlalachemy_database_uri
+  to   = aws_secretsmanager_secret.manifest_sqlalchemy_database_uri
+}
+
+moved {
+  from = aws_secretsmanager_secret_version.manifest_sqlalachemy_database_uri
+  to   = aws_secretsmanager_secret_version.manifest_sqlalchemy_database_uri
+}
+
+moved {
+  from = aws_secretsmanager_secret.manifest_sqlalachemy_database_reader_uri
+  to   = aws_secretsmanager_secret.manifest_sqlalchemy_database_reader_uri
+}
+
+moved {
+  from = aws_secretsmanager_secret_version.manifest_sqlalachemy_database_reader_uri
+  to   = aws_secretsmanager_secret_version.manifest_sqlalchemy_database_reader_uri
+}
+
+resource "aws_secretsmanager_secret" "manifest_sqlalchemy_database_uri" {
   provider                = aws.core_services
   name                    = "MANIFEST_SQLALCHEMY_DATABASE_URI"
   recovery_window_in_days = 0
@@ -326,21 +346,21 @@ resource "aws_secretsmanager_secret" "manifest_sqlalachemy_database_uri" {
 
 # THESE BELOW ARE DEPENDENT ON DYNAMICALLY GENERATED AWS INFORMATION
 
-resource "aws_secretsmanager_secret_version" "manifest_sqlalachemy_database_uri" {
+resource "aws_secretsmanager_secret_version" "manifest_sqlalchemy_database_uri" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_sqlalachemy_database_uri.id
+  secret_id     = aws_secretsmanager_secret.manifest_sqlalchemy_database_uri.id
   secret_string = "postgresql://${var.app_db_user}:${var.app_db_user_password}@${var.database_read_write_proxy_endpoint}/${var.app_db_database_name}"
 }
 
-resource "aws_secretsmanager_secret" "manifest_sqlalachemy_database_reader_uri" {
+resource "aws_secretsmanager_secret" "manifest_sqlalchemy_database_reader_uri" {
   provider                = aws.core_services
   name                    = "MANIFEST_SQLALCHEMY_DATABASE_READER_URI"
   recovery_window_in_days = 0
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_sqlalachemy_database_reader_uri" {
+resource "aws_secretsmanager_secret_version" "manifest_sqlalchemy_database_reader_uri" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_sqlalachemy_database_reader_uri.id
+  secret_id     = aws_secretsmanager_secret.manifest_sqlalchemy_database_reader_uri.id
   secret_string = "postgresql://${var.app_db_user}:${var.app_db_user_password}@${var.database_read_only_proxy_endpoint}/${var.app_db_database_name}"
 }
 
@@ -866,27 +886,27 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_default_pool
   secret_string = var.aws_pinpoint_default_pool_id
 }
 
-resource "aws_secretsmanager_secret" "manifest_sqlalachemy_database_uri_unprefixed" {
+resource "aws_secretsmanager_secret" "manifest_sqlalchemy_database_uri_unprefixed" {
   provider                = aws.core_services
   name                    = "SQLALCHEMY_DATABASE_URI"
   recovery_window_in_days = 0
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_sqlalachemy_database_uri_unprefixed" {
+resource "aws_secretsmanager_secret_version" "manifest_sqlalchemy_database_uri_unprefixed" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_sqlalachemy_database_uri_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.manifest_sqlalchemy_database_uri_unprefixed.id
   secret_string = "postgresql://${var.app_db_user}:${var.app_db_user_password}@${var.database_read_write_proxy_endpoint}/${var.app_db_database_name}"
 }
 
-resource "aws_secretsmanager_secret" "manifest_sqlalachemy_database_reader_uri_unprefixed" {
+resource "aws_secretsmanager_secret" "manifest_sqlalchemy_database_reader_uri_unprefixed" {
   provider                = aws.core_services
   name                    = "SQLALCHEMY_DATABASE_READER_URI"
   recovery_window_in_days = 0
 }
 
-resource "aws_secretsmanager_secret_version" "manifest_sqlalachemy_database_reader_uri_unprefixed" {
+resource "aws_secretsmanager_secret_version" "manifest_sqlalchemy_database_reader_uri_unprefixed" {
   provider      = aws.core_services
-  secret_id     = aws_secretsmanager_secret.manifest_sqlalachemy_database_reader_uri_unprefixed.id
+  secret_id     = aws_secretsmanager_secret.manifest_sqlalchemy_database_reader_uri_unprefixed.id
   secret_string = "postgresql://${var.app_db_user}:${var.app_db_user_password}@${var.database_read_only_proxy_endpoint}/${var.app_db_database_name}"
 }
 

--- a/aws/manifest_secrets/secrets.tf
+++ b/aws/manifest_secrets/secrets.tf
@@ -572,6 +572,10 @@ resource "aws_secretsmanager_secret_version" "manifest_scan_verdict_callback_tok
 # is additive-only (nothing above is destroyed by this change). Once the
 # Helm/ExternalSecret rollout is verified against these names, delete the
 # LEGACY MANIFEST_-prefixed block above. Tracking: PR #2787.
+#
+# TODO: recovery_window_in_days is temporarily 7 on these (matching the
+# legacy block) purely as a migration safety net. Once the legacy block
+# above is deleted, set these back to 0 to match the original convention.
 # ---------------------------------------------------------------------------
 resource "aws_secretsmanager_secret" "admin_client_secret" {
   provider                = aws.core_services

--- a/aws/manifest_secrets/secrets.tf
+++ b/aws/manifest_secrets/secrets.tf
@@ -1,6 +1,6 @@
 resource "aws_secretsmanager_secret" "manifest_admin_client_secret" {
   provider                = aws.core_services
-  name                    = "MANIFEST_ADMIN_CLIENT_SECRET"
+  name                    = "ADMIN_CLIENT_SECRET"
   recovery_window_in_days = 0
 }
 
@@ -12,7 +12,7 @@ resource "aws_secretsmanager_secret_version" "manifest_admin_client_secret_versi
 
 resource "aws_secretsmanager_secret" "manifest_auth_tokens" {
   provider                = aws.core_services
-  name                    = "MANIFEST_AUTH_TOKENS"
+  name                    = "AUTH_TOKENS"
   recovery_window_in_days = 0
 }
 
@@ -24,7 +24,7 @@ resource "aws_secretsmanager_secret_version" "manifest_auth_tokens_version" {
 
 resource "aws_secretsmanager_secret" "manifest_airtable_api_key" {
   provider                = aws.core_services
-  name                    = "MANIFEST_AIRTABLE_API_KEY"
+  name                    = "AIRTABLE_API_KEY"
   recovery_window_in_days = 0
 }
 
@@ -36,7 +36,7 @@ resource "aws_secretsmanager_secret_version" "manifest_airtable_api_key_version"
 
 resource "aws_secretsmanager_secret" "manifest_document_download_api_key" {
   provider                = aws.core_services
-  name                    = "MANIFEST_DOCUMENT_DOWNLOAD_API_KEY"
+  name                    = "DOCUMENT_DOWNLOAD_API_KEY"
   recovery_window_in_days = 0
 }
 
@@ -48,7 +48,7 @@ resource "aws_secretsmanager_secret_version" "manifest_document_download_api_key
 
 resource "aws_secretsmanager_secret" "manifest_aws_route53_zone" {
   provider                = aws.core_services
-  name                    = "MANIFEST_AWS_ROUTE53_ZONE"
+  name                    = "AWS_ROUTE53_ZONE"
   recovery_window_in_days = 0
 }
 
@@ -60,7 +60,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_route53_zone_version"
 
 resource "aws_secretsmanager_secret" "manifest_aws_ses_access_key" {
   provider                = aws.core_services
-  name                    = "MANIFEST_AWS_SES_ACCESS_KEY"
+  name                    = "AWS_SES_ACCESS_KEY"
   recovery_window_in_days = 0
 }
 
@@ -72,7 +72,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_ses_access_key_versio
 
 resource "aws_secretsmanager_secret" "manifest_aws_ses_secret_key" {
   provider                = aws.core_services
-  name                    = "MANIFEST_AWS_SES_SECRET_KEY"
+  name                    = "AWS_SES_SECRET_KEY"
   recovery_window_in_days = 0
 }
 
@@ -84,7 +84,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_ses_secret_key_versio
 
 resource "aws_secretsmanager_secret" "manifest_dangerous_salt" {
   provider                = aws.core_services
-  name                    = "MANIFEST_DANGEROUS_SALT"
+  name                    = "DANGEROUS_SALT"
   recovery_window_in_days = 0
 }
 
@@ -96,7 +96,7 @@ resource "aws_secretsmanager_secret_version" "manifest_dangerous_salt_version" {
 
 resource "aws_secretsmanager_secret" "manifest_debug_key" {
   provider                = aws.core_services
-  name                    = "MANIFEST_DEBUG_KEY"
+  name                    = "DEBUG_KEY"
   recovery_window_in_days = 0
 }
 
@@ -108,7 +108,7 @@ resource "aws_secretsmanager_secret_version" "manifest_debug_key_version" {
 
 resource "aws_secretsmanager_secret" "manifest_fresh_desk_product_id" {
   provider                = aws.core_services
-  name                    = "MANIFEST_FRESH_DESK_PRODUCT_ID"
+  name                    = "FRESH_DESK_PRODUCT_ID"
   recovery_window_in_days = 0
 }
 
@@ -120,7 +120,7 @@ resource "aws_secretsmanager_secret_version" "manifest_fresh_desk_product_id_ver
 
 resource "aws_secretsmanager_secret" "manifest_fresh_desk_api_key" {
   provider                = aws.core_services
-  name                    = "MANIFEST_FRESH_DESK_API_KEY"
+  name                    = "FRESH_DESK_API_KEY"
   recovery_window_in_days = 0
 }
 
@@ -132,7 +132,7 @@ resource "aws_secretsmanager_secret_version" "manifest_fresh_desk_api_key_versio
 
 resource "aws_secretsmanager_secret" "manifest_gc_articles_api_auth_username" {
   provider                = aws.core_services
-  name                    = "MANIFEST_GC_ARTICLES_API_AUTH_USERNAME"
+  name                    = "GC_ARTICLES_API_AUTH_USERNAME"
   recovery_window_in_days = 0
 }
 
@@ -144,7 +144,7 @@ resource "aws_secretsmanager_secret_version" "manifest_gc_articles_api_auth_user
 
 resource "aws_secretsmanager_secret" "manifest_gc_articles_api_auth_password" {
   provider                = aws.core_services
-  name                    = "MANIFEST_GC_ARTICLES_API_AUTH_PASSWORD"
+  name                    = "GC_ARTICLES_API_AUTH_PASSWORD"
   recovery_window_in_days = 0
 }
 
@@ -156,7 +156,7 @@ resource "aws_secretsmanager_secret_version" "manifest_gc_articles_api_auth_pass
 
 resource "aws_secretsmanager_secret" "manifest_gc_articles_waf_rate_bypass_secret" {
   provider                = aws.core_services
-  name                    = "MANIFEST_GC_ARTICLES_WAF_RATE_BYPASS_SECRET"
+  name                    = "GC_ARTICLES_WAF_RATE_BYPASS_SECRET"
   recovery_window_in_days = 0
 }
 
@@ -168,7 +168,7 @@ resource "aws_secretsmanager_secret_version" "manifest_gc_articles_waf_rate_bypa
 
 resource "aws_secretsmanager_secret" "manifest_mixpanel_project_token" {
   provider                = aws.core_services
-  name                    = "MANIFEST_MIXPANEL_PROJECT_TOKEN"
+  name                    = "MIXPANEL_PROJECT_TOKEN"
   recovery_window_in_days = 0
 }
 
@@ -180,7 +180,7 @@ resource "aws_secretsmanager_secret_version" "manifest_mixpanel_project_token_ve
 
 resource "aws_secretsmanager_secret" "manifest_crm_github_personal_access_token" {
   provider                = aws.core_services
-  name                    = "MANIFEST_CRM_GITHUB_PERSONAL_ACCESS_TOKEN"
+  name                    = "CRM_GITHUB_PERSONAL_ACCESS_TOKEN"
   recovery_window_in_days = 0
 }
 
@@ -192,7 +192,7 @@ resource "aws_secretsmanager_secret_version" "manifest_crm_github_personal_acces
 
 resource "aws_secretsmanager_secret" "manifest_secret_key" {
   provider                = aws.core_services
-  name                    = "MANIFEST_SECRET_KEY"
+  name                    = "SECRET_KEY"
   recovery_window_in_days = 0
 }
 
@@ -204,7 +204,7 @@ resource "aws_secretsmanager_secret_version" "manifest_secret_key_version" {
 
 resource "aws_secretsmanager_secret" "manifest_sendgrid_api_key" {
   provider                = aws.core_services
-  name                    = "MANIFEST_SENDGRID_API_KEY"
+  name                    = "SENDGRID_API_KEY"
   recovery_window_in_days = 0
 }
 
@@ -216,7 +216,7 @@ resource "aws_secretsmanager_secret_version" "manifest_sendgrid_api_key_version"
 
 resource "aws_secretsmanager_secret" "manifest_waf_secret" {
   provider                = aws.core_services
-  name                    = "MANIFEST_WAF_SECRET"
+  name                    = "WAF_SECRET"
   recovery_window_in_days = 0
 }
 
@@ -228,7 +228,7 @@ resource "aws_secretsmanager_secret_version" "manifest_waf_secret_version" {
 
 resource "aws_secretsmanager_secret" "manifest_zendesk_api_key" {
   provider                = aws.core_services
-  name                    = "MANIFEST_ZENDESK_API_KEY"
+  name                    = "ZENDESK_API_KEY"
   recovery_window_in_days = 0
 }
 
@@ -240,7 +240,7 @@ resource "aws_secretsmanager_secret_version" "manifest_zendesk_api_key_version" 
 
 resource "aws_secretsmanager_secret" "manifest_zendesk_sell_api_key" {
   provider                = aws.core_services
-  name                    = "MANIFEST_ZENDESK_SELL_API_KEY"
+  name                    = "ZENDESK_SELL_API_KEY"
   recovery_window_in_days = 0
 }
 
@@ -252,7 +252,7 @@ resource "aws_secretsmanager_secret_version" "manifest_zendesk_sell_api_key_vers
 
 resource "aws_secretsmanager_secret" "manifest_sre_client_secret" {
   provider                = aws.core_services
-  name                    = "MANIFEST_SRE_CLIENT_SECRET"
+  name                    = "SRE_CLIENT_SECRET"
   recovery_window_in_days = 0
 }
 
@@ -264,7 +264,7 @@ resource "aws_secretsmanager_secret_version" "manifest_sre_client_secret_version
 
 resource "aws_secretsmanager_secret" "manifest_cache_clear_client_secret" {
   provider                = aws.core_services
-  name                    = "MANIFEST_CACHE_CLEAR_CLIENT_SECRET"
+  name                    = "CACHE_CLEAR_CLIENT_SECRET"
   recovery_window_in_days = 0
 }
 
@@ -276,7 +276,7 @@ resource "aws_secretsmanager_secret_version" "manifest_cache_clear_client_secret
 
 resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_sc_pool_id" {
   provider                = aws.core_services
-  name                    = "MANIFEST_AWS_PINPOINT_SC_POOL_ID"
+  name                    = "AWS_PINPOINT_SC_POOL_ID"
   recovery_window_in_days = 0
 }
 
@@ -288,7 +288,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_sc_pool_id_v
 
 resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_sc_template_ids" {
   provider                = aws.core_services
-  name                    = "MANIFEST_AWS_PINPOINT_SC_TEMPLATE_IDS"
+  name                    = "AWS_PINPOINT_SC_TEMPLATE_IDS"
   recovery_window_in_days = 0
 }
 
@@ -300,7 +300,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_sc_template_
 
 resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_default_pool_id" {
   provider                = aws.core_services
-  name                    = "MANIFEST_AWS_PINPOINT_DEFAULT_POOL_ID"
+  name                    = "AWS_PINPOINT_DEFAULT_POOL_ID"
   recovery_window_in_days = 0
 }
 
@@ -312,7 +312,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_default_pool
 
 resource "aws_secretsmanager_secret" "manifest_sqlalachemy_database_uri" {
   provider                = aws.core_services
-  name                    = "MANIFEST_SQLALCHEMY_DATABASE_URI"
+  name                    = "SQLALCHEMY_DATABASE_URI"
   recovery_window_in_days = 0
 }
 
@@ -326,7 +326,7 @@ resource "aws_secretsmanager_secret_version" "manifest_sqlalachemy_database_uri"
 
 resource "aws_secretsmanager_secret" "manifest_sqlalachemy_database_reader_uri" {
   provider                = aws.core_services
-  name                    = "MANIFEST_SQLALCHEMY_DATABASE_READER_URI"
+  name                    = "SQLALCHEMY_DATABASE_READER_URI"
   recovery_window_in_days = 0
 }
 
@@ -338,7 +338,7 @@ resource "aws_secretsmanager_secret_version" "manifest_sqlalachemy_database_read
 
 resource "aws_secretsmanager_secret" "manifest_postgres_host" {
   provider                = aws.core_services
-  name                    = "MANIFEST_POSTGRES_HOST"
+  name                    = "POSTGRES_HOST"
   recovery_window_in_days = 0
 }
 
@@ -350,7 +350,7 @@ resource "aws_secretsmanager_secret_version" "manifest_postgres_host_version" {
 
 resource "aws_secretsmanager_secret" "manifest_postgres_sql" {
   provider                = aws.core_services
-  name                    = "MANIFEST_POSTGRES_SQL"
+  name                    = "POSTGRES_SQL"
   recovery_window_in_days = 0
 }
 
@@ -362,7 +362,7 @@ resource "aws_secretsmanager_secret_version" "manifest_postgres_sql_version" {
 
 resource "aws_secretsmanager_secret" "manifest_cache_ops_url" {
   provider                = aws.core_services
-  name                    = "MANIFEST_CACHE_OPS_URL"
+  name                    = "CACHE_OPS_URL"
   recovery_window_in_days = 0
 }
 
@@ -374,7 +374,7 @@ resource "aws_secretsmanager_secret_version" "manifest_cache_ops_url" {
 
 resource "aws_secretsmanager_secret" "manifest_redis_publish_url" {
   provider                = aws.core_services
-  name                    = "MANIFEST_REDIS_PUBLISH_URL"
+  name                    = "REDIS_PUBLISH_URL"
   recovery_window_in_days = 0
 }
 
@@ -387,7 +387,7 @@ resource "aws_secretsmanager_secret_version" "manifest_redis_publish_url" {
 
 resource "aws_secretsmanager_secret" "manifest_redis_url" {
   provider                = aws.core_services
-  name                    = "MANIFEST_REDIS_URL"
+  name                    = "REDIS_URL"
   recovery_window_in_days = 0
 }
 
@@ -399,7 +399,7 @@ resource "aws_secretsmanager_secret_version" "manifest_redis_url" {
 
 resource "aws_secretsmanager_secret" "manifest_cypress_user_pw_secret" {
   provider                = aws.core_services
-  name                    = "MANIFEST_CYPRESS_USER_PW_SECRET"
+  name                    = "CYPRESS_USER_PW_SECRET"
   recovery_window_in_days = 0
 }
 
@@ -411,7 +411,7 @@ resource "aws_secretsmanager_secret_version" "manifest_cypress_user_pw_secret" {
 
 resource "aws_secretsmanager_secret" "manifest_cypress_auth_client_secret" {
   provider                = aws.core_services
-  name                    = "MANIFEST_CYPRESS_AUTH_CLIENT_SECRET"
+  name                    = "CYPRESS_AUTH_CLIENT_SECRET"
   recovery_window_in_days = 0
 }
 
@@ -423,7 +423,7 @@ resource "aws_secretsmanager_secret_version" "manifest_cypress_auth_client_secre
 
 resource "aws_secretsmanager_secret" "manifest_docker_hub_username" {
   provider                = aws.core_services
-  name                    = "MANIFEST_DOCKER_HUB_USERNAME"
+  name                    = "DOCKER_HUB_USERNAME"
   recovery_window_in_days = 0
 }
 
@@ -435,7 +435,7 @@ resource "aws_secretsmanager_secret_version" "manifest_docker_hub_username" {
 
 resource "aws_secretsmanager_secret" "manifest_docker_hub_pat" {
   provider                = aws.core_services
-  name                    = "MANIFEST_DOCKER_HUB_PAT"
+  name                    = "DOCKER_HUB_PAT"
   recovery_window_in_days = 0
 }
 
@@ -448,7 +448,7 @@ resource "aws_secretsmanager_secret_version" "manifest_docker_hub_pat" {
 resource "aws_secretsmanager_secret" "manifest_signoz_smtp_username" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
-  name                    = "MANIFEST_SIGNOZ_SMTP_USERNAME"
+  name                    = "SIGNOZ_SMTP_USERNAME"
   recovery_window_in_days = 0
 }
 
@@ -462,7 +462,7 @@ resource "aws_secretsmanager_secret_version" "manifest_signoz_smtp_username" {
 resource "aws_secretsmanager_secret" "manifest_signoz_smtp_password" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
-  name                    = "MANIFEST_SIGNOZ_SMTP_PASSWORD"
+  name                    = "SIGNOZ_SMTP_PASSWORD"
   recovery_window_in_days = 0
 }
 
@@ -476,7 +476,7 @@ resource "aws_secretsmanager_secret_version" "manifest_signoz_smtp_password" {
 resource "aws_secretsmanager_secret" "manifest_signoz_dashboard_api_key" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
-  name                    = "MANIFEST_SIGNOZ_DASHBOARD_API_KEY"
+  name                    = "SIGNOZ_DASHBOARD_API_KEY"
   recovery_window_in_days = 0
 }
 
@@ -490,7 +490,7 @@ resource "aws_secretsmanager_secret_version" "manifest_signoz_dashboard_api_key"
 resource "aws_secretsmanager_secret" "manifest_signoz_postgres_password" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
-  name                    = "MANIFEST_SIGNOZ_POSTGRES_PASSWORD"
+  name                    = "SIGNOZ_POSTGRES_PASSWORD"
   recovery_window_in_days = 0
 }
 
@@ -505,7 +505,7 @@ resource "aws_secretsmanager_secret_version" "manifest_signoz_postgres_password"
 
 resource "aws_secretsmanager_secret" "manifest_falco_credentials" {
   provider                = aws.core_services
-  name                    = "MANIFEST_FALCO_CREDENTIALS"
+  name                    = "FALCO_CREDENTIALS"
   recovery_window_in_days = 0
 }
 
@@ -517,7 +517,7 @@ resource "aws_secretsmanager_secret_version" "manifest_falco_credentials_version
 
 resource "aws_secretsmanager_secret" "manifest_falco_slack_webhook_url" {
   provider                = aws.core_services
-  name                    = "MANIFEST_FALCO_SLACK_WEBHOOK_URL"
+  name                    = "FALCO_SLACK_WEBHOOK_URL"
   recovery_window_in_days = 0
 }
 
@@ -529,7 +529,7 @@ resource "aws_secretsmanager_secret_version" "manifest_falco_slack_webhook_url_v
 
 resource "aws_secretsmanager_secret" "manifest_scan_verdict_callback_token" {
   provider                = aws.core_services
-  name                    = "MANIFEST_SCAN_VERDICT_CALLBACK_TOKEN"
+  name                    = "SCAN_VERDICT_CALLBACK_TOKEN"
   recovery_window_in_days = 0
 }
 

--- a/aws/manifest_secrets/secrets.tf
+++ b/aws/manifest_secrets/secrets.tf
@@ -577,7 +577,7 @@ resource "aws_secretsmanager_secret_version" "manifest_scan_verdict_callback_tok
 resource "aws_secretsmanager_secret" "manifest_admin_client_secret_unprefixed" {
   provider                = aws.core_services
   name                    = "ADMIN_CLIENT_SECRET"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_admin_client_secret_version_unprefixed" {
@@ -589,7 +589,7 @@ resource "aws_secretsmanager_secret_version" "manifest_admin_client_secret_versi
 resource "aws_secretsmanager_secret" "manifest_auth_tokens_unprefixed" {
   provider                = aws.core_services
   name                    = "AUTH_TOKENS"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_auth_tokens_version_unprefixed" {
@@ -601,7 +601,7 @@ resource "aws_secretsmanager_secret_version" "manifest_auth_tokens_version_unpre
 resource "aws_secretsmanager_secret" "manifest_airtable_api_key_unprefixed" {
   provider                = aws.core_services
   name                    = "AIRTABLE_API_KEY"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_airtable_api_key_version_unprefixed" {
@@ -613,7 +613,7 @@ resource "aws_secretsmanager_secret_version" "manifest_airtable_api_key_version_
 resource "aws_secretsmanager_secret" "manifest_document_download_api_key_unprefixed" {
   provider                = aws.core_services
   name                    = "DOCUMENT_DOWNLOAD_API_KEY"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_document_download_api_key_version_unprefixed" {
@@ -625,7 +625,7 @@ resource "aws_secretsmanager_secret_version" "manifest_document_download_api_key
 resource "aws_secretsmanager_secret" "manifest_aws_route53_zone_unprefixed" {
   provider                = aws.core_services
   name                    = "AWS_ROUTE53_ZONE"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_aws_route53_zone_version_unprefixed" {
@@ -637,7 +637,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_route53_zone_version_
 resource "aws_secretsmanager_secret" "manifest_aws_ses_access_key_unprefixed" {
   provider                = aws.core_services
   name                    = "AWS_SES_ACCESS_KEY"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_aws_ses_access_key_version_unprefixed" {
@@ -649,7 +649,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_ses_access_key_versio
 resource "aws_secretsmanager_secret" "manifest_aws_ses_secret_key_unprefixed" {
   provider                = aws.core_services
   name                    = "AWS_SES_SECRET_KEY"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_aws_ses_secret_key_version_unprefixed" {
@@ -661,7 +661,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_ses_secret_key_versio
 resource "aws_secretsmanager_secret" "manifest_dangerous_salt_unprefixed" {
   provider                = aws.core_services
   name                    = "DANGEROUS_SALT"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_dangerous_salt_version_unprefixed" {
@@ -673,7 +673,7 @@ resource "aws_secretsmanager_secret_version" "manifest_dangerous_salt_version_un
 resource "aws_secretsmanager_secret" "manifest_debug_key_unprefixed" {
   provider                = aws.core_services
   name                    = "DEBUG_KEY"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_debug_key_version_unprefixed" {
@@ -685,7 +685,7 @@ resource "aws_secretsmanager_secret_version" "manifest_debug_key_version_unprefi
 resource "aws_secretsmanager_secret" "manifest_fresh_desk_product_id_unprefixed" {
   provider                = aws.core_services
   name                    = "FRESH_DESK_PRODUCT_ID"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_fresh_desk_product_id_version_unprefixed" {
@@ -697,7 +697,7 @@ resource "aws_secretsmanager_secret_version" "manifest_fresh_desk_product_id_ver
 resource "aws_secretsmanager_secret" "manifest_fresh_desk_api_key_unprefixed" {
   provider                = aws.core_services
   name                    = "FRESH_DESK_API_KEY"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_fresh_desk_api_key_version_unprefixed" {
@@ -709,7 +709,7 @@ resource "aws_secretsmanager_secret_version" "manifest_fresh_desk_api_key_versio
 resource "aws_secretsmanager_secret" "manifest_gc_articles_api_auth_username_unprefixed" {
   provider                = aws.core_services
   name                    = "GC_ARTICLES_API_AUTH_USERNAME"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_gc_articles_api_auth_username_version_unprefixed" {
@@ -721,7 +721,7 @@ resource "aws_secretsmanager_secret_version" "manifest_gc_articles_api_auth_user
 resource "aws_secretsmanager_secret" "manifest_gc_articles_api_auth_password_unprefixed" {
   provider                = aws.core_services
   name                    = "GC_ARTICLES_API_AUTH_PASSWORD"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_gc_articles_api_auth_password_version_unprefixed" {
@@ -733,7 +733,7 @@ resource "aws_secretsmanager_secret_version" "manifest_gc_articles_api_auth_pass
 resource "aws_secretsmanager_secret" "manifest_gc_articles_waf_rate_bypass_secret_unprefixed" {
   provider                = aws.core_services
   name                    = "GC_ARTICLES_WAF_RATE_BYPASS_SECRET"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_gc_articles_waf_rate_bypass_secret_version_unprefixed" {
@@ -745,7 +745,7 @@ resource "aws_secretsmanager_secret_version" "manifest_gc_articles_waf_rate_bypa
 resource "aws_secretsmanager_secret" "manifest_mixpanel_project_token_unprefixed" {
   provider                = aws.core_services
   name                    = "MIXPANEL_PROJECT_TOKEN"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_mixpanel_project_token_version_unprefixed" {
@@ -757,7 +757,7 @@ resource "aws_secretsmanager_secret_version" "manifest_mixpanel_project_token_ve
 resource "aws_secretsmanager_secret" "manifest_crm_github_personal_access_token_unprefixed" {
   provider                = aws.core_services
   name                    = "CRM_GITHUB_PERSONAL_ACCESS_TOKEN"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_crm_github_personal_access_token_version_unprefixed" {
@@ -769,7 +769,7 @@ resource "aws_secretsmanager_secret_version" "manifest_crm_github_personal_acces
 resource "aws_secretsmanager_secret" "manifest_secret_key_unprefixed" {
   provider                = aws.core_services
   name                    = "SECRET_KEY"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_secret_key_version_unprefixed" {
@@ -781,7 +781,7 @@ resource "aws_secretsmanager_secret_version" "manifest_secret_key_version_unpref
 resource "aws_secretsmanager_secret" "manifest_sendgrid_api_key_unprefixed" {
   provider                = aws.core_services
   name                    = "SENDGRID_API_KEY"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_sendgrid_api_key_version_unprefixed" {
@@ -793,7 +793,7 @@ resource "aws_secretsmanager_secret_version" "manifest_sendgrid_api_key_version_
 resource "aws_secretsmanager_secret" "manifest_waf_secret_unprefixed" {
   provider                = aws.core_services
   name                    = "WAF_SECRET"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_waf_secret_version_unprefixed" {
@@ -805,7 +805,7 @@ resource "aws_secretsmanager_secret_version" "manifest_waf_secret_version_unpref
 resource "aws_secretsmanager_secret" "manifest_zendesk_api_key_unprefixed" {
   provider                = aws.core_services
   name                    = "ZENDESK_API_KEY"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_zendesk_api_key_version_unprefixed" {
@@ -817,7 +817,7 @@ resource "aws_secretsmanager_secret_version" "manifest_zendesk_api_key_version_u
 resource "aws_secretsmanager_secret" "manifest_zendesk_sell_api_key_unprefixed" {
   provider                = aws.core_services
   name                    = "ZENDESK_SELL_API_KEY"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_zendesk_sell_api_key_version_unprefixed" {
@@ -829,7 +829,7 @@ resource "aws_secretsmanager_secret_version" "manifest_zendesk_sell_api_key_vers
 resource "aws_secretsmanager_secret" "manifest_sre_client_secret_unprefixed" {
   provider                = aws.core_services
   name                    = "SRE_CLIENT_SECRET"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_sre_client_secret_version_unprefixed" {
@@ -841,7 +841,7 @@ resource "aws_secretsmanager_secret_version" "manifest_sre_client_secret_version
 resource "aws_secretsmanager_secret" "manifest_cache_clear_client_secret_unprefixed" {
   provider                = aws.core_services
   name                    = "CACHE_CLEAR_CLIENT_SECRET"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_cache_clear_client_secret_version_unprefixed" {
@@ -853,7 +853,7 @@ resource "aws_secretsmanager_secret_version" "manifest_cache_clear_client_secret
 resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_sc_pool_id_unprefixed" {
   provider                = aws.core_services
   name                    = "AWS_PINPOINT_SC_POOL_ID"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_sc_pool_id_version_unprefixed" {
@@ -865,7 +865,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_sc_pool_id_v
 resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_sc_template_ids_unprefixed" {
   provider                = aws.core_services
   name                    = "AWS_PINPOINT_SC_TEMPLATE_IDS"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_sc_template_ids_version_unprefixed" {
@@ -877,7 +877,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_sc_template_
 resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_default_pool_id_unprefixed" {
   provider                = aws.core_services
   name                    = "AWS_PINPOINT_DEFAULT_POOL_ID"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_default_pool_id_version_unprefixed" {
@@ -889,7 +889,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_default_pool
 resource "aws_secretsmanager_secret" "manifest_sqlalchemy_database_uri_unprefixed" {
   provider                = aws.core_services
   name                    = "SQLALCHEMY_DATABASE_URI"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_sqlalchemy_database_uri_unprefixed" {
@@ -901,7 +901,7 @@ resource "aws_secretsmanager_secret_version" "manifest_sqlalchemy_database_uri_u
 resource "aws_secretsmanager_secret" "manifest_sqlalchemy_database_reader_uri_unprefixed" {
   provider                = aws.core_services
   name                    = "SQLALCHEMY_DATABASE_READER_URI"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_sqlalchemy_database_reader_uri_unprefixed" {
@@ -913,7 +913,7 @@ resource "aws_secretsmanager_secret_version" "manifest_sqlalchemy_database_reade
 resource "aws_secretsmanager_secret" "manifest_postgres_host_unprefixed" {
   provider                = aws.core_services
   name                    = "POSTGRES_HOST"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_postgres_host_version_unprefixed" {
@@ -925,7 +925,7 @@ resource "aws_secretsmanager_secret_version" "manifest_postgres_host_version_unp
 resource "aws_secretsmanager_secret" "manifest_postgres_sql_unprefixed" {
   provider                = aws.core_services
   name                    = "POSTGRES_SQL"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_postgres_sql_version_unprefixed" {
@@ -937,7 +937,7 @@ resource "aws_secretsmanager_secret_version" "manifest_postgres_sql_version_unpr
 resource "aws_secretsmanager_secret" "manifest_cache_ops_url_unprefixed" {
   provider                = aws.core_services
   name                    = "CACHE_OPS_URL"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_cache_ops_url_unprefixed" {
@@ -949,7 +949,7 @@ resource "aws_secretsmanager_secret_version" "manifest_cache_ops_url_unprefixed"
 resource "aws_secretsmanager_secret" "manifest_redis_publish_url_unprefixed" {
   provider                = aws.core_services
   name                    = "REDIS_PUBLISH_URL"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_redis_publish_url_unprefixed" {
@@ -961,7 +961,7 @@ resource "aws_secretsmanager_secret_version" "manifest_redis_publish_url_unprefi
 resource "aws_secretsmanager_secret" "manifest_redis_url_unprefixed" {
   provider                = aws.core_services
   name                    = "REDIS_URL"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_redis_url_unprefixed" {
@@ -973,7 +973,7 @@ resource "aws_secretsmanager_secret_version" "manifest_redis_url_unprefixed" {
 resource "aws_secretsmanager_secret" "manifest_cypress_user_pw_secret_unprefixed" {
   provider                = aws.core_services
   name                    = "CYPRESS_USER_PW_SECRET"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_cypress_user_pw_secret_unprefixed" {
@@ -985,7 +985,7 @@ resource "aws_secretsmanager_secret_version" "manifest_cypress_user_pw_secret_un
 resource "aws_secretsmanager_secret" "manifest_cypress_auth_client_secret_unprefixed" {
   provider                = aws.core_services
   name                    = "CYPRESS_AUTH_CLIENT_SECRET"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_cypress_auth_client_secret_unprefixed" {
@@ -997,7 +997,7 @@ resource "aws_secretsmanager_secret_version" "manifest_cypress_auth_client_secre
 resource "aws_secretsmanager_secret" "manifest_docker_hub_username_unprefixed" {
   provider                = aws.core_services
   name                    = "DOCKER_HUB_USERNAME"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_docker_hub_username_unprefixed" {
@@ -1009,7 +1009,7 @@ resource "aws_secretsmanager_secret_version" "manifest_docker_hub_username_unpre
 resource "aws_secretsmanager_secret" "manifest_docker_hub_pat_unprefixed" {
   provider                = aws.core_services
   name                    = "DOCKER_HUB_PAT"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_docker_hub_pat_unprefixed" {
@@ -1022,7 +1022,7 @@ resource "aws_secretsmanager_secret" "manifest_signoz_smtp_username_unprefixed" 
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
   name                    = "SIGNOZ_SMTP_USERNAME"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_signoz_smtp_username_unprefixed" {
@@ -1036,7 +1036,7 @@ resource "aws_secretsmanager_secret" "manifest_signoz_smtp_password_unprefixed" 
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
   name                    = "SIGNOZ_SMTP_PASSWORD"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_signoz_smtp_password_unprefixed" {
@@ -1050,7 +1050,7 @@ resource "aws_secretsmanager_secret" "manifest_signoz_dashboard_api_key_unprefix
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
   name                    = "SIGNOZ_DASHBOARD_API_KEY"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_signoz_dashboard_api_key_unprefixed" {
@@ -1064,7 +1064,7 @@ resource "aws_secretsmanager_secret" "manifest_signoz_postgres_password_unprefix
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
   name                    = "SIGNOZ_POSTGRES_PASSWORD"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_signoz_postgres_password_unprefixed" {
@@ -1077,7 +1077,7 @@ resource "aws_secretsmanager_secret_version" "manifest_signoz_postgres_password_
 resource "aws_secretsmanager_secret" "manifest_falco_credentials_unprefixed" {
   provider                = aws.core_services
   name                    = "FALCO_CREDENTIALS"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_falco_credentials_version_unprefixed" {
@@ -1089,7 +1089,7 @@ resource "aws_secretsmanager_secret_version" "manifest_falco_credentials_version
 resource "aws_secretsmanager_secret" "manifest_falco_slack_webhook_url_unprefixed" {
   provider                = aws.core_services
   name                    = "FALCO_SLACK_WEBHOOK_URL"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_falco_slack_webhook_url_version_unprefixed" {
@@ -1101,7 +1101,7 @@ resource "aws_secretsmanager_secret_version" "manifest_falco_slack_webhook_url_v
 resource "aws_secretsmanager_secret" "manifest_scan_verdict_callback_token_unprefixed" {
   provider                = aws.core_services
   name                    = "SCAN_VERDICT_CALLBACK_TOKEN"
-  recovery_window_in_days = 0
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_scan_verdict_callback_token_unprefixed" {

--- a/aws/manifest_secrets/secrets.tf
+++ b/aws/manifest_secrets/secrets.tf
@@ -1,6 +1,6 @@
 resource "aws_secretsmanager_secret" "manifest_admin_client_secret" {
   provider                = aws.core_services
-  name                    = "ADMIN_CLIENT_SECRET"
+  name                    = "MANIFEST_ADMIN_CLIENT_SECRET"
   recovery_window_in_days = 0
 }
 
@@ -12,7 +12,7 @@ resource "aws_secretsmanager_secret_version" "manifest_admin_client_secret_versi
 
 resource "aws_secretsmanager_secret" "manifest_auth_tokens" {
   provider                = aws.core_services
-  name                    = "AUTH_TOKENS"
+  name                    = "MANIFEST_AUTH_TOKENS"
   recovery_window_in_days = 0
 }
 
@@ -24,7 +24,7 @@ resource "aws_secretsmanager_secret_version" "manifest_auth_tokens_version" {
 
 resource "aws_secretsmanager_secret" "manifest_airtable_api_key" {
   provider                = aws.core_services
-  name                    = "AIRTABLE_API_KEY"
+  name                    = "MANIFEST_AIRTABLE_API_KEY"
   recovery_window_in_days = 0
 }
 
@@ -36,7 +36,7 @@ resource "aws_secretsmanager_secret_version" "manifest_airtable_api_key_version"
 
 resource "aws_secretsmanager_secret" "manifest_document_download_api_key" {
   provider                = aws.core_services
-  name                    = "DOCUMENT_DOWNLOAD_API_KEY"
+  name                    = "MANIFEST_DOCUMENT_DOWNLOAD_API_KEY"
   recovery_window_in_days = 0
 }
 
@@ -48,7 +48,7 @@ resource "aws_secretsmanager_secret_version" "manifest_document_download_api_key
 
 resource "aws_secretsmanager_secret" "manifest_aws_route53_zone" {
   provider                = aws.core_services
-  name                    = "AWS_ROUTE53_ZONE"
+  name                    = "MANIFEST_AWS_ROUTE53_ZONE"
   recovery_window_in_days = 0
 }
 
@@ -60,7 +60,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_route53_zone_version"
 
 resource "aws_secretsmanager_secret" "manifest_aws_ses_access_key" {
   provider                = aws.core_services
-  name                    = "AWS_SES_ACCESS_KEY"
+  name                    = "MANIFEST_AWS_SES_ACCESS_KEY"
   recovery_window_in_days = 0
 }
 
@@ -72,7 +72,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_ses_access_key_versio
 
 resource "aws_secretsmanager_secret" "manifest_aws_ses_secret_key" {
   provider                = aws.core_services
-  name                    = "AWS_SES_SECRET_KEY"
+  name                    = "MANIFEST_AWS_SES_SECRET_KEY"
   recovery_window_in_days = 0
 }
 
@@ -84,7 +84,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_ses_secret_key_versio
 
 resource "aws_secretsmanager_secret" "manifest_dangerous_salt" {
   provider                = aws.core_services
-  name                    = "DANGEROUS_SALT"
+  name                    = "MANIFEST_DANGEROUS_SALT"
   recovery_window_in_days = 0
 }
 
@@ -96,7 +96,7 @@ resource "aws_secretsmanager_secret_version" "manifest_dangerous_salt_version" {
 
 resource "aws_secretsmanager_secret" "manifest_debug_key" {
   provider                = aws.core_services
-  name                    = "DEBUG_KEY"
+  name                    = "MANIFEST_DEBUG_KEY"
   recovery_window_in_days = 0
 }
 
@@ -108,7 +108,7 @@ resource "aws_secretsmanager_secret_version" "manifest_debug_key_version" {
 
 resource "aws_secretsmanager_secret" "manifest_fresh_desk_product_id" {
   provider                = aws.core_services
-  name                    = "FRESH_DESK_PRODUCT_ID"
+  name                    = "MANIFEST_FRESH_DESK_PRODUCT_ID"
   recovery_window_in_days = 0
 }
 
@@ -120,7 +120,7 @@ resource "aws_secretsmanager_secret_version" "manifest_fresh_desk_product_id_ver
 
 resource "aws_secretsmanager_secret" "manifest_fresh_desk_api_key" {
   provider                = aws.core_services
-  name                    = "FRESH_DESK_API_KEY"
+  name                    = "MANIFEST_FRESH_DESK_API_KEY"
   recovery_window_in_days = 0
 }
 
@@ -132,7 +132,7 @@ resource "aws_secretsmanager_secret_version" "manifest_fresh_desk_api_key_versio
 
 resource "aws_secretsmanager_secret" "manifest_gc_articles_api_auth_username" {
   provider                = aws.core_services
-  name                    = "GC_ARTICLES_API_AUTH_USERNAME"
+  name                    = "MANIFEST_GC_ARTICLES_API_AUTH_USERNAME"
   recovery_window_in_days = 0
 }
 
@@ -144,7 +144,7 @@ resource "aws_secretsmanager_secret_version" "manifest_gc_articles_api_auth_user
 
 resource "aws_secretsmanager_secret" "manifest_gc_articles_api_auth_password" {
   provider                = aws.core_services
-  name                    = "GC_ARTICLES_API_AUTH_PASSWORD"
+  name                    = "MANIFEST_GC_ARTICLES_API_AUTH_PASSWORD"
   recovery_window_in_days = 0
 }
 
@@ -156,7 +156,7 @@ resource "aws_secretsmanager_secret_version" "manifest_gc_articles_api_auth_pass
 
 resource "aws_secretsmanager_secret" "manifest_gc_articles_waf_rate_bypass_secret" {
   provider                = aws.core_services
-  name                    = "GC_ARTICLES_WAF_RATE_BYPASS_SECRET"
+  name                    = "MANIFEST_GC_ARTICLES_WAF_RATE_BYPASS_SECRET"
   recovery_window_in_days = 0
 }
 
@@ -168,7 +168,7 @@ resource "aws_secretsmanager_secret_version" "manifest_gc_articles_waf_rate_bypa
 
 resource "aws_secretsmanager_secret" "manifest_mixpanel_project_token" {
   provider                = aws.core_services
-  name                    = "MIXPANEL_PROJECT_TOKEN"
+  name                    = "MANIFEST_MIXPANEL_PROJECT_TOKEN"
   recovery_window_in_days = 0
 }
 
@@ -180,7 +180,7 @@ resource "aws_secretsmanager_secret_version" "manifest_mixpanel_project_token_ve
 
 resource "aws_secretsmanager_secret" "manifest_crm_github_personal_access_token" {
   provider                = aws.core_services
-  name                    = "CRM_GITHUB_PERSONAL_ACCESS_TOKEN"
+  name                    = "MANIFEST_CRM_GITHUB_PERSONAL_ACCESS_TOKEN"
   recovery_window_in_days = 0
 }
 
@@ -192,7 +192,7 @@ resource "aws_secretsmanager_secret_version" "manifest_crm_github_personal_acces
 
 resource "aws_secretsmanager_secret" "manifest_secret_key" {
   provider                = aws.core_services
-  name                    = "SECRET_KEY"
+  name                    = "MANIFEST_SECRET_KEY"
   recovery_window_in_days = 0
 }
 
@@ -204,7 +204,7 @@ resource "aws_secretsmanager_secret_version" "manifest_secret_key_version" {
 
 resource "aws_secretsmanager_secret" "manifest_sendgrid_api_key" {
   provider                = aws.core_services
-  name                    = "SENDGRID_API_KEY"
+  name                    = "MANIFEST_SENDGRID_API_KEY"
   recovery_window_in_days = 0
 }
 
@@ -216,7 +216,7 @@ resource "aws_secretsmanager_secret_version" "manifest_sendgrid_api_key_version"
 
 resource "aws_secretsmanager_secret" "manifest_waf_secret" {
   provider                = aws.core_services
-  name                    = "WAF_SECRET"
+  name                    = "MANIFEST_WAF_SECRET"
   recovery_window_in_days = 0
 }
 
@@ -228,7 +228,7 @@ resource "aws_secretsmanager_secret_version" "manifest_waf_secret_version" {
 
 resource "aws_secretsmanager_secret" "manifest_zendesk_api_key" {
   provider                = aws.core_services
-  name                    = "ZENDESK_API_KEY"
+  name                    = "MANIFEST_ZENDESK_API_KEY"
   recovery_window_in_days = 0
 }
 
@@ -240,7 +240,7 @@ resource "aws_secretsmanager_secret_version" "manifest_zendesk_api_key_version" 
 
 resource "aws_secretsmanager_secret" "manifest_zendesk_sell_api_key" {
   provider                = aws.core_services
-  name                    = "ZENDESK_SELL_API_KEY"
+  name                    = "MANIFEST_ZENDESK_SELL_API_KEY"
   recovery_window_in_days = 0
 }
 
@@ -252,7 +252,7 @@ resource "aws_secretsmanager_secret_version" "manifest_zendesk_sell_api_key_vers
 
 resource "aws_secretsmanager_secret" "manifest_sre_client_secret" {
   provider                = aws.core_services
-  name                    = "SRE_CLIENT_SECRET"
+  name                    = "MANIFEST_SRE_CLIENT_SECRET"
   recovery_window_in_days = 0
 }
 
@@ -264,7 +264,7 @@ resource "aws_secretsmanager_secret_version" "manifest_sre_client_secret_version
 
 resource "aws_secretsmanager_secret" "manifest_cache_clear_client_secret" {
   provider                = aws.core_services
-  name                    = "CACHE_CLEAR_CLIENT_SECRET"
+  name                    = "MANIFEST_CACHE_CLEAR_CLIENT_SECRET"
   recovery_window_in_days = 0
 }
 
@@ -276,7 +276,7 @@ resource "aws_secretsmanager_secret_version" "manifest_cache_clear_client_secret
 
 resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_sc_pool_id" {
   provider                = aws.core_services
-  name                    = "AWS_PINPOINT_SC_POOL_ID"
+  name                    = "MANIFEST_AWS_PINPOINT_SC_POOL_ID"
   recovery_window_in_days = 0
 }
 
@@ -288,7 +288,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_sc_pool_id_v
 
 resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_sc_template_ids" {
   provider                = aws.core_services
-  name                    = "AWS_PINPOINT_SC_TEMPLATE_IDS"
+  name                    = "MANIFEST_AWS_PINPOINT_SC_TEMPLATE_IDS"
   recovery_window_in_days = 0
 }
 
@@ -300,7 +300,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_sc_template_
 
 resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_default_pool_id" {
   provider                = aws.core_services
-  name                    = "AWS_PINPOINT_DEFAULT_POOL_ID"
+  name                    = "MANIFEST_AWS_PINPOINT_DEFAULT_POOL_ID"
   recovery_window_in_days = 0
 }
 
@@ -312,7 +312,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_default_pool
 
 resource "aws_secretsmanager_secret" "manifest_sqlalachemy_database_uri" {
   provider                = aws.core_services
-  name                    = "SQLALCHEMY_DATABASE_URI"
+  name                    = "MANIFEST_SQLALCHEMY_DATABASE_URI"
   recovery_window_in_days = 0
 }
 
@@ -326,7 +326,7 @@ resource "aws_secretsmanager_secret_version" "manifest_sqlalachemy_database_uri"
 
 resource "aws_secretsmanager_secret" "manifest_sqlalachemy_database_reader_uri" {
   provider                = aws.core_services
-  name                    = "SQLALCHEMY_DATABASE_READER_URI"
+  name                    = "MANIFEST_SQLALCHEMY_DATABASE_READER_URI"
   recovery_window_in_days = 0
 }
 
@@ -338,7 +338,7 @@ resource "aws_secretsmanager_secret_version" "manifest_sqlalachemy_database_read
 
 resource "aws_secretsmanager_secret" "manifest_postgres_host" {
   provider                = aws.core_services
-  name                    = "POSTGRES_HOST"
+  name                    = "MANIFEST_POSTGRES_HOST"
   recovery_window_in_days = 0
 }
 
@@ -350,7 +350,7 @@ resource "aws_secretsmanager_secret_version" "manifest_postgres_host_version" {
 
 resource "aws_secretsmanager_secret" "manifest_postgres_sql" {
   provider                = aws.core_services
-  name                    = "POSTGRES_SQL"
+  name                    = "MANIFEST_POSTGRES_SQL"
   recovery_window_in_days = 0
 }
 
@@ -362,7 +362,7 @@ resource "aws_secretsmanager_secret_version" "manifest_postgres_sql_version" {
 
 resource "aws_secretsmanager_secret" "manifest_cache_ops_url" {
   provider                = aws.core_services
-  name                    = "CACHE_OPS_URL"
+  name                    = "MANIFEST_CACHE_OPS_URL"
   recovery_window_in_days = 0
 }
 
@@ -374,7 +374,7 @@ resource "aws_secretsmanager_secret_version" "manifest_cache_ops_url" {
 
 resource "aws_secretsmanager_secret" "manifest_redis_publish_url" {
   provider                = aws.core_services
-  name                    = "REDIS_PUBLISH_URL"
+  name                    = "MANIFEST_REDIS_PUBLISH_URL"
   recovery_window_in_days = 0
 }
 
@@ -387,7 +387,7 @@ resource "aws_secretsmanager_secret_version" "manifest_redis_publish_url" {
 
 resource "aws_secretsmanager_secret" "manifest_redis_url" {
   provider                = aws.core_services
-  name                    = "REDIS_URL"
+  name                    = "MANIFEST_REDIS_URL"
   recovery_window_in_days = 0
 }
 
@@ -399,7 +399,7 @@ resource "aws_secretsmanager_secret_version" "manifest_redis_url" {
 
 resource "aws_secretsmanager_secret" "manifest_cypress_user_pw_secret" {
   provider                = aws.core_services
-  name                    = "CYPRESS_USER_PW_SECRET"
+  name                    = "MANIFEST_CYPRESS_USER_PW_SECRET"
   recovery_window_in_days = 0
 }
 
@@ -411,7 +411,7 @@ resource "aws_secretsmanager_secret_version" "manifest_cypress_user_pw_secret" {
 
 resource "aws_secretsmanager_secret" "manifest_cypress_auth_client_secret" {
   provider                = aws.core_services
-  name                    = "CYPRESS_AUTH_CLIENT_SECRET"
+  name                    = "MANIFEST_CYPRESS_AUTH_CLIENT_SECRET"
   recovery_window_in_days = 0
 }
 
@@ -423,7 +423,7 @@ resource "aws_secretsmanager_secret_version" "manifest_cypress_auth_client_secre
 
 resource "aws_secretsmanager_secret" "manifest_docker_hub_username" {
   provider                = aws.core_services
-  name                    = "DOCKER_HUB_USERNAME"
+  name                    = "MANIFEST_DOCKER_HUB_USERNAME"
   recovery_window_in_days = 0
 }
 
@@ -435,7 +435,7 @@ resource "aws_secretsmanager_secret_version" "manifest_docker_hub_username" {
 
 resource "aws_secretsmanager_secret" "manifest_docker_hub_pat" {
   provider                = aws.core_services
-  name                    = "DOCKER_HUB_PAT"
+  name                    = "MANIFEST_DOCKER_HUB_PAT"
   recovery_window_in_days = 0
 }
 
@@ -448,7 +448,7 @@ resource "aws_secretsmanager_secret_version" "manifest_docker_hub_pat" {
 resource "aws_secretsmanager_secret" "manifest_signoz_smtp_username" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
-  name                    = "SIGNOZ_SMTP_USERNAME"
+  name                    = "MANIFEST_SIGNOZ_SMTP_USERNAME"
   recovery_window_in_days = 0
 }
 
@@ -462,7 +462,7 @@ resource "aws_secretsmanager_secret_version" "manifest_signoz_smtp_username" {
 resource "aws_secretsmanager_secret" "manifest_signoz_smtp_password" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
-  name                    = "SIGNOZ_SMTP_PASSWORD"
+  name                    = "MANIFEST_SIGNOZ_SMTP_PASSWORD"
   recovery_window_in_days = 0
 }
 
@@ -476,7 +476,7 @@ resource "aws_secretsmanager_secret_version" "manifest_signoz_smtp_password" {
 resource "aws_secretsmanager_secret" "manifest_signoz_dashboard_api_key" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
-  name                    = "SIGNOZ_DASHBOARD_API_KEY"
+  name                    = "MANIFEST_SIGNOZ_DASHBOARD_API_KEY"
   recovery_window_in_days = 0
 }
 
@@ -490,7 +490,7 @@ resource "aws_secretsmanager_secret_version" "manifest_signoz_dashboard_api_key"
 resource "aws_secretsmanager_secret" "manifest_signoz_postgres_password" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
-  name                    = "SIGNOZ_POSTGRES_PASSWORD"
+  name                    = "MANIFEST_SIGNOZ_POSTGRES_PASSWORD"
   recovery_window_in_days = 0
 }
 
@@ -505,7 +505,7 @@ resource "aws_secretsmanager_secret_version" "manifest_signoz_postgres_password"
 
 resource "aws_secretsmanager_secret" "manifest_falco_credentials" {
   provider                = aws.core_services
-  name                    = "FALCO_CREDENTIALS"
+  name                    = "MANIFEST_FALCO_CREDENTIALS"
   recovery_window_in_days = 0
 }
 
@@ -517,7 +517,7 @@ resource "aws_secretsmanager_secret_version" "manifest_falco_credentials_version
 
 resource "aws_secretsmanager_secret" "manifest_falco_slack_webhook_url" {
   provider                = aws.core_services
-  name                    = "FALCO_SLACK_WEBHOOK_URL"
+  name                    = "MANIFEST_FALCO_SLACK_WEBHOOK_URL"
   recovery_window_in_days = 0
 }
 
@@ -529,7 +529,7 @@ resource "aws_secretsmanager_secret_version" "manifest_falco_slack_webhook_url_v
 
 resource "aws_secretsmanager_secret" "manifest_scan_verdict_callback_token" {
   provider                = aws.core_services
-  name                    = "SCAN_VERDICT_CALLBACK_TOKEN"
+  name                    = "MANIFEST_SCAN_VERDICT_CALLBACK_TOKEN"
   recovery_window_in_days = 0
 }
 

--- a/aws/manifest_secrets/secrets.tf
+++ b/aws/manifest_secrets/secrets.tf
@@ -9,7 +9,7 @@
 resource "aws_secretsmanager_secret" "manifest_admin_client_secret" {
   provider                = aws.core_services
   name                    = "MANIFEST_ADMIN_CLIENT_SECRET"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_admin_client_secret_version" {
@@ -21,7 +21,7 @@ resource "aws_secretsmanager_secret_version" "manifest_admin_client_secret_versi
 resource "aws_secretsmanager_secret" "manifest_auth_tokens" {
   provider                = aws.core_services
   name                    = "MANIFEST_AUTH_TOKENS"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_auth_tokens_version" {
@@ -33,7 +33,7 @@ resource "aws_secretsmanager_secret_version" "manifest_auth_tokens_version" {
 resource "aws_secretsmanager_secret" "manifest_airtable_api_key" {
   provider                = aws.core_services
   name                    = "MANIFEST_AIRTABLE_API_KEY"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_airtable_api_key_version" {
@@ -45,7 +45,7 @@ resource "aws_secretsmanager_secret_version" "manifest_airtable_api_key_version"
 resource "aws_secretsmanager_secret" "manifest_document_download_api_key" {
   provider                = aws.core_services
   name                    = "MANIFEST_DOCUMENT_DOWNLOAD_API_KEY"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_document_download_api_key_version" {
@@ -57,7 +57,7 @@ resource "aws_secretsmanager_secret_version" "manifest_document_download_api_key
 resource "aws_secretsmanager_secret" "manifest_aws_route53_zone" {
   provider                = aws.core_services
   name                    = "MANIFEST_AWS_ROUTE53_ZONE"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_aws_route53_zone_version" {
@@ -69,7 +69,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_route53_zone_version"
 resource "aws_secretsmanager_secret" "manifest_aws_ses_access_key" {
   provider                = aws.core_services
   name                    = "MANIFEST_AWS_SES_ACCESS_KEY"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_aws_ses_access_key_version" {
@@ -81,7 +81,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_ses_access_key_versio
 resource "aws_secretsmanager_secret" "manifest_aws_ses_secret_key" {
   provider                = aws.core_services
   name                    = "MANIFEST_AWS_SES_SECRET_KEY"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_aws_ses_secret_key_version" {
@@ -93,7 +93,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_ses_secret_key_versio
 resource "aws_secretsmanager_secret" "manifest_dangerous_salt" {
   provider                = aws.core_services
   name                    = "MANIFEST_DANGEROUS_SALT"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_dangerous_salt_version" {
@@ -105,7 +105,7 @@ resource "aws_secretsmanager_secret_version" "manifest_dangerous_salt_version" {
 resource "aws_secretsmanager_secret" "manifest_debug_key" {
   provider                = aws.core_services
   name                    = "MANIFEST_DEBUG_KEY"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_debug_key_version" {
@@ -117,7 +117,7 @@ resource "aws_secretsmanager_secret_version" "manifest_debug_key_version" {
 resource "aws_secretsmanager_secret" "manifest_fresh_desk_product_id" {
   provider                = aws.core_services
   name                    = "MANIFEST_FRESH_DESK_PRODUCT_ID"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_fresh_desk_product_id_version" {
@@ -129,7 +129,7 @@ resource "aws_secretsmanager_secret_version" "manifest_fresh_desk_product_id_ver
 resource "aws_secretsmanager_secret" "manifest_fresh_desk_api_key" {
   provider                = aws.core_services
   name                    = "MANIFEST_FRESH_DESK_API_KEY"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_fresh_desk_api_key_version" {
@@ -141,7 +141,7 @@ resource "aws_secretsmanager_secret_version" "manifest_fresh_desk_api_key_versio
 resource "aws_secretsmanager_secret" "manifest_gc_articles_api_auth_username" {
   provider                = aws.core_services
   name                    = "MANIFEST_GC_ARTICLES_API_AUTH_USERNAME"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_gc_articles_api_auth_username_version" {
@@ -153,7 +153,7 @@ resource "aws_secretsmanager_secret_version" "manifest_gc_articles_api_auth_user
 resource "aws_secretsmanager_secret" "manifest_gc_articles_api_auth_password" {
   provider                = aws.core_services
   name                    = "MANIFEST_GC_ARTICLES_API_AUTH_PASSWORD"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_gc_articles_api_auth_password_version" {
@@ -165,7 +165,7 @@ resource "aws_secretsmanager_secret_version" "manifest_gc_articles_api_auth_pass
 resource "aws_secretsmanager_secret" "manifest_gc_articles_waf_rate_bypass_secret" {
   provider                = aws.core_services
   name                    = "MANIFEST_GC_ARTICLES_WAF_RATE_BYPASS_SECRET"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_gc_articles_waf_rate_bypass_secret_version" {
@@ -177,7 +177,7 @@ resource "aws_secretsmanager_secret_version" "manifest_gc_articles_waf_rate_bypa
 resource "aws_secretsmanager_secret" "manifest_mixpanel_project_token" {
   provider                = aws.core_services
   name                    = "MANIFEST_MIXPANEL_PROJECT_TOKEN"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_mixpanel_project_token_version" {
@@ -189,7 +189,7 @@ resource "aws_secretsmanager_secret_version" "manifest_mixpanel_project_token_ve
 resource "aws_secretsmanager_secret" "manifest_crm_github_personal_access_token" {
   provider                = aws.core_services
   name                    = "MANIFEST_CRM_GITHUB_PERSONAL_ACCESS_TOKEN"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_crm_github_personal_access_token_version" {
@@ -201,7 +201,7 @@ resource "aws_secretsmanager_secret_version" "manifest_crm_github_personal_acces
 resource "aws_secretsmanager_secret" "manifest_secret_key" {
   provider                = aws.core_services
   name                    = "MANIFEST_SECRET_KEY"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_secret_key_version" {
@@ -213,7 +213,7 @@ resource "aws_secretsmanager_secret_version" "manifest_secret_key_version" {
 resource "aws_secretsmanager_secret" "manifest_sendgrid_api_key" {
   provider                = aws.core_services
   name                    = "MANIFEST_SENDGRID_API_KEY"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_sendgrid_api_key_version" {
@@ -225,7 +225,7 @@ resource "aws_secretsmanager_secret_version" "manifest_sendgrid_api_key_version"
 resource "aws_secretsmanager_secret" "manifest_waf_secret" {
   provider                = aws.core_services
   name                    = "MANIFEST_WAF_SECRET"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_waf_secret_version" {
@@ -237,7 +237,7 @@ resource "aws_secretsmanager_secret_version" "manifest_waf_secret_version" {
 resource "aws_secretsmanager_secret" "manifest_zendesk_api_key" {
   provider                = aws.core_services
   name                    = "MANIFEST_ZENDESK_API_KEY"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_zendesk_api_key_version" {
@@ -249,7 +249,7 @@ resource "aws_secretsmanager_secret_version" "manifest_zendesk_api_key_version" 
 resource "aws_secretsmanager_secret" "manifest_zendesk_sell_api_key" {
   provider                = aws.core_services
   name                    = "MANIFEST_ZENDESK_SELL_API_KEY"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_zendesk_sell_api_key_version" {
@@ -261,7 +261,7 @@ resource "aws_secretsmanager_secret_version" "manifest_zendesk_sell_api_key_vers
 resource "aws_secretsmanager_secret" "manifest_sre_client_secret" {
   provider                = aws.core_services
   name                    = "MANIFEST_SRE_CLIENT_SECRET"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_sre_client_secret_version" {
@@ -273,7 +273,7 @@ resource "aws_secretsmanager_secret_version" "manifest_sre_client_secret_version
 resource "aws_secretsmanager_secret" "manifest_cache_clear_client_secret" {
   provider                = aws.core_services
   name                    = "MANIFEST_CACHE_CLEAR_CLIENT_SECRET"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_cache_clear_client_secret_version" {
@@ -285,7 +285,7 @@ resource "aws_secretsmanager_secret_version" "manifest_cache_clear_client_secret
 resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_sc_pool_id" {
   provider                = aws.core_services
   name                    = "MANIFEST_AWS_PINPOINT_SC_POOL_ID"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_sc_pool_id_version" {
@@ -297,7 +297,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_sc_pool_id_v
 resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_sc_template_ids" {
   provider                = aws.core_services
   name                    = "MANIFEST_AWS_PINPOINT_SC_TEMPLATE_IDS"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_sc_template_ids_version" {
@@ -309,7 +309,7 @@ resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_sc_template_
 resource "aws_secretsmanager_secret" "manifest_aws_pinpoint_default_pool_id" {
   provider                = aws.core_services
   name                    = "MANIFEST_AWS_PINPOINT_DEFAULT_POOL_ID"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_aws_pinpoint_default_pool_id_version" {
@@ -341,7 +341,7 @@ moved {
 resource "aws_secretsmanager_secret" "manifest_sqlalchemy_database_uri" {
   provider                = aws.core_services
   name                    = "MANIFEST_SQLALCHEMY_DATABASE_URI"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 # THESE BELOW ARE DEPENDENT ON DYNAMICALLY GENERATED AWS INFORMATION
@@ -355,7 +355,7 @@ resource "aws_secretsmanager_secret_version" "manifest_sqlalchemy_database_uri" 
 resource "aws_secretsmanager_secret" "manifest_sqlalchemy_database_reader_uri" {
   provider                = aws.core_services
   name                    = "MANIFEST_SQLALCHEMY_DATABASE_READER_URI"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_sqlalchemy_database_reader_uri" {
@@ -367,7 +367,7 @@ resource "aws_secretsmanager_secret_version" "manifest_sqlalchemy_database_reade
 resource "aws_secretsmanager_secret" "manifest_postgres_host" {
   provider                = aws.core_services
   name                    = "MANIFEST_POSTGRES_HOST"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_postgres_host_version" {
@@ -379,7 +379,7 @@ resource "aws_secretsmanager_secret_version" "manifest_postgres_host_version" {
 resource "aws_secretsmanager_secret" "manifest_postgres_sql" {
   provider                = aws.core_services
   name                    = "MANIFEST_POSTGRES_SQL"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_postgres_sql_version" {
@@ -391,7 +391,7 @@ resource "aws_secretsmanager_secret_version" "manifest_postgres_sql_version" {
 resource "aws_secretsmanager_secret" "manifest_cache_ops_url" {
   provider                = aws.core_services
   name                    = "MANIFEST_CACHE_OPS_URL"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_cache_ops_url" {
@@ -403,7 +403,7 @@ resource "aws_secretsmanager_secret_version" "manifest_cache_ops_url" {
 resource "aws_secretsmanager_secret" "manifest_redis_publish_url" {
   provider                = aws.core_services
   name                    = "MANIFEST_REDIS_PUBLISH_URL"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_redis_publish_url" {
@@ -416,7 +416,7 @@ resource "aws_secretsmanager_secret_version" "manifest_redis_publish_url" {
 resource "aws_secretsmanager_secret" "manifest_redis_url" {
   provider                = aws.core_services
   name                    = "MANIFEST_REDIS_URL"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_redis_url" {
@@ -428,7 +428,7 @@ resource "aws_secretsmanager_secret_version" "manifest_redis_url" {
 resource "aws_secretsmanager_secret" "manifest_cypress_user_pw_secret" {
   provider                = aws.core_services
   name                    = "MANIFEST_CYPRESS_USER_PW_SECRET"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_cypress_user_pw_secret" {
@@ -440,7 +440,7 @@ resource "aws_secretsmanager_secret_version" "manifest_cypress_user_pw_secret" {
 resource "aws_secretsmanager_secret" "manifest_cypress_auth_client_secret" {
   provider                = aws.core_services
   name                    = "MANIFEST_CYPRESS_AUTH_CLIENT_SECRET"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_cypress_auth_client_secret" {
@@ -452,7 +452,7 @@ resource "aws_secretsmanager_secret_version" "manifest_cypress_auth_client_secre
 resource "aws_secretsmanager_secret" "manifest_docker_hub_username" {
   provider                = aws.core_services
   name                    = "MANIFEST_DOCKER_HUB_USERNAME"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_docker_hub_username" {
@@ -464,7 +464,7 @@ resource "aws_secretsmanager_secret_version" "manifest_docker_hub_username" {
 resource "aws_secretsmanager_secret" "manifest_docker_hub_pat" {
   provider                = aws.core_services
   name                    = "MANIFEST_DOCKER_HUB_PAT"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_docker_hub_pat" {
@@ -477,7 +477,7 @@ resource "aws_secretsmanager_secret" "manifest_signoz_smtp_username" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
   name                    = "MANIFEST_SIGNOZ_SMTP_USERNAME"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_signoz_smtp_username" {
@@ -491,7 +491,7 @@ resource "aws_secretsmanager_secret" "manifest_signoz_smtp_password" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
   name                    = "MANIFEST_SIGNOZ_SMTP_PASSWORD"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_signoz_smtp_password" {
@@ -505,7 +505,7 @@ resource "aws_secretsmanager_secret" "manifest_signoz_dashboard_api_key" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
   name                    = "MANIFEST_SIGNOZ_DASHBOARD_API_KEY"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_signoz_dashboard_api_key" {
@@ -519,7 +519,7 @@ resource "aws_secretsmanager_secret" "manifest_signoz_postgres_password" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
   name                    = "MANIFEST_SIGNOZ_POSTGRES_PASSWORD"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_signoz_postgres_password" {
@@ -534,7 +534,7 @@ resource "aws_secretsmanager_secret_version" "manifest_signoz_postgres_password"
 resource "aws_secretsmanager_secret" "manifest_falco_credentials" {
   provider                = aws.core_services
   name                    = "MANIFEST_FALCO_CREDENTIALS"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_falco_credentials_version" {
@@ -546,7 +546,7 @@ resource "aws_secretsmanager_secret_version" "manifest_falco_credentials_version
 resource "aws_secretsmanager_secret" "manifest_falco_slack_webhook_url" {
   provider                = aws.core_services
   name                    = "MANIFEST_FALCO_SLACK_WEBHOOK_URL"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_falco_slack_webhook_url_version" {
@@ -558,7 +558,7 @@ resource "aws_secretsmanager_secret_version" "manifest_falco_slack_webhook_url_v
 resource "aws_secretsmanager_secret" "manifest_scan_verdict_callback_token" {
   provider                = aws.core_services
   name                    = "MANIFEST_SCAN_VERDICT_CALLBACK_TOKEN"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "manifest_scan_verdict_callback_token" {
@@ -573,14 +573,11 @@ resource "aws_secretsmanager_secret_version" "manifest_scan_verdict_callback_tok
 # Helm/ExternalSecret rollout is verified against these names, delete the
 # LEGACY MANIFEST_-prefixed block above. Tracking: PR #2787.
 #
-# TODO: recovery_window_in_days is temporarily 7 on these (matching the
-# legacy block) purely as a migration safety net. Once the legacy block
-# above is deleted, set these back to 0 to match the original convention.
 # ---------------------------------------------------------------------------
 resource "aws_secretsmanager_secret" "admin_client_secret" {
   provider                = aws.core_services
   name                    = "ADMIN_CLIENT_SECRET"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "admin_client_secret_version" {
@@ -592,7 +589,7 @@ resource "aws_secretsmanager_secret_version" "admin_client_secret_version" {
 resource "aws_secretsmanager_secret" "auth_tokens" {
   provider                = aws.core_services
   name                    = "AUTH_TOKENS"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "auth_tokens_version" {
@@ -604,7 +601,7 @@ resource "aws_secretsmanager_secret_version" "auth_tokens_version" {
 resource "aws_secretsmanager_secret" "airtable_api_key" {
   provider                = aws.core_services
   name                    = "AIRTABLE_API_KEY"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "airtable_api_key_version" {
@@ -616,7 +613,7 @@ resource "aws_secretsmanager_secret_version" "airtable_api_key_version" {
 resource "aws_secretsmanager_secret" "document_download_api_key" {
   provider                = aws.core_services
   name                    = "DOCUMENT_DOWNLOAD_API_KEY"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "document_download_api_key_version" {
@@ -628,7 +625,7 @@ resource "aws_secretsmanager_secret_version" "document_download_api_key_version"
 resource "aws_secretsmanager_secret" "aws_route53_zone" {
   provider                = aws.core_services
   name                    = "AWS_ROUTE53_ZONE"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "aws_route53_zone_version" {
@@ -640,7 +637,7 @@ resource "aws_secretsmanager_secret_version" "aws_route53_zone_version" {
 resource "aws_secretsmanager_secret" "aws_ses_access_key" {
   provider                = aws.core_services
   name                    = "AWS_SES_ACCESS_KEY"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "aws_ses_access_key_version" {
@@ -652,7 +649,7 @@ resource "aws_secretsmanager_secret_version" "aws_ses_access_key_version" {
 resource "aws_secretsmanager_secret" "aws_ses_secret_key" {
   provider                = aws.core_services
   name                    = "AWS_SES_SECRET_KEY"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "aws_ses_secret_key_version" {
@@ -664,7 +661,7 @@ resource "aws_secretsmanager_secret_version" "aws_ses_secret_key_version" {
 resource "aws_secretsmanager_secret" "dangerous_salt" {
   provider                = aws.core_services
   name                    = "DANGEROUS_SALT"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "dangerous_salt_version" {
@@ -676,7 +673,7 @@ resource "aws_secretsmanager_secret_version" "dangerous_salt_version" {
 resource "aws_secretsmanager_secret" "debug_key" {
   provider                = aws.core_services
   name                    = "DEBUG_KEY"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "debug_key_version" {
@@ -688,7 +685,7 @@ resource "aws_secretsmanager_secret_version" "debug_key_version" {
 resource "aws_secretsmanager_secret" "fresh_desk_product_id" {
   provider                = aws.core_services
   name                    = "FRESH_DESK_PRODUCT_ID"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "fresh_desk_product_id_version" {
@@ -700,7 +697,7 @@ resource "aws_secretsmanager_secret_version" "fresh_desk_product_id_version" {
 resource "aws_secretsmanager_secret" "fresh_desk_api_key" {
   provider                = aws.core_services
   name                    = "FRESH_DESK_API_KEY"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "fresh_desk_api_key_version" {
@@ -712,7 +709,7 @@ resource "aws_secretsmanager_secret_version" "fresh_desk_api_key_version" {
 resource "aws_secretsmanager_secret" "gc_articles_api_auth_username" {
   provider                = aws.core_services
   name                    = "GC_ARTICLES_API_AUTH_USERNAME"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "gc_articles_api_auth_username_version" {
@@ -724,7 +721,7 @@ resource "aws_secretsmanager_secret_version" "gc_articles_api_auth_username_vers
 resource "aws_secretsmanager_secret" "gc_articles_api_auth_password" {
   provider                = aws.core_services
   name                    = "GC_ARTICLES_API_AUTH_PASSWORD"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "gc_articles_api_auth_password_version" {
@@ -736,7 +733,7 @@ resource "aws_secretsmanager_secret_version" "gc_articles_api_auth_password_vers
 resource "aws_secretsmanager_secret" "gc_articles_waf_rate_bypass_secret" {
   provider                = aws.core_services
   name                    = "GC_ARTICLES_WAF_RATE_BYPASS_SECRET"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "gc_articles_waf_rate_bypass_secret_version" {
@@ -748,7 +745,7 @@ resource "aws_secretsmanager_secret_version" "gc_articles_waf_rate_bypass_secret
 resource "aws_secretsmanager_secret" "mixpanel_project_token" {
   provider                = aws.core_services
   name                    = "MIXPANEL_PROJECT_TOKEN"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "mixpanel_project_token_version" {
@@ -760,7 +757,7 @@ resource "aws_secretsmanager_secret_version" "mixpanel_project_token_version" {
 resource "aws_secretsmanager_secret" "crm_github_personal_access_token" {
   provider                = aws.core_services
   name                    = "CRM_GITHUB_PERSONAL_ACCESS_TOKEN"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "crm_github_personal_access_token_version" {
@@ -772,7 +769,7 @@ resource "aws_secretsmanager_secret_version" "crm_github_personal_access_token_v
 resource "aws_secretsmanager_secret" "secret_key" {
   provider                = aws.core_services
   name                    = "SECRET_KEY"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "secret_key_version" {
@@ -784,7 +781,7 @@ resource "aws_secretsmanager_secret_version" "secret_key_version" {
 resource "aws_secretsmanager_secret" "sendgrid_api_key" {
   provider                = aws.core_services
   name                    = "SENDGRID_API_KEY"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "sendgrid_api_key_version" {
@@ -796,7 +793,7 @@ resource "aws_secretsmanager_secret_version" "sendgrid_api_key_version" {
 resource "aws_secretsmanager_secret" "waf_secret" {
   provider                = aws.core_services
   name                    = "WAF_SECRET"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "waf_secret_version" {
@@ -808,7 +805,7 @@ resource "aws_secretsmanager_secret_version" "waf_secret_version" {
 resource "aws_secretsmanager_secret" "zendesk_api_key" {
   provider                = aws.core_services
   name                    = "ZENDESK_API_KEY"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "zendesk_api_key_version" {
@@ -820,7 +817,7 @@ resource "aws_secretsmanager_secret_version" "zendesk_api_key_version" {
 resource "aws_secretsmanager_secret" "zendesk_sell_api_key" {
   provider                = aws.core_services
   name                    = "ZENDESK_SELL_API_KEY"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "zendesk_sell_api_key_version" {
@@ -832,7 +829,7 @@ resource "aws_secretsmanager_secret_version" "zendesk_sell_api_key_version" {
 resource "aws_secretsmanager_secret" "sre_client_secret" {
   provider                = aws.core_services
   name                    = "SRE_CLIENT_SECRET"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "sre_client_secret_version" {
@@ -844,7 +841,7 @@ resource "aws_secretsmanager_secret_version" "sre_client_secret_version" {
 resource "aws_secretsmanager_secret" "cache_clear_client_secret" {
   provider                = aws.core_services
   name                    = "CACHE_CLEAR_CLIENT_SECRET"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "cache_clear_client_secret_version" {
@@ -856,7 +853,7 @@ resource "aws_secretsmanager_secret_version" "cache_clear_client_secret_version"
 resource "aws_secretsmanager_secret" "aws_pinpoint_sc_pool_id" {
   provider                = aws.core_services
   name                    = "AWS_PINPOINT_SC_POOL_ID"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "aws_pinpoint_sc_pool_id_version" {
@@ -868,7 +865,7 @@ resource "aws_secretsmanager_secret_version" "aws_pinpoint_sc_pool_id_version" {
 resource "aws_secretsmanager_secret" "aws_pinpoint_sc_template_ids" {
   provider                = aws.core_services
   name                    = "AWS_PINPOINT_SC_TEMPLATE_IDS"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "aws_pinpoint_sc_template_ids_version" {
@@ -880,7 +877,7 @@ resource "aws_secretsmanager_secret_version" "aws_pinpoint_sc_template_ids_versi
 resource "aws_secretsmanager_secret" "aws_pinpoint_default_pool_id" {
   provider                = aws.core_services
   name                    = "AWS_PINPOINT_DEFAULT_POOL_ID"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "aws_pinpoint_default_pool_id_version" {
@@ -892,7 +889,7 @@ resource "aws_secretsmanager_secret_version" "aws_pinpoint_default_pool_id_versi
 resource "aws_secretsmanager_secret" "sqlalchemy_database_uri" {
   provider                = aws.core_services
   name                    = "SQLALCHEMY_DATABASE_URI"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "sqlalchemy_database_uri_version" {
@@ -904,7 +901,7 @@ resource "aws_secretsmanager_secret_version" "sqlalchemy_database_uri_version" {
 resource "aws_secretsmanager_secret" "sqlalchemy_database_reader_uri" {
   provider                = aws.core_services
   name                    = "SQLALCHEMY_DATABASE_READER_URI"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "sqlalchemy_database_reader_uri_version" {
@@ -916,7 +913,7 @@ resource "aws_secretsmanager_secret_version" "sqlalchemy_database_reader_uri_ver
 resource "aws_secretsmanager_secret" "postgres_host" {
   provider                = aws.core_services
   name                    = "POSTGRES_HOST"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "postgres_host_version" {
@@ -928,7 +925,7 @@ resource "aws_secretsmanager_secret_version" "postgres_host_version" {
 resource "aws_secretsmanager_secret" "postgres_sql" {
   provider                = aws.core_services
   name                    = "POSTGRES_SQL"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "postgres_sql_version" {
@@ -940,7 +937,7 @@ resource "aws_secretsmanager_secret_version" "postgres_sql_version" {
 resource "aws_secretsmanager_secret" "cache_ops_url" {
   provider                = aws.core_services
   name                    = "CACHE_OPS_URL"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "cache_ops_url_version" {
@@ -952,7 +949,7 @@ resource "aws_secretsmanager_secret_version" "cache_ops_url_version" {
 resource "aws_secretsmanager_secret" "redis_publish_url" {
   provider                = aws.core_services
   name                    = "REDIS_PUBLISH_URL"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "redis_publish_url_version" {
@@ -964,7 +961,7 @@ resource "aws_secretsmanager_secret_version" "redis_publish_url_version" {
 resource "aws_secretsmanager_secret" "redis_url" {
   provider                = aws.core_services
   name                    = "REDIS_URL"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "redis_url_version" {
@@ -976,7 +973,7 @@ resource "aws_secretsmanager_secret_version" "redis_url_version" {
 resource "aws_secretsmanager_secret" "cypress_user_pw_secret" {
   provider                = aws.core_services
   name                    = "CYPRESS_USER_PW_SECRET"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "cypress_user_pw_secret_version" {
@@ -988,7 +985,7 @@ resource "aws_secretsmanager_secret_version" "cypress_user_pw_secret_version" {
 resource "aws_secretsmanager_secret" "cypress_auth_client_secret" {
   provider                = aws.core_services
   name                    = "CYPRESS_AUTH_CLIENT_SECRET"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "cypress_auth_client_secret_version" {
@@ -1000,7 +997,7 @@ resource "aws_secretsmanager_secret_version" "cypress_auth_client_secret_version
 resource "aws_secretsmanager_secret" "docker_hub_username" {
   provider                = aws.core_services
   name                    = "DOCKER_HUB_USERNAME"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "docker_hub_username_version" {
@@ -1012,7 +1009,7 @@ resource "aws_secretsmanager_secret_version" "docker_hub_username_version" {
 resource "aws_secretsmanager_secret" "docker_hub_pat" {
   provider                = aws.core_services
   name                    = "DOCKER_HUB_PAT"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "docker_hub_pat_version" {
@@ -1025,7 +1022,7 @@ resource "aws_secretsmanager_secret" "signoz_smtp_username" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
   name                    = "SIGNOZ_SMTP_USERNAME"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "signoz_smtp_username_version" {
@@ -1039,7 +1036,7 @@ resource "aws_secretsmanager_secret" "signoz_smtp_password" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
   name                    = "SIGNOZ_SMTP_PASSWORD"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "signoz_smtp_password_version" {
@@ -1053,7 +1050,7 @@ resource "aws_secretsmanager_secret" "signoz_dashboard_api_key" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
   name                    = "SIGNOZ_DASHBOARD_API_KEY"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "signoz_dashboard_api_key_version" {
@@ -1067,7 +1064,7 @@ resource "aws_secretsmanager_secret" "signoz_postgres_password" {
   provider                = aws.core_services
   count                   = var.enable_signoz ? 1 : 0
   name                    = "SIGNOZ_POSTGRES_PASSWORD"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "signoz_postgres_password_version" {
@@ -1080,7 +1077,7 @@ resource "aws_secretsmanager_secret_version" "signoz_postgres_password_version" 
 resource "aws_secretsmanager_secret" "falco_credentials" {
   provider                = aws.core_services
   name                    = "FALCO_CREDENTIALS"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "falco_credentials_version" {
@@ -1092,7 +1089,7 @@ resource "aws_secretsmanager_secret_version" "falco_credentials_version" {
 resource "aws_secretsmanager_secret" "falco_slack_webhook_url" {
   provider                = aws.core_services
   name                    = "FALCO_SLACK_WEBHOOK_URL"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "falco_slack_webhook_url_version" {
@@ -1104,7 +1101,7 @@ resource "aws_secretsmanager_secret_version" "falco_slack_webhook_url_version" {
 resource "aws_secretsmanager_secret" "scan_verdict_callback_token" {
   provider                = aws.core_services
   name                    = "SCAN_VERDICT_CALLBACK_TOKEN"
-  recovery_window_in_days = 7
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "scan_verdict_callback_token_version" {

--- a/aws/manifest_secrets/variables.tf
+++ b/aws/manifest_secrets/variables.tf
@@ -29,12 +29,12 @@ variable "signoz_smtp_password" {
   sensitive = true
 }
 
-variable "manifest_signoz_postgres_password" {
+variable "signoz_postgres_password" {
   default   = "changeme"
   sensitive = true
 }
 
-variable "manifest_signoz_dashboard_api_key" {
+variable "signoz_dashboard_api_key" {
   default   = "changeme"
   sensitive = true
 }

--- a/aws/system_status/lambda.tf
+++ b/aws/system_status/lambda.tf
@@ -26,7 +26,7 @@ module "system_status" {
     system_status_api_url              = var.system_status_api_url
     system_status_bucket_name          = "notification-canada-ca-${var.env}-system-status"
     sqlalchemy_database_reader_uri     = "postgresql://app_db_user:${var.app_db_user_password}@${var.database_read_only_proxy_endpoint}/${var.rds_database_name}"
-    gc_articles_waf_rate_bypass_secret = var.manifest_gc_articles_waf_rate_bypass_secret
+    gc_articles_waf_rate_bypass_secret = var.gc_articles_waf_rate_bypass_secret
   }
 }
 

--- a/env/variables.tf
+++ b/env/variables.tf
@@ -450,16 +450,6 @@ variable "rds_database_name" {
   type = string
 }
 
-variable "admin_client_secret" {
-  type      = string
-  sensitive = true
-}
-
-variable "auth_tokens" {
-  type      = string
-  sensitive = true
-}
-
 variable "ff_batch_insertion" {
   type = string
 }
@@ -756,178 +746,168 @@ variable "pinpoint_to_sqs_sms_callbacks_docker_tag" {
   type = string
 }
 
-variable "manifest_admin_client_secret" {
+variable "admin_client_secret" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_auth_tokens" {
+variable "auth_tokens" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_document_download_api_key" {
+variable "airtable_api_key" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_airtable_api_key" {
+variable "aws_route53_zone" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_aws_route53_zone" {
+variable "aws_ses_access_key" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_aws_ses_access_key" {
+variable "aws_ses_secret_key" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_aws_ses_secret_key" {
+variable "dangerous_salt" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_dangerous_salt" {
+variable "debug_key" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_debug_key" {
+variable "fresh_desk_product_id" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_fresh_desk_product_id" {
+variable "fresh_desk_api_key" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_fresh_desk_api_key" {
+variable "gc_articles_api_auth_username" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_gc_articles_api_auth_username" {
+variable "gc_articles_api_auth_password" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_gc_articles_api_auth_password" {
-  type      = string
-  sensitive = true
-}
-
-variable "manifest_gc_articles_waf_rate_bypass_secret" {
+variable "gc_articles_waf_rate_bypass_secret" {
   type      = string
   sensitive = true
   default   = "changeme"
 }
 
-variable "manifest_mixpanel_project_token" {
+variable "mixpanel_project_token" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_crm_github_personal_access_token" {
+variable "crm_github_personal_access_token" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_secret_key" {
+variable "secret_key" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_sendgrid_api_key" {
+variable "sendgrid_api_key" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_waf_secret" {
+variable "zendesk_api_key" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_zendesk_api_key" {
+variable "zendesk_sell_api_key" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_zendesk_sell_api_key" {
+variable "sre_client_secret" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_sre_client_secret" {
+variable "cache_clear_client_secret" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_cache_clear_client_secret" {
+variable "aws_pinpoint_sc_pool_id" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_aws_pinpoint_sc_pool_id" {
+variable "aws_pinpoint_sc_template_ids" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_aws_pinpoint_sc_template_ids" {
+variable "aws_pinpoint_default_pool_id" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_aws_pinpoint_default_pool_id" {
+variable "cypress_user_pw_secret" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_cypress_user_pw_secret" {
+variable "cypress_auth_client_secret" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_cypress_auth_client_secret" {
-  type      = string
-  sensitive = true
-}
-
-variable "manifest_smoke_api_key" {
+variable "smoke_api_key" {
   type      = string
   default   = "changeme"
   sensitive = true
 }
 
-variable "manifest_smoke_admin_client_secret" {
+variable "smoke_admin_client_secret" {
   type      = string
   default   = "changeme"
   sensitive = true
 }
 
-variable "manifest_pr_bot_github_token" {
+variable "pr_bot_github_token" {
   type      = string
   sensitive = true
   default   = "stagingonly"
 }
 
-variable "manifest_falco_credentials" {
+variable "falco_credentials" {
   type      = string
   sensitive = true
   default   = "changeme"
 }
 
-variable "manifest_falco_slack_webhook_url" {
+variable "falco_slack_webhook_url" {
   type      = string
   sensitive = true
   default   = "changeme"
 }
 
-variable "manifest_scan_verdict_callback_token" {
+variable "scan_verdict_callback_token" {
   type      = string
   sensitive = true
 }
@@ -1000,12 +980,12 @@ variable "github_manifests_workflow_token" {
   default   = "prodonly"
 }
 
-variable "manifest_docker_hub_username" {
+variable "docker_hub_username" {
   type      = string
   sensitive = true
 }
 
-variable "manifest_docker_hub_pat" {
+variable "docker_hub_pat" {
   type      = string
   sensitive = true
 }


### PR DESCRIPTION
## What
Part 1: renames all `manifest_`-prefixed Terraform **variables** to drop the prefix (`env/variables.tf` etc.).

Part 2: adds de-prefixed **duplicate** AWS Secrets Manager secrets for all 44 manifest secrets in `aws/manifest_secrets/secrets.tf`, additive-only. The original `MANIFEST_*` secrets are untouched.

## Why additive, not a rename
Renaming the `name` attribute on `aws_secretsmanager_secret` is a ForceNew change — Terraform destroys and recreates the resource. These secrets are configured with `recovery_window_in_days = 0`, so an in-place rename would delete the old secret **immediately and irrecoverably**, before the Helm/ExternalSecret side (notification-manifests) is ready to read the new names.

Instead, each of the 44 manifest secrets now has a `"_unprefixed"` twin resource, sourcing from the same variable/expression, with the `MANIFEST_` prefix stripped from the AWS-facing name. Nothing is deleted by this PR.

## Rollout plan
1. Merge/apply this PR — creates 44 new secrets side by side with the existing ones. Zero risk, fully reversible.
2. Update the notification-manifests Helm/ExternalSecret config to read the new de-prefixed names, deploy, and verify in each environment.
3. Open a follow-up PR here to delete the legacy `MANIFEST_`-prefixed resources (their labels and the "LEGACY" comment block make them easy to find).

## Variable rename collisions handled
Three of the `manifest_` variables collided with existing declarations once the prefix was stripped:
- `manifest_admin_client_secret` → merged into the existing `admin_client_secret` variable (had zero consumers, no functional change).
- `manifest_auth_tokens` → merged into the existing `auth_tokens` variable (had zero consumers).
- `manifest_waf_secret` → merged into the existing `waf_secret` variable (confirmed same value used for both, consolidated into one).
- `document_download_api_key` (formerly `manifest_document_download_api_key`) is removed entirely; the secret now reads from `auth_tokens` since both held the same value.

## Not in scope / needs manual follow-up
- `.tfvars` files (`production.tfvars`, `production-keys.tfvars`, `staging.tfvars`, etc.) were updated separately, outside this PR.
- Resource local names (Terraform addresses) for the legacy resources are left unchanged.
- Corresponding 1Password entries should be double-checked against the new variable names.
- Downstream repos/services (notification-manifests Helm/ExternalSecret config) still need to be updated to read the new de-prefixed secret names — tracked separately.